### PR TITLE
fix(browser): a renderer that never answers took the EDT, and the menu bar, with it

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
@@ -76,6 +76,10 @@ class DesktopBrowserIntegration(
      * shutting the previous one down where the cache is replaced was the other option and was
      * rejected - a plugin can still be holding that integration, and its calls would start
      * answering null underneath it.
+     *
+     * Never shut down, and that is not an admitted leak: with `allowCoreThreadTimeOut` the worker
+     * exits after its idle window and the executor becomes garbage along with the integration that
+     * held it. An instance that never made a call never started a thread in the first place.
      */
     private val accessorCall = BoundedBrowserCall("boss-plugin-browser-call-${System.identityHashCode(browser)}")
 
@@ -91,7 +95,6 @@ class DesktopBrowserIntegration(
      */
     override suspend fun executeJavaScript(script: String): Any? =
         accessorCall.call(
-            BoundedBrowserCall.DEFAULT_TIMEOUT_MS,
             onError = { e ->
                 browserAccessorLogger.debug(
                     LogCategory.BROWSER,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
@@ -61,6 +61,25 @@ class DesktopBrowserIntegration(
     internal val browser: LockedBrowser,
 ) : BrowserIntegration {
     /**
+     * One per integration, not one per process.
+     *
+     * Sharing a single instance across every tab was the wrong trade: the motivating case is a
+     * renderer parked on a modal `window.prompt`, which never returns, so the shared thread stays
+     * held for as long as that dialog is open and *every* plugin call in the process then costs a
+     * full deadline and answers null - on tabs that are perfectly healthy, for a dialog nobody knows
+     * is open. Per-integration puts the blast radius back to the one tab that stopped answering,
+     * which is what the per-handle instance in BrowserHandleImpl already achieves.
+     *
+     * Affordable because [BoundedBrowserCall]'s thread is created on first call and retires when
+     * idle: these accessors are rebuilt on every tab switch and nothing disposes them, so an
+     * instance that is churned through without making a call costs nothing at all. Explicitly
+     * shutting the previous one down where the cache is replaced was the other option and was
+     * rejected - a plugin can still be holding that integration, and its calls would start
+     * answering null underneath it.
+     */
+    private val accessorCall = BoundedBrowserCall("boss-plugin-browser-call-${System.identityHashCode(browser)}")
+
+    /**
      * Evaluate [script] in the tab this accessor is pointed at, or null if the renderer did not
      * answer in time.
      *
@@ -72,7 +91,7 @@ class DesktopBrowserIntegration(
      */
     override suspend fun executeJavaScript(script: String): Any? =
         accessorCall.call(
-            JS_CALL_TIMEOUT_MS,
+            BoundedBrowserCall.DEFAULT_TIMEOUT_MS,
             onError = { e ->
                 browserAccessorLogger.debug(
                     LogCategory.BROWSER,
@@ -94,21 +113,6 @@ class DesktopBrowserIntegration(
                 browserAccessorLogger.warn(LogCategory.BROWSER, "navigate failed", mapOf("error" to (e.message ?: "unknown")))
             }
         }
-    }
-
-    private companion object {
-        /**
-         * One per process rather than one per integration.
-         *
-         * These accessors are built and replaced on every tab switch and nothing disposes them, so
-         * a per-instance thread would leak one each time. The cost of sharing is that a wedged tab
-         * makes plugin JS on *other* tabs wait out the deadline too - bounded, and far cheaper than
-         * the thread leak or the frozen app.
-         */
-        private val accessorCall = BoundedBrowserCall("boss-plugin-browser-call")
-
-        /** Matches BrowserHandleImpl's bound on the same class of call. */
-        private const val JS_CALL_TIMEOUT_MS = 10_000L
     }
 
     override fun isBrowserAvailable(): Boolean =

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.plugin.panels.right_top
 
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabComponent
+import ai.rever.boss.plugin.browser.BoundedBrowserCall
 import ai.rever.boss.plugin.browser.BrowserServiceImpl
 import ai.rever.boss.plugin.browser.LockedBrowser
 import ai.rever.boss.utils.logging.BossLogger
@@ -59,25 +60,32 @@ actual class BrowserAccessor {
 class DesktopBrowserIntegration(
     internal val browser: LockedBrowser,
 ) : BrowserIntegration {
+    /**
+     * Evaluate [script] in the tab this accessor is pointed at, or null if the renderer did not
+     * answer in time.
+     *
+     * This is the *plugin-facing* path - `DefaultPlugin.getBrowserIntegration` resolves it and
+     * `BrowserIntegrationAdapter.executeJavaScript` hands it out - so it is a shipped API onto the
+     * exact freeze [BoundedBrowserCall] describes. It ran on `Dispatchers.Main`, which meant a
+     * plugin driving a tab parked on a modal `window.prompt` took the EDT, and AppKit's main thread
+     * with it.
+     */
     override suspend fun executeJavaScript(script: String): Any? =
-        withContext(Dispatchers.Main) {
-            try {
-                val mainFrame = browser.mainFrame().orElse(null)
-                if (mainFrame != null) {
-                    mainFrame.executeJavaScript<Any>(script)
-                } else {
-                    null
-                }
-            } catch (e: Exception) {
+        accessorCall.call(
+            JS_CALL_TIMEOUT_MS,
+            onError = { e ->
                 browserAccessorLogger.debug(
                     LogCategory.BROWSER,
                     "executeJavaScript failed - returning null",
                     mapOf("error" to e.toString()),
                 )
-                null
-            }
+            },
+        ) {
+            browser.mainFrame().orElse(null)?.executeJavaScript<Any>(script)
         }
 
+    // Stays on Main: `loadUrl` is answered by the browser process, which page JS cannot block, so
+    // it is not the hazard executeJavaScript above is and gains nothing from queueing behind one.
     override suspend fun navigate(url: String) {
         withContext(Dispatchers.Main) {
             try {
@@ -86,6 +94,21 @@ class DesktopBrowserIntegration(
                 browserAccessorLogger.warn(LogCategory.BROWSER, "navigate failed", mapOf("error" to (e.message ?: "unknown")))
             }
         }
+    }
+
+    private companion object {
+        /**
+         * One per process rather than one per integration.
+         *
+         * These accessors are built and replaced on every tab switch and nothing disposes them, so
+         * a per-instance thread would leak one each time. The cost of sharing is that a wedged tab
+         * makes plugin JS on *other* tabs wait out the deadline too - bounded, and far cheaper than
+         * the thread leak or the frozen app.
+         */
+        private val accessorCall = BoundedBrowserCall("boss-plugin-browser-call")
+
+        /** Matches BrowserHandleImpl's bound on the same class of call. */
+        private const val JS_CALL_TIMEOUT_MS = 10_000L
     }
 
     override fun isBrowserAvailable(): Boolean =

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.plugin.browser
 
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,7 +13,10 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.CancellationException
-import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -41,21 +46,41 @@ import kotlin.coroutines.coroutineContext
  * lost it silently, and nothing in the signature said so. The deadline is a property of this class
  * or it is not a property at all.
  *
- * One residual constraint cannot be fixed here, so it is stated instead: a caller running **on
- * [dispatcher] itself** can still have its *resumption* blocked, because resuming needs that one
- * thread back and the call it gave up on is holding it. The timeout fires and the value is ready;
- * delivering it is what waits. So do not `await` a [call] from a coroutine confined to [dispatcher]
- * — the scopes built on it launch fire-and-forget work, they do not await. The EDT is safe either
- * way, which is the property that matters.
+ * **Scope of a wedge.** One instance is one blast radius, so give one to each thing that can wedge
+ * independently — a tab, a peer, an integration — rather than sharing one process-wide. A shared
+ * instance turns "this tab stopped answering" into "every call in the process costs a full deadline
+ * and answers null", for as long as a dialog nobody knows about stays open. The thread costs nothing
+ * until the first call and retires itself after [IDLE_THREAD_TTL_SECONDS] idle, so per-instance is
+ * cheap even where instances are churned through without ever making a call.
+ *
+ * One residual constraint cannot be fixed here, so it is warned about at runtime instead: a caller
+ * running **on [dispatcher] itself** can still have its *resumption* blocked, because resuming needs
+ * that one thread back and the call it gave up on is holding it. The timeout fires and the value is
+ * ready; delivering it is what waits. So do not `await` a [call] from a coroutine confined to
+ * [dispatcher] — the scopes built on it launch fire-and-forget work, they do not await. The EDT is
+ * safe either way, which is the property that matters.
  */
 internal class BoundedBrowserCall(
-    threadName: String,
+    private val threadName: String,
     private val waitDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
+    private val logger = BossLogger.forComponent("BoundedBrowserCall")
+
+    /**
+     * Core thread that retires when idle, rather than [java.util.concurrent.Executors]'s permanent
+     * one. That is what makes an instance cheap enough to hand out per tab: an instance that never
+     * makes a call never creates a thread, and one that goes quiet gives its thread back.
+     */
     private val executor =
-        Executors.newSingleThreadExecutor { runnable ->
+        ThreadPoolExecutor(
+            1,
+            1,
+            IDLE_THREAD_TTL_SECONDS,
+            TimeUnit.SECONDS,
+            LinkedBlockingQueue(),
+        ) { runnable ->
             Thread(runnable, threadName).apply { isDaemon = true }
-        }
+        }.apply { allowCoreThreadTimeOut(true) }
 
     /**
      * The one thread every blocking round trip runs on.
@@ -82,24 +107,28 @@ internal class BoundedBrowserCall(
      *
      * A timed-out call is not abandoned cheaply: it keeps [dispatcher]'s thread until the renderer
      * answers, and later calls queue behind it. That is the trade — a tab that stops answering
-     * degrades to null instead of freezing the application.
+     * degrades to null instead of freezing the application — and it is why the timeout is always
+     * logged. Silently answering null forever is a worse thing to debug than a freeze, because
+     * nothing points at the page that caused it; the WARN names the thread, which carries the id of
+     * whatever owns this instance.
      */
     // The CancellationException below is swallowed on purpose and cannot carry information worth
     // keeping: it is either the caller's, in which case ensureActive rethrows it untouched, or it is
     // the executor rejecting a dispatch after shutdown, which is this class's own bookkeeping.
     @Suppress("SwallowedException")
     suspend fun <T> call(
-        timeoutMs: Long,
+        timeoutMs: Long = DEFAULT_TIMEOUT_MS,
         onError: (Throwable) -> Unit = {},
+        onTimeout: () -> Unit = {},
         block: () -> T?,
     ): T? {
+        warnIfCallerIsConfinedToOurThread()
         val job = scope.async { runCatching { block() } }
         return try {
-            withContext(waitDispatcher) { withTimeoutOrNull(timeoutMs) { job.await() } }
-                ?.getOrElse { error ->
-                    onError(error)
-                    null
-                }
+            val outcome = withContext(waitDispatcher) { withTimeoutOrNull(timeoutMs) { job.await() } }
+            // Not `?.getOrElse`: on timeout `withTimeoutOrNull` answers null, which would short
+            // circuit straight past every report and leave the wedge completely silent.
+            if (outcome == null) reportTimeout(timeoutMs, onTimeout) else outcome.getOrElse { reportError(it, onError) }
         } catch (e: CancellationException) {
             // Distinguishes "the caller gave up" from "this browser went away underneath us".
             // ensureActive rethrows only the former; a rejected dispatch after shutdown lands here
@@ -108,6 +137,47 @@ internal class BoundedBrowserCall(
             null
         } finally {
             if (!job.isCompleted) job.cancel()
+        }
+    }
+
+    private fun <T> reportTimeout(
+        timeoutMs: Long,
+        onTimeout: () -> Unit,
+    ): T? {
+        logger.warn(
+            LogCategory.BROWSER,
+            "Browser round trip timed out - the renderer did not answer",
+            mapOf("thread" to threadName, "timeoutMs" to timeoutMs.toString()),
+        )
+        onTimeout()
+        return null
+    }
+
+    private fun <T> reportError(
+        error: Throwable,
+        onError: (Throwable) -> Unit,
+    ): T? {
+        onError(error)
+        return null
+    }
+
+    /**
+     * The deadlock [call]'s KDoc describes, named at the moment it happens.
+     *
+     * On the happy path awaiting from [dispatcher] works — the block finishes, the thread frees, the
+     * hop back succeeds — so it passes every test and every manual run, and hangs forever only once
+     * a renderer wedges. That is the exact freeze this class exists to prevent, so it must not be
+     * discoverable only by reproducing it. A warning rather than a throw: this sits on a plugin-facing
+     * path, and turning a latent hang into a thrown exception in someone else's coroutine is its own
+     * kind of surprise.
+     */
+    private suspend fun warnIfCallerIsConfinedToOurThread() {
+        if (coroutineContext[ContinuationInterceptor] === dispatcher) {
+            logger.warn(
+                LogCategory.BROWSER,
+                "Browser round trip awaited from its own dispatcher - this will hang if the renderer wedges",
+                mapOf("thread" to threadName),
+            )
         }
     }
 
@@ -120,5 +190,23 @@ internal class BoundedBrowserCall(
      */
     fun shutdown() {
         executor.shutdown()
+    }
+
+    companion object {
+        /**
+         * How long a renderer round trip waits before giving up and answering null.
+         *
+         * Generous rather than tight: it bounds a call someone asked for and that may legitimately
+         * be slow, and its only job is to make the wait finite. A page that never answers — one
+         * parked on a modal `window.prompt` — used to hold its thread forever, and that thread used
+         * to be the EDT.
+         *
+         * Named here rather than duplicated per call site: two copies with a comment claiming they
+         * match is exactly the pair this repo pins in a test elsewhere.
+         */
+        const val DEFAULT_TIMEOUT_MS = 10_000L
+
+        /** Long enough to serve a burst of calls on one thread, short enough not to hold one idle. */
+        private const val IDLE_THREAD_TTL_SECONDS = 30L
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
@@ -182,6 +182,17 @@ internal class BoundedBrowserCall(
     }
 
     /**
+     * Work queued on [dispatcher] and not yet started.
+     *
+     * The queue is unbounded, which is fine for anything awaited - [call]'s `finally` cancels the job
+     * it gave up on, so a stale one resumes with cancellation instead of running when the renderer
+     * recovers. It is NOT fine for a fire-and-forget stream: nothing cancels those, so against a
+     * wedged renderer they pile up holding their payloads. A caller producing such a stream should
+     * read this and drop rather than enqueue.
+     */
+    val backlog: Int get() = executor.queue.size
+
+    /**
      * Stop accepting new calls.
      *
      * `shutdown()` and not `shutdownNow()`: a call already inside JxBrowser cannot be interrupted,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.CancellationException
@@ -25,7 +26,7 @@ import kotlin.coroutines.coroutineContext
  * `Frame.executeJavaScript` and `JsObject.putProperty` block until the *renderer* replies, and a
  * renderer has every right not to: one parked on a modal `window.prompt` cannot run script until the
  * dialog is answered, and one being swapped out mid-navigation never answers at all. Nothing can
- * interrupt the wait — the call has no suspension point, so a `withTimeoutOrNull` wrapped *around*
+ * interrupt the wait - the call has no suspension point, so a `withTimeoutOrNull` wrapped *around*
  * it is not a bound.
  *
  * Made from `Dispatchers.Main` that is a dead application, not a slow call: the EDT parks forever,
@@ -33,11 +34,11 @@ import kotlin.coroutines.coroutineContext
  *
  * Two threads are load-bearing, and they must be different ones:
  *
- *  - **[dispatcher]** — one daemon thread the blocking call is confined to. Daemon, because nothing
+ *  - **[dispatcher]** - one daemon thread the blocking call is confined to. Daemon, because nothing
  *    can interrupt a call already inside JxBrowser and a wedged renderer must not hold up exit.
  *    Single, because that caps the cost of a wedge at one parked thread; later calls queue behind it
  *    and time out on schedule.
- *  - **[waitDispatcher]** — where the *wait* runs. Both on one thread and the timeout cannot fire:
+ *  - **[waitDispatcher]** - where the *wait* runs. Both on one thread and the timeout cannot fire:
  *    resuming the awaiting continuation needs a dispatch onto the very thread the blocking call is
  *    holding, so the wait would last as long as the renderer takes and the bound would be no bound.
  *
@@ -47,7 +48,7 @@ import kotlin.coroutines.coroutineContext
  * or it is not a property at all.
  *
  * **Scope of a wedge.** One instance is one blast radius, so give one to each thing that can wedge
- * independently — a tab, a peer, an integration — rather than sharing one process-wide. A shared
+ * independently - a tab, a peer, an integration - rather than sharing one process-wide. A shared
  * instance turns "this tab stopped answering" into "every call in the process costs a full deadline
  * and answers null", for as long as a dialog nobody knows about stays open. The thread costs nothing
  * until the first call and retires itself after [IDLE_THREAD_TTL_SECONDS] idle, so per-instance is
@@ -57,7 +58,7 @@ import kotlin.coroutines.coroutineContext
  * running **on [dispatcher] itself** can still have its *resumption* blocked, because resuming needs
  * that one thread back and the call it gave up on is holding it. The timeout fires and the value is
  * ready; delivering it is what waits. So do not `await` a [call] from a coroutine confined to
- * [dispatcher] — the scopes built on it launch fire-and-forget work, they do not await. The EDT is
+ * [dispatcher] - the scopes built on it launch fire-and-forget work, they do not await. The EDT is
  * safe either way, which is the property that matters.
  */
 internal class BoundedBrowserCall(
@@ -101,13 +102,13 @@ internal class BoundedBrowserCall(
      * Run [block] on [dispatcher], answering null if it has not returned within [timeoutMs].
      *
      * Null is also the answer when [block] throws (reported to [onError]) and when this call's own
-     * scope is gone because [shutdown] has run — a disposed browser answers null like every other
+     * scope is gone because [shutdown] has run - a disposed browser answers null like every other
      * failure here rather than throwing into a plugin's coroutine. A cancellation belonging to the
      * *caller* still propagates.
      *
      * A timed-out call is not abandoned cheaply: it keeps [dispatcher]'s thread until the renderer
-     * answers, and later calls queue behind it. That is the trade — a tab that stops answering
-     * degrades to null instead of freezing the application — and it is why the timeout is always
+     * answers, and later calls queue behind it. That is the trade - a tab that stops answering
+     * degrades to null instead of freezing the application - and it is why the timeout is always
      * logged. Silently answering null forever is a worse thing to debug than a freeze, because
      * nothing points at the page that caused it; the WARN names the thread, which carries the id of
      * whatever owns this instance.
@@ -164,8 +165,8 @@ internal class BoundedBrowserCall(
     /**
      * The deadlock [call]'s KDoc describes, named at the moment it happens.
      *
-     * On the happy path awaiting from [dispatcher] works — the block finishes, the thread frees, the
-     * hop back succeeds — so it passes every test and every manual run, and hangs forever only once
+     * On the happy path awaiting from [dispatcher] works - the block finishes, the thread frees, the
+     * hop back succeeds - so it passes every test and every manual run, and hangs forever only once
      * a renderer wedges. That is the exact freeze this class exists to prevent, so it must not be
      * discoverable only by reproducing it. A warning rather than a throw: this sits on a plugin-facing
      * path, and turning a latent hang into a thrown exception in someone else's coroutine is its own
@@ -182,6 +183,35 @@ internal class BoundedBrowserCall(
     }
 
     /**
+     * Run [block] on [dispatcher] without waiting for it.
+     *
+     * For the round trips a **non-suspend** caller has to make - a plugin-facing `fun` that returns
+     * Unit, an injection, a teardown. No deadline applies and none is missing: there is no wait to
+     * bound, the caller returns immediately either way, and a wedged renderer costs this instance's
+     * one thread and nothing else. Awaiting instead is what could not be done from here anyway,
+     * since a non-suspend caller has no context to suspend in.
+     *
+     * Queued on the same unbounded queue as [call] and NOT cancelled by anything, so a caller
+     * producing a *stream* through this must check [backlog] and drop. See [backlog].
+     */
+    fun post(block: () -> Unit) {
+        scope.launch {
+            // runCatching for the reason [call] uses it: JxBrowser throws from a torn-down frame,
+            // and the narrowest useful type here is Throwable. A backstop rather than the reporting
+            // path - callers own their own failures - but without it a throw from fire-and-forget
+            // work reaches the default handler and prints to stderr, bypassing BossLogger entirely.
+            runCatching { block() }.onFailure { error ->
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "Fire-and-forget browser call failed",
+                    mapOf("thread" to threadName),
+                    error = error,
+                )
+            }
+        }
+    }
+
+    /**
      * Work queued on [dispatcher] and not yet started.
      *
      * The queue is unbounded, which is fine for anything awaited - [call]'s `finally` cancels the job
@@ -189,6 +219,10 @@ internal class BoundedBrowserCall(
      * recovers. It is NOT fine for a fire-and-forget stream: nothing cancels those, so against a
      * wedged renderer they pile up holding their payloads. A caller producing such a stream should
      * read this and drop rather than enqueue.
+     *
+     * Counts only what has not *started*. A stream whose queue this gates must therefore also count
+     * whatever it holds in a queue of its own upstream of here, or the gate reads zero in exactly
+     * the state it was written for - see `CoBrowseRtcPeerImpl.sendDom`.
      */
     val backlog: Int get() = executor.queue.size
 
@@ -198,6 +232,12 @@ internal class BoundedBrowserCall(
      * `shutdown()` and not `shutdownNow()`: a call already inside JxBrowser cannot be interrupted,
      * so interrupting would buy nothing, and work already queued still deserves to run. The thread
      * is daemon, so a wedged call cannot hold up exit.
+     *
+     * Not a full teardown, and deliberately not: [scope] is left uncancelled and [dispatcher] left
+     * open, because cancelling the scope would drop work already queued - which is the teardown its
+     * owner usually just posted. Both are reachable-object concerns only, and the executor's thread
+     * retires on its own after [IDLE_THREAD_TTL_SECONDS], so the whole instance becomes garbage with
+     * whatever owned it. Later calls answer null via the rejected-dispatch path in [call].
      */
     fun shutdown() {
         executor.shutdown()
@@ -208,8 +248,8 @@ internal class BoundedBrowserCall(
          * How long a renderer round trip waits before giving up and answering null.
          *
          * Generous rather than tight: it bounds a call someone asked for and that may legitimately
-         * be slow, and its only job is to make the wait finite. A page that never answers — one
-         * parked on a modal `window.prompt` — used to hold its thread forever, and that thread used
+         * be slow, and its only job is to make the wait finite. A page that never answers - one
+         * parked on a modal `window.prompt` - used to hold its thread forever, and that thread used
          * to be the EDT.
          *
          * Named here rather than duplicated per call site: two copies with a comment claiming they

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
@@ -1,0 +1,124 @@
+package ai.rever.boss.plugin.browser
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.CancellationException
+import java.util.concurrent.Executors
+import kotlin.coroutines.coroutineContext
+
+/**
+ * A blocking browser round trip, confined to one thread and answered within a deadline.
+ *
+ * `Frame.executeJavaScript` and `JsObject.putProperty` block until the *renderer* replies, and a
+ * renderer has every right not to: one parked on a modal `window.prompt` cannot run script until the
+ * dialog is answered, and one being swapped out mid-navigation never answers at all. Nothing can
+ * interrupt the wait — the call has no suspension point, so a `withTimeoutOrNull` wrapped *around*
+ * it is not a bound.
+ *
+ * Made from `Dispatchers.Main` that is a dead application, not a slow call: the EDT parks forever,
+ * AppKit's main thread parks behind it, and the macOS menu bar goes with the window.
+ *
+ * Two threads are load-bearing, and they must be different ones:
+ *
+ *  - **[dispatcher]** — one daemon thread the blocking call is confined to. Daemon, because nothing
+ *    can interrupt a call already inside JxBrowser and a wedged renderer must not hold up exit.
+ *    Single, because that caps the cost of a wedge at one parked thread; later calls queue behind it
+ *    and time out on schedule.
+ *  - **[waitDispatcher]** — where the *wait* runs. Both on one thread and the timeout cannot fire:
+ *    resuming the awaiting continuation needs a dispatch onto the very thread the blocking call is
+ *    holding, so the wait would last as long as the renderer takes and the bound would be no bound.
+ *
+ * The hop to [waitDispatcher] is inside [call] rather than left to the caller on purpose. When the
+ * bound depended on the caller's context, a caller that happened to be confined to a single thread
+ * lost it silently, and nothing in the signature said so. The deadline is a property of this class
+ * or it is not a property at all.
+ *
+ * One residual constraint cannot be fixed here, so it is stated instead: a caller running **on
+ * [dispatcher] itself** can still have its *resumption* blocked, because resuming needs that one
+ * thread back and the call it gave up on is holding it. The timeout fires and the value is ready;
+ * delivering it is what waits. So do not `await` a [call] from a coroutine confined to [dispatcher]
+ * — the scopes built on it launch fire-and-forget work, they do not await. The EDT is safe either
+ * way, which is the property that matters.
+ */
+internal class BoundedBrowserCall(
+    threadName: String,
+    private val waitDispatcher: CoroutineDispatcher = Dispatchers.Default,
+) {
+    private val executor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, threadName).apply { isDaemon = true }
+        }
+
+    /**
+     * The one thread every blocking round trip runs on.
+     *
+     * Exposed so fire-and-forget browser work (injection, teardown) can be launched straight onto
+     * it and stay ordered against the calls made through [call].
+     */
+    val dispatcher: ExecutorCoroutineDispatcher = executor.asCoroutineDispatcher()
+
+    /**
+     * Root of the calls, so a timed-out one is NOT a child of the coroutine that gave up on it.
+     * Cancelling it could not interrupt the blocking call anyway, and as a child it would be
+     * cancelled by the very timeout it is supposed to outlive.
+     */
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    /**
+     * Run [block] on [dispatcher], answering null if it has not returned within [timeoutMs].
+     *
+     * Null is also the answer when [block] throws (reported to [onError]) and when this call's own
+     * scope is gone because [shutdown] has run — a disposed browser answers null like every other
+     * failure here rather than throwing into a plugin's coroutine. A cancellation belonging to the
+     * *caller* still propagates.
+     *
+     * A timed-out call is not abandoned cheaply: it keeps [dispatcher]'s thread until the renderer
+     * answers, and later calls queue behind it. That is the trade — a tab that stops answering
+     * degrades to null instead of freezing the application.
+     */
+    // The CancellationException below is swallowed on purpose and cannot carry information worth
+    // keeping: it is either the caller's, in which case ensureActive rethrows it untouched, or it is
+    // the executor rejecting a dispatch after shutdown, which is this class's own bookkeeping.
+    @Suppress("SwallowedException")
+    suspend fun <T> call(
+        timeoutMs: Long,
+        onError: (Throwable) -> Unit = {},
+        block: () -> T?,
+    ): T? {
+        val job = scope.async { runCatching { block() } }
+        return try {
+            withContext(waitDispatcher) { withTimeoutOrNull(timeoutMs) { job.await() } }
+                ?.getOrElse { error ->
+                    onError(error)
+                    null
+                }
+        } catch (e: CancellationException) {
+            // Distinguishes "the caller gave up" from "this browser went away underneath us".
+            // ensureActive rethrows only the former; a rejected dispatch after shutdown lands here
+            // as a cancellation this call owns, and owes the plugin a null rather than a throw.
+            coroutineContext.ensureActive()
+            null
+        } finally {
+            if (!job.isCompleted) job.cancel()
+        }
+    }
+
+    /**
+     * Stop accepting new calls.
+     *
+     * `shutdown()` and not `shutdownNow()`: a call already inside JxBrowser cannot be interrupted,
+     * so interrupting would buy nothing, and work already queued still deserves to run. The thread
+     * is daemon, so a wedged call cannot hold up exit.
+     */
+    fun shutdown() {
+        executor.shutdown()
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -2077,8 +2077,15 @@ internal class BrowserHandleImpl(
     /**
      * Inject the rrweb recorder + page→host bridge into [frame] (main frame only).
      * rrweb captures same-origin iframes natively, so we never start a second
-     * recorder in subframes. Runs on [handleCall]'s thread, never Main: it blocks
-     * on the renderer, and on Main a page that stopped answering froze the app.
+     * recorder in subframes.
+     *
+     * Two callers, two threads, and never Main on either - the same pair
+     * [injectPageEventScript] has: [handleCall]'s thread when [startCoBrowseCapture]
+     * injects into the already-loaded document, and JxBrowser's own inject-callback
+     * thread from [ensureCoBrowseInjectCallback]'s document-start injector, which has
+     * to block there before calling proceed(). What matters is that neither is the
+     * EDT, because this blocks on the renderer four times over, and on Main a page
+     * that stopped answering froze the app.
      */
     private fun injectCoBrowseRecorder(frame: Frame) {
         try {
@@ -2354,6 +2361,14 @@ internal class BrowserHandleImpl(
         // Bounded on [handleCall] for the reason [executeJavaScript] gives: a viewer actuating a tab
         // whose page has stopped answering must not freeze the host.
         //
+        // No backlog guard here, unlike CoBrowseRtcPeerImpl.sendDom, and the difference is that this
+        // one is AWAITED. The viewer gets one status per event and cannot outrun its own round trips,
+        // so the queue depth is bounded by the number of viewers rather than by a frame rate - and
+        // `call`'s finally cancels whatever it gave up on, so a stale event resumes with cancellation
+        // instead of being actuated late into a page that recovered. What is left is retention: the
+        // task and its eventJson sit on the queue while the renderer is wedged. sendDom has neither
+        // property, which is why it drops instead.
+        //
         // The catch stays INSIDE the block rather than wrapping the call. Kotlin's
         // CancellationException is a java.util.concurrent one, which extends IllegalStateException,
         // so a `catch (e: Exception)` around the await would swallow a caller's cancellation and
@@ -2534,6 +2549,13 @@ internal class BrowserHandleImpl(
      *
      * Every part of that bound lives in [BoundedBrowserCall], including which thread the wait runs
      * on - see its KDoc for why leaving that to the caller silently lost the deadline.
+     *
+     * **The behaviour change a plugin can see.** This used to wait forever (and take the app with
+     * it); it now answers null after [BoundedBrowserCall.DEFAULT_TIMEOUT_MS]. That null is
+     * indistinguishable from a script that legitimately evaluated to null, so a plugin reading it as
+     * "no such element" will occasionally see that on a page slow enough to miss the deadline. The
+     * timeout is always logged with the tab's thread name, which is the only way to tell the two
+     * apart from outside.
      */
     override suspend fun executeJavaScript(script: String): Any? {
         if (!isValid) return null
@@ -3494,14 +3516,30 @@ internal class BrowserHandleImpl(
         SwingUtilities.invokeLater { closeSurfacePopOut() }
     }
 
+    /**
+     * The one round trip on this handle whose thread the *caller* used to pick.
+     *
+     * A non-suspend override on the public [BrowserHandle] interface that blocked on the renderer
+     * inline, so a plugin calling it from a `Dispatchers.Main` coroutine or a Compose click handler
+     * made the freeze this class was otherwise fixed for - and `BrowserMainThreadRoundTripTest`
+     * cannot see it, because there is no Main marker at the call site: the EDT-ness came from a
+     * caller a module away.
+     *
+     * [BoundedBrowserCall.post] rather than [BoundedBrowserCall.call] because there is nothing to
+     * await - this returns Unit, and a non-suspend caller has no context to suspend in anyway. The
+     * cost is that a caller now learns nothing about failure beyond the log, which it did not learn
+     * before either.
+     */
     override fun requestPictureInPicture() {
         if (!isValid) return
-        browser.mainFrame().ifPresent { frame ->
-            try {
-                frame.executeJavaScript<Unit>(BrowserJavaScripts.enablePictureInPicture)
-                logger.debug(LogCategory.BROWSER, "Requested Picture-in-Picture mode")
-            } catch (e: Exception) {
-                logger.warn(LogCategory.BROWSER, "Failed to request Picture-in-Picture", error = e)
+        handleCall.post {
+            browser.mainFrame().ifPresent { frame ->
+                try {
+                    frame.executeJavaScript<Unit>(BrowserJavaScripts.enablePictureInPicture)
+                    logger.debug(LogCategory.BROWSER, "Requested Picture-in-Picture mode")
+                } catch (e: Exception) {
+                    logger.warn(LogCategory.BROWSER, "Failed to request Picture-in-Picture", error = e)
+                }
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -505,39 +505,15 @@ internal class BrowserHandleImpl(
         }
     }
 
-    // Off-thread executor for the handle-level RENDERER round-trips that used to run on the EDT.
-    //
-    // `executeJavaScript` and `JsObject.putProperty` block until the renderer answers, and a
-    // renderer that is not answering — one parked on a modal `window.prompt`, one being swapped out
-    // mid-redirect — never sends the reply. Nothing can interrupt that wait. Made from
-    // Dispatchers.Main it parks the EDT permanently, and because AppKit's main thread runs behind
-    // the EDT the macOS menu bar goes with it: the whole application is gone and force-quit is the
-    // only way out. That is the hazard [pageInjectExecutor] documents for the RPC thread, on the one
-    // thread where it costs the most.
-    //
-    // Browser-process calls are deliberately NOT moved here: `loadUrl`, `browser.url()` and
-    // `dispatch` are answered by a process that page JS cannot block, so they are not this failure.
-    // Only round trips that a page can stall belong on this thread.
-    //
-    // One thread, and daemon, for the reason [contextMenuExecutor] spells out: nothing can interrupt
-    // a call already inside JxBrowser, so a wedged renderer costs one parked thread and later calls
-    // on THIS tab queue behind it and time out — instead of taking the application with them.
-    private val handleCallExecutor =
-        Executors.newSingleThreadExecutor { runnable ->
-            Thread(runnable, "boss-browser-call-$id").apply { isDaemon = true }
-        }
-    private val handleCallDispatcher = handleCallExecutor.asCoroutineDispatcher()
-
-    // The coroutine that *waits* on one of those calls must not share its thread. Both on one
-    // thread, the timeout cannot fire — see [contextMenuScope], which spells out why.
-    private val handleCallScope =
-        CoroutineScope(
-            SupervisorJob() +
-                Dispatchers.Default +
-                CoroutineExceptionHandler { _, error ->
-                    logger.warn(LogCategory.BROWSER, "Browser round trip failed", error = error)
-                },
-        )
+    /**
+     * Every blocking renderer round trip this handle makes, off the EDT and answered on a deadline.
+     *
+     * See [BoundedBrowserCall] for why both of those are necessary and why they need two different
+     * threads. Browser-process calls are deliberately NOT routed through here: `loadUrl`,
+     * `browser.url()` and `dispatch` are answered by a process page JS cannot block, so they are not
+     * this failure and gain nothing from queueing behind a wedged renderer.
+     */
+    private val handleCall = BoundedBrowserCall("boss-browser-call-$id")
 
     // --- Co-browse / tab sharing (DOM state-sync) ---
     // Whether the rrweb recorder is actively streaming this tab to viewers.
@@ -558,11 +534,12 @@ internal class BrowserHandleImpl(
     // Page→host bridge injected onto window.__bossCoBrowse; its onEvent is repointed per capture.
     private val coBrowseBridge = CoBrowseBridge()
 
-    // Scope for injection/teardown. Every launch in it makes a blocking renderer round trip, so it
-    // runs on [handleCallDispatcher] rather than Main: on Main a viewer sharing a tab whose page
-    // stops answering froze the whole app. Single-threaded, so co-browse input keeps the order it
-    // arrived in, exactly as it did on the EDT.
-    private val coBrowseScope = CoroutineScope(SupervisorJob() + handleCallDispatcher)
+    // Scope for injection/teardown. Its launches make blocking renderer round trips, so it runs on
+    // [handleCall]'s thread rather than Main: on Main, a viewer sharing a tab whose page stops
+    // answering froze the whole app. Single-threaded, so those stay ordered against each other.
+    //
+    // dispatchCoBrowseInput is the one member that overrides this back to Main - see its comment.
+    private val coBrowseScope = CoroutineScope(SupervisorJob() + handleCall.dispatcher)
 
     // --- Page event channel (setPageEventScript) ---
     // The plugin-supplied document-start script, or null when uninstalled. Read by the injector
@@ -582,11 +559,11 @@ internal class BrowserHandleImpl(
     // then be injected twice.
     private val pageEventInjectRegistered = AtomicBoolean(false)
 
-    // Scope for the one immediate injection into the already-loaded document. On
-    // [handleCallDispatcher] and not Main for the reason [coBrowseScope] gives: that injection hands
-    // the bridge over with `putProperty`, which is a blocking renderer round trip, and it is the
-    // call that was observed holding the EDT with the menu bar behind it.
-    private val pageEventScope = CoroutineScope(SupervisorJob() + handleCallDispatcher)
+    // Scope for the one immediate injection into the already-loaded document. On [handleCall]'s
+    // thread and not Main for the reason [coBrowseScope] gives: that injection hands the bridge over
+    // with `putProperty`, a blocking renderer round trip, and it is the call that was caught holding
+    // the EDT with the macOS menu bar parked behind it.
+    private val pageEventScope = CoroutineScope(SupervisorJob() + handleCall.dispatcher)
 
     /*
      * Why there is NO "inject once per document" counter here, though there was one for a while.
@@ -2022,8 +1999,9 @@ internal class BrowserHandleImpl(
         }
     }
 
-    // Main thread only. Reads pageEventScript once into a local: it is @Volatile, and an uninstall
-    // racing this would otherwise hand over the bridge and then evaluate null.
+    // Runs on [handleCall]'s thread, never Main - it blocks on the renderer twice over (a
+    // `executeJavaScript` and a `putProperty`). Reads pageEventScript once into a local: it is
+    // @Volatile, and an uninstall racing this would otherwise hand over the bridge and evaluate null.
     //
     // Two guards, each a distinct "nothing to do here": no script installed, and no window to hand
     // the bridge through. They log differently, so collapsing them would hide which one fired.
@@ -2084,7 +2062,8 @@ internal class BrowserHandleImpl(
     /**
      * Inject the rrweb recorder + page→host bridge into [frame] (main frame only).
      * rrweb captures same-origin iframes natively, so we never start a second
-     * recorder in subframes. Must run on the JxBrowser/Main thread.
+     * recorder in subframes. Runs on [handleCall]'s thread, never Main: it blocks
+     * on the renderer, and on Main a page that stopped answering froze the app.
      */
     private fun injectCoBrowseRecorder(frame: Frame) {
         try {
@@ -2209,7 +2188,13 @@ internal class BrowserHandleImpl(
 
         fun bool(k: String) = o[k]?.jsonPrimitive?.booleanOrNull ?: false
         val kind = str("kind")
-        coBrowseScope.launch {
+        // Main, overriding [coBrowseScope]'s dispatcher, which is the one member here that keeps its
+        // pre-existing thread. `browser.dispatch` is answered by the browser process, not the
+        // renderer, so page JS cannot stall it and it was never part of this freeze. Two reasons not
+        // to move it anyway: it would be an unannounced behaviour change to remote input under
+        // HARDWARE_ACCELERATED, and while the shared thread is wedged a viewer's pointer keeps
+        // enqueueing one task per event at frame rate onto an unbounded queue.
+        coBrowseScope.launch(Dispatchers.Main) {
             try {
                 val point = Point.of(int("x"), int("y"))
                 when (kind) {
@@ -2351,48 +2336,61 @@ internal class BrowserHandleImpl(
             )
             return null
         }
-        // Raced on [handleCallDispatcher] with a bounded wait, for the reason [executeJavaScript]
-        // gives: a viewer actuating a tab whose page has stopped answering must not freeze the host.
+        // Bounded on [handleCall] for the reason [executeJavaScript] gives: a viewer actuating a tab
+        // whose page has stopped answering must not freeze the host.
         //
-        // The catch stays INSIDE the child rather than moving out to wrap the await. Kotlin's
+        // The catch stays INSIDE the block rather than wrapping the call. Kotlin's
         // CancellationException is a java.util.concurrent one, which extends IllegalStateException,
-        // so a `catch (e: Exception)` around `call.await()` would swallow a caller's cancellation
-        // and answer "err" to it - reporting a co-browse failure for what was an orderly teardown.
-        val call =
-            handleCallScope.async(handleCallDispatcher) {
-                try {
-                    val status =
-                        browser
-                            .mainFrame()
-                            .map { frame ->
-                                frame.executeJavaScript<String?>(CoBrowseScripts.applyControl(eventJson))
-                            }.orElse(null)
-                    if (status != "ok") {
-                        // Non-ok statuses ("stale"/"denied"/"nomirror"/"err:…") are how
-                        // control failures surface — keep them visible for live debugging.
-                        logger.warn(
-                            LogCategory.BROWSER,
-                            "Co-browse control not applied",
-                            mapOf("handleId" to id, "status" to (status ?: "null"), "event" to eventJson.take(120)),
-                        )
-                    }
-                    status
-                } catch (e: Exception) {
+        // so a `catch (e: Exception)` around the await would swallow a caller's cancellation and
+        // answer "err" to it - reporting a co-browse failure for what was an orderly teardown.
+        return handleCall.call(JS_CALL_TIMEOUT_MS) {
+            try {
+                val status =
+                    browser
+                        .mainFrame()
+                        .map { frame ->
+                            frame.executeJavaScript<String?>(CoBrowseScripts.applyControl(eventJson))
+                        }.orElse(null)
+                if (status != "ok") {
+                    // Non-ok statuses ("stale"/"denied"/"nomirror"/"err:…") are ordinary outcomes and
+                    // stay visible for live debugging - but the payload does NOT go with them.
+                    // CoBrowseScripts.applyControl assigns `p.value` for kind 'input', so eventJson
+                    // carries the literal text the viewer typed into a field, which can be a
+                    // password. The kind is what makes the line useful; the value never was.
                     logger.warn(
                         LogCategory.BROWSER,
-                        "Co-browse control apply failed",
-                        mapOf("handleId" to id),
-                        error = e,
+                        "Co-browse control not applied",
+                        mapOf("handleId" to id, "status" to (status ?: "null"), "kind" to coBrowseEventKind(eventJson)),
                     )
-                    "err"
                 }
+                status
+            } catch (e: Exception) {
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "Co-browse control apply failed",
+                    mapOf("handleId" to id),
+                    error = e,
+                )
+                "err"
             }
-        return try {
-            withTimeoutOrNull(JS_CALL_TIMEOUT_MS) { call.await() }
-        } finally {
-            if (!call.isCompleted) call.cancel()
         }
     }
+
+    /**
+     * The event's `kind` alone, for logging.
+     *
+     * A co-browse event's payload can hold whatever a viewer typed, so it is never logged; AGENTS.md
+     * requires [ai.rever.boss.utils.logging.LogSanitizer] for anything that might carry a secret,
+     * and the cheapest way to satisfy that here is to not carry one.
+     */
+    private fun coBrowseEventKind(eventJson: String): String =
+        runCatching {
+            kotlinx.serialization.json.Json
+                .parseToJsonElement(eventJson)
+                .jsonObject["kind"]
+                ?.jsonPrimitive
+                ?.contentOrNull
+        }.getOrNull() ?: "unknown"
 
     /**
      * Generation first, and `isClosed` last and guarded, because the two are not equally
@@ -2513,37 +2511,22 @@ internal class BrowserHandleImpl(
     /**
      * Evaluate a plugin's script in the main frame, or null if the renderer did not answer in time.
      *
-     * Raced rather than wrapped, exactly as [readFrameBeacon] and the context-menu lookup are:
-     * `executeJavaScript` has no suspension point, so a `withTimeoutOrNull` placed around it could
-     * not interrupt it and the bound would be no bound at all. Awaiting a separate job on a
-     * different thread does bound the wait.
-     *
-     * A timed-out call is NOT abandoned cheaply: it keeps [handleCallDispatcher]'s one thread until
-     * the renderer answers, and every later call on this tab queues behind it and returns null on
-     * schedule. That is the whole trade — a tab that stops answering degrades to null instead of
-     * freezing the application.
+     * Every part of that bound lives in [BoundedBrowserCall], including which thread the wait runs
+     * on - see its KDoc for why leaving that to the caller silently lost the deadline.
      */
     override suspend fun executeJavaScript(script: String): Any? {
         if (!isValid) return null
-        // A child of the scope, not of this coroutine: a child of this one would be cancelled by the
-        // timeout below, and cancelling it cannot interrupt the blocking call anyway.
-        val call =
-            handleCallScope.async(handleCallDispatcher) {
-                runCatching { browser.mainFrame().map { it.executeJavaScript<Any?>(script) }.orElse(null) }
-                    .onFailure { e ->
-                        logger.warn(
-                            LogCategory.BROWSER,
-                            "JS execution error",
-                            mapOf("handleId" to id, "error" to (e.message ?: "unknown")),
-                        )
-                    }.getOrNull()
-            }
-        return try {
-            withTimeoutOrNull(JS_CALL_TIMEOUT_MS) { call.await() }
-        } finally {
-            // In a finally, not after the await: dispose cancels this scope, and `call.await()` then
-            // rethrows that CancellationException straight past anything placed after it.
-            if (!call.isCompleted) call.cancel()
+        return handleCall.call(
+            JS_CALL_TIMEOUT_MS,
+            onError = { e ->
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "JS execution error",
+                    mapOf("handleId" to id, "error" to (e.message ?: "unknown")),
+                )
+            },
+        ) {
+            browser.mainFrame().map { it.executeJavaScript<Any?>(script) }.orElse(null)
         }
     }
 
@@ -4233,11 +4216,9 @@ internal class BrowserHandleImpl(
         pageInjectJob.getAndSet(null)?.cancel()
         pageInjectScope.cancel()
         pageInjectExecutor.shutdown()
-        // Last of the four, and after the two scopes above that post onto it. shutdown() not
-        // shutdownNow() for the reason they all give: the thread is daemon and a call already inside
-        // JxBrowser cannot be interrupted, so interrupting would buy nothing.
-        handleCallScope.cancel()
-        handleCallExecutor.shutdown()
+        // Last of the four, and after the two scopes above that post onto its thread, so their
+        // queued teardown still runs. See [BoundedBrowserCall.shutdown] for why not shutdownNow().
+        handleCall.shutdown()
         // Drop this browser's injectors, WITHOUT unclaiming the shared callback slot - that slot
         // belongs to BrowserInjectDispatcher on behalf of every registered injector, and removing
         // it here would tear down another feature's hook as a side effect of this teardown.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -505,6 +505,40 @@ internal class BrowserHandleImpl(
         }
     }
 
+    // Off-thread executor for the handle-level RENDERER round-trips that used to run on the EDT.
+    //
+    // `executeJavaScript` and `JsObject.putProperty` block until the renderer answers, and a
+    // renderer that is not answering — one parked on a modal `window.prompt`, one being swapped out
+    // mid-redirect — never sends the reply. Nothing can interrupt that wait. Made from
+    // Dispatchers.Main it parks the EDT permanently, and because AppKit's main thread runs behind
+    // the EDT the macOS menu bar goes with it: the whole application is gone and force-quit is the
+    // only way out. That is the hazard [pageInjectExecutor] documents for the RPC thread, on the one
+    // thread where it costs the most.
+    //
+    // Browser-process calls are deliberately NOT moved here: `loadUrl`, `browser.url()` and
+    // `dispatch` are answered by a process that page JS cannot block, so they are not this failure.
+    // Only round trips that a page can stall belong on this thread.
+    //
+    // One thread, and daemon, for the reason [contextMenuExecutor] spells out: nothing can interrupt
+    // a call already inside JxBrowser, so a wedged renderer costs one parked thread and later calls
+    // on THIS tab queue behind it and time out — instead of taking the application with them.
+    private val handleCallExecutor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "boss-browser-call-$id").apply { isDaemon = true }
+        }
+    private val handleCallDispatcher = handleCallExecutor.asCoroutineDispatcher()
+
+    // The coroutine that *waits* on one of those calls must not share its thread. Both on one
+    // thread, the timeout cannot fire — see [contextMenuScope], which spells out why.
+    private val handleCallScope =
+        CoroutineScope(
+            SupervisorJob() +
+                Dispatchers.Default +
+                CoroutineExceptionHandler { _, error ->
+                    logger.warn(LogCategory.BROWSER, "Browser round trip failed", error = error)
+                },
+        )
+
     // --- Co-browse / tab sharing (DOM state-sync) ---
     // Whether the rrweb recorder is actively streaming this tab to viewers.
     @Volatile private var coBrowseCapturing = false
@@ -524,8 +558,11 @@ internal class BrowserHandleImpl(
     // Page→host bridge injected onto window.__bossCoBrowse; its onEvent is repointed per capture.
     private val coBrowseBridge = CoBrowseBridge()
 
-    // Main-thread scope for injection/teardown (rrweb inject + executeJavaScript run on Main).
-    private val coBrowseScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    // Scope for injection/teardown. Every launch in it makes a blocking renderer round trip, so it
+    // runs on [handleCallDispatcher] rather than Main: on Main a viewer sharing a tab whose page
+    // stops answering froze the whole app. Single-threaded, so co-browse input keeps the order it
+    // arrived in, exactly as it did on the EDT.
+    private val coBrowseScope = CoroutineScope(SupervisorJob() + handleCallDispatcher)
 
     // --- Page event channel (setPageEventScript) ---
     // The plugin-supplied document-start script, or null when uninstalled. Read by the injector
@@ -545,8 +582,11 @@ internal class BrowserHandleImpl(
     // then be injected twice.
     private val pageEventInjectRegistered = AtomicBoolean(false)
 
-    // Main-thread scope for the one immediate injection into the already-loaded document.
-    private val pageEventScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    // Scope for the one immediate injection into the already-loaded document. On
+    // [handleCallDispatcher] and not Main for the reason [coBrowseScope] gives: that injection hands
+    // the bridge over with `putProperty`, which is a blocking renderer round trip, and it is the
+    // call that was observed holding the EDT with the menu bar behind it.
+    private val pageEventScope = CoroutineScope(SupervisorJob() + handleCallDispatcher)
 
     /*
      * Why there is NO "inject once per document" counter here, though there was one for a while.
@@ -2311,28 +2351,46 @@ internal class BrowserHandleImpl(
             )
             return null
         }
-        return withContext(Dispatchers.Main) {
-            try {
-                val status =
-                    browser
-                        .mainFrame()
-                        .map { frame ->
-                            frame.executeJavaScript<String?>(CoBrowseScripts.applyControl(eventJson))
-                        }.orElse(null)
-                if (status != "ok") {
-                    // Non-ok statuses ("stale"/"denied"/"nomirror"/"err:…") are how
-                    // control failures surface — keep them visible for live debugging.
+        // Raced on [handleCallDispatcher] with a bounded wait, for the reason [executeJavaScript]
+        // gives: a viewer actuating a tab whose page has stopped answering must not freeze the host.
+        //
+        // The catch stays INSIDE the child rather than moving out to wrap the await. Kotlin's
+        // CancellationException is a java.util.concurrent one, which extends IllegalStateException,
+        // so a `catch (e: Exception)` around `call.await()` would swallow a caller's cancellation
+        // and answer "err" to it - reporting a co-browse failure for what was an orderly teardown.
+        val call =
+            handleCallScope.async(handleCallDispatcher) {
+                try {
+                    val status =
+                        browser
+                            .mainFrame()
+                            .map { frame ->
+                                frame.executeJavaScript<String?>(CoBrowseScripts.applyControl(eventJson))
+                            }.orElse(null)
+                    if (status != "ok") {
+                        // Non-ok statuses ("stale"/"denied"/"nomirror"/"err:…") are how
+                        // control failures surface — keep them visible for live debugging.
+                        logger.warn(
+                            LogCategory.BROWSER,
+                            "Co-browse control not applied",
+                            mapOf("handleId" to id, "status" to (status ?: "null"), "event" to eventJson.take(120)),
+                        )
+                    }
+                    status
+                } catch (e: Exception) {
                     logger.warn(
                         LogCategory.BROWSER,
-                        "Co-browse control not applied",
-                        mapOf("handleId" to id, "status" to (status ?: "null"), "event" to eventJson.take(120)),
+                        "Co-browse control apply failed",
+                        mapOf("handleId" to id),
+                        error = e,
                     )
+                    "err"
                 }
-                status
-            } catch (e: Exception) {
-                logger.warn(LogCategory.BROWSER, "Co-browse control apply failed", mapOf("handleId" to id), error = e)
-                "err"
             }
+        return try {
+            withTimeoutOrNull(JS_CALL_TIMEOUT_MS) { call.await() }
+        } finally {
+            if (!call.isCompleted) call.cancel()
         }
     }
 
@@ -2452,15 +2510,40 @@ internal class BrowserHandleImpl(
         }
     }
 
+    /**
+     * Evaluate a plugin's script in the main frame, or null if the renderer did not answer in time.
+     *
+     * Raced rather than wrapped, exactly as [readFrameBeacon] and the context-menu lookup are:
+     * `executeJavaScript` has no suspension point, so a `withTimeoutOrNull` placed around it could
+     * not interrupt it and the bound would be no bound at all. Awaiting a separate job on a
+     * different thread does bound the wait.
+     *
+     * A timed-out call is NOT abandoned cheaply: it keeps [handleCallDispatcher]'s one thread until
+     * the renderer answers, and every later call on this tab queues behind it and returns null on
+     * schedule. That is the whole trade — a tab that stops answering degrades to null instead of
+     * freezing the application.
+     */
     override suspend fun executeJavaScript(script: String): Any? {
         if (!isValid) return null
-        return withContext(Dispatchers.Main) {
-            try {
-                browser.mainFrame().map { it.executeJavaScript<Any?>(script) }.orElse(null)
-            } catch (e: Exception) {
-                logger.warn(LogCategory.BROWSER, "JS execution error", mapOf("handleId" to id, "error" to (e.message ?: "unknown")))
-                null
+        // A child of the scope, not of this coroutine: a child of this one would be cancelled by the
+        // timeout below, and cancelling it cannot interrupt the blocking call anyway.
+        val call =
+            handleCallScope.async(handleCallDispatcher) {
+                runCatching { browser.mainFrame().map { it.executeJavaScript<Any?>(script) }.orElse(null) }
+                    .onFailure { e ->
+                        logger.warn(
+                            LogCategory.BROWSER,
+                            "JS execution error",
+                            mapOf("handleId" to id, "error" to (e.message ?: "unknown")),
+                        )
+                    }.getOrNull()
             }
+        return try {
+            withTimeoutOrNull(JS_CALL_TIMEOUT_MS) { call.await() }
+        } finally {
+            // In a finally, not after the await: dispose cancels this scope, and `call.await()` then
+            // rethrows that CancellationException straight past anything placed after it.
+            if (!call.isCompleted) call.cancel()
         }
     }
 
@@ -4150,6 +4233,11 @@ internal class BrowserHandleImpl(
         pageInjectJob.getAndSet(null)?.cancel()
         pageInjectScope.cancel()
         pageInjectExecutor.shutdown()
+        // Last of the four, and after the two scopes above that post onto it. shutdown() not
+        // shutdownNow() for the reason they all give: the thread is daemon and a call already inside
+        // JxBrowser cannot be interrupted, so interrupting would buy nothing.
+        handleCallScope.cancel()
+        handleCallExecutor.shutdown()
         // Drop this browser's injectors, WITHOUT unclaiming the shared callback slot - that slot
         // belongs to BrowserInjectDispatcher on behalf of every registered injector, and removing
         // it here would tear down another feature's hook as a side effect of this teardown.
@@ -4314,6 +4402,15 @@ internal class BrowserHandleImpl(
          * before opening without it. Bounds a blocking JS round-trip against a busy page.
          */
         private const val FORM_FIELD_LOOKUP_TIMEOUT_MS = 500L
+
+        /**
+         * How long a plugin's script evaluation waits for the renderer before giving up and
+         * answering null. Generous rather than tight: this bounds a call a plugin asked for and
+         * may legitimately be slow, and its only job is to make the wait finite. A page that
+         * never answers - one parked on a modal `window.prompt` - used to hold this thread
+         * forever, and that thread used to be the EDT.
+         */
+        private const val JS_CALL_TIMEOUT_MS = 10_000L
 
         /**
          * How far back a failure retracts visits recorded by a callback that raced ahead

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -512,6 +512,16 @@ internal class BrowserHandleImpl(
      * threads. Browser-process calls are deliberately NOT routed through here: `loadUrl`,
      * `browser.url()` and `dispatch` are answered by a process page JS cannot block, so they are not
      * this failure and gain nothing from queueing behind a wedged renderer.
+     *
+     * **Why [frameProbeExecutor], [contextMenuExecutor] and [pageInjectExecutor] are still separate.**
+     * This class is a strictly better version of all three - retiring thread, encapsulated deadline,
+     * one place the two-thread rule lives - and folding them in would leave one pattern instead of
+     * four. It is deliberately not done here, and the reason is not inertia: merging the queues merges
+     * the blast radii. Today a wedged page-helper injection still leaves the context menu answering
+     * and the stall probe reporting, because each waits on its own thread; behind one queue they
+     * would all time out together, and the frame-stall probe in particular exists to interrogate a
+     * page already suspected of misbehaving. Folding them in is a real option, but it is a decision
+     * about how much independence to trade for one pattern, and it belongs in its own change.
      */
     private val handleCall = BoundedBrowserCall("boss-browser-call-$id")
 
@@ -1999,9 +2009,14 @@ internal class BrowserHandleImpl(
         }
     }
 
-    // Runs on [handleCall]'s thread, never Main - it blocks on the renderer twice over (a
-    // `executeJavaScript` and a `putProperty`). Reads pageEventScript once into a local: it is
-    // @Volatile, and an uninstall racing this would otherwise hand over the bridge and evaluate null.
+    // Two callers, two threads, and never Main on either: [handleCall]'s thread when
+    // setPageEventScript injects into the already-loaded document, and JxBrowser's own inject-callback
+    // thread from the document-start injector, which has to block there before calling proceed().
+    // Both are correct; what matters is that neither is the EDT, because this blocks on the renderer
+    // twice over (an `executeJavaScript` and a `putProperty`).
+    //
+    // Reads pageEventScript once into a local: it is @Volatile, and an uninstall racing this would
+    // otherwise hand over the bridge and evaluate null.
     //
     // Two guards, each a distinct "nothing to do here": no script installed, and no window to hand
     // the bridge through. They log differently, so collapsing them would hide which one fired.
@@ -2343,7 +2358,7 @@ internal class BrowserHandleImpl(
         // CancellationException is a java.util.concurrent one, which extends IllegalStateException,
         // so a `catch (e: Exception)` around the await would swallow a caller's cancellation and
         // answer "err" to it - reporting a co-browse failure for what was an orderly teardown.
-        return handleCall.call(BoundedBrowserCall.DEFAULT_TIMEOUT_MS) {
+        return handleCall.call {
             try {
                 val status =
                     browser
@@ -2523,7 +2538,6 @@ internal class BrowserHandleImpl(
     override suspend fun executeJavaScript(script: String): Any? {
         if (!isValid) return null
         return handleCall.call(
-            BoundedBrowserCall.DEFAULT_TIMEOUT_MS,
             onError = { e ->
                 logger.warn(
                     LogCategory.BROWSER,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -2343,7 +2343,7 @@ internal class BrowserHandleImpl(
         // CancellationException is a java.util.concurrent one, which extends IllegalStateException,
         // so a `catch (e: Exception)` around the await would swallow a caller's cancellation and
         // answer "err" to it - reporting a co-browse failure for what was an orderly teardown.
-        return handleCall.call(JS_CALL_TIMEOUT_MS) {
+        return handleCall.call(BoundedBrowserCall.DEFAULT_TIMEOUT_MS) {
             try {
                 val status =
                     browser
@@ -2360,7 +2360,13 @@ internal class BrowserHandleImpl(
                     logger.warn(
                         LogCategory.BROWSER,
                         "Co-browse control not applied",
-                        mapOf("handleId" to id, "status" to (status ?: "null"), "kind" to coBrowseEventKind(eventJson)),
+                        mapOf(
+                            "handleId" to id,
+                            // Truncated because an "err:…" status is built from a page-side exception
+                            // message, so its length and content are the page's to choose.
+                            "status" to (status?.take(STATUS_LOG_LIMIT) ?: "null"),
+                            "kind" to coBrowseEventKind(eventJson),
+                        ),
                     )
                 }
                 status
@@ -2517,7 +2523,7 @@ internal class BrowserHandleImpl(
     override suspend fun executeJavaScript(script: String): Any? {
         if (!isValid) return null
         return handleCall.call(
-            JS_CALL_TIMEOUT_MS,
+            BoundedBrowserCall.DEFAULT_TIMEOUT_MS,
             onError = { e ->
                 logger.warn(
                     LogCategory.BROWSER,
@@ -4216,8 +4222,16 @@ internal class BrowserHandleImpl(
         pageInjectJob.getAndSet(null)?.cancel()
         pageInjectScope.cancel()
         pageInjectExecutor.shutdown()
-        // Last of the four, and after the two scopes above that post onto its thread, so their
-        // queued teardown still runs. See [BoundedBrowserCall.shutdown] for why not shutdownNow().
+        // Last of the four. Note what this ordering does NOT buy: coBrowseScope and pageEventScope
+        // were cancelled above, and cancelling a scope also cancels children that were dispatched but
+        // have not started - startCoroutineCancellable means DispatchedTask.run sees an inactive job
+        // and resumes with the cancellation instead of running the body. So the teardown queued by
+        // stopCoBrowseCapture (recordStop, setControlGuard(false)) does not run here, and did not
+        // before this change either, when both scopes were cancelled the same way on Main.
+        //
+        // Left alone rather than re-posted outside the cancelled scope: the browser is closing a few
+        // lines below, so stopping a recorder in a page that is about to go away buys nothing.
+        // See [BoundedBrowserCall.shutdown] for why not shutdownNow().
         handleCall.shutdown()
         // Drop this browser's injectors, WITHOUT unclaiming the shared callback slot - that slot
         // belongs to BrowserInjectDispatcher on behalf of every registered injector, and removing
@@ -4270,6 +4284,9 @@ internal class BrowserHandleImpl(
     companion object {
         /** Cause-chain depth [isTransportFailure] inspects before giving up. */
         private const val MAX_CAUSE_DEPTH = 16
+
+        /** How much of a page-authored co-browse status string reaches the log. */
+        private const val STATUS_LOG_LIMIT = 80
 
         /**
          * Popup browsers we are currently waiting to capture an upload body for.
@@ -4383,15 +4400,6 @@ internal class BrowserHandleImpl(
          * before opening without it. Bounds a blocking JS round-trip against a busy page.
          */
         private const val FORM_FIELD_LOOKUP_TIMEOUT_MS = 500L
-
-        /**
-         * How long a plugin's script evaluation waits for the renderer before giving up and
-         * answering null. Generous rather than tight: this bounds a call a plugin asked for and
-         * may legitimately be slow, and its only job is to make the wait finite. A page that
-         * never answers - one parked on a modal `window.prompt` - used to hold this thread
-         * forever, and that thread used to be the EDT.
-         */
-        private const val JS_CALL_TIMEOUT_MS = 10_000L
 
         /**
          * How far back a failure retracts visits recorded by a callback that raced ahead

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
@@ -98,7 +98,7 @@ internal class CoBrowseRtcPeerImpl(
     private val injected = AtomicBoolean(false)
     private val injectQueued = AtomicBoolean(false)
 
-    /** One warning per stall, not one per dropped frame. */
+    /** One warning per stall, not one per dropped frame. Cleared only on a drained queue. */
     private val domDropWarned = AtomicBoolean(false)
 
     @Volatile private var ready = false
@@ -109,6 +109,17 @@ internal class CoBrowseRtcPeerImpl(
     // loaded + initialized are queued here and flushed on init — the viewer can
     // send its offer faster than the localhost page loads.
     private val pending = ArrayList<String>()
+
+    /**
+     * How many of [pending] are DOM frames. Guarded by `pending`'s own monitor.
+     *
+     * Counted separately rather than gating on `pending.size`, because [pending] also holds the
+     * offer and every ICE candidate, and a peer that is slow to come up can easily produce more of
+     * those than [MAX_DOM_BACKLOG] - which would then drop the whole DOM stream for a reason that
+     * has nothing to do with the stream. Read outside the lock only for the warning watermark, where
+     * a stale count costs at most one extra WARN.
+     */
+    @Volatile private var pendingDomFrames = 0
 
     /** Page title of the tab to capture; read when the peer page calls getDisplayMedia. */
     @Volatile private var targetTitle: String? = null
@@ -193,20 +204,43 @@ internal class CoBrowseRtcPeerImpl(
             ready = true
             queued = ArrayList(pending)
             pending.clear()
+            pendingDomFrames = 0
         }
+        // This loop is the burst [sendDom]'s KDoc says it is avoiding, so the DOM frames in here are
+        // capped on the queueing side - see [runJs]'s domFrame. The signalling ops (offer, ICE) are
+        // not capped and do not need to be: they are one-per-negotiation, not a stream.
         queued.forEach { runCatching { frame.executeJavaScript<Any?>(it) } }
     }
 
     private fun mainFrame(): Frame? = browser?.takeIf { !it.isClosed }?.mainFrame()?.orElse(null)
 
-    private fun runJs(script: String) {
-        if (closed) return
+    /**
+     * Queue [script] for the peer page, or dispatch it now if the page is already up.
+     *
+     * @param domFrame marks the rrweb stream, the one caller that drops rather than enqueues. The cap
+     *   is applied to whichever queue the script would land on, because the two are alternatives and
+     *   not stages: until the page answers, nothing here reaches the executor at all, so a cap read
+     *   off [BoundedBrowserCall.backlog] alone is bypassed in exactly the state it was written for.
+     * @return false when the frame was dropped, so the caller can warn once per stall.
+     */
+    // Five returns rather than two: they are the three outcomes (closed, dropped, accepted) across
+    // the two queues, and collapsing them means carrying the decision out of the synchronized block
+    // that has to make it - where `ready` can already have flipped.
+    @Suppress("ReturnCount")
+    private fun runJs(
+        script: String,
+        domFrame: Boolean = false,
+    ): Boolean {
+        if (closed) return false
         synchronized(pending) {
             if (!ready) {
+                if (domFrame && pendingDomFrames >= MAX_DOM_BACKLOG) return false
                 pending.add(script)
-                return
+                if (domFrame) pendingDomFrames++
+                return true
             } // apply once initialized
         }
+        if (domFrame && browserCall.backlog >= MAX_DOM_BACKLOG) return false
         scope.launch {
             try {
                 mainFrame()?.executeJavaScript<Any?>(script)
@@ -216,6 +250,7 @@ internal class CoBrowseRtcPeerImpl(
                 logger.warn(LogCategory.BROWSER, "WebRTC peer JS call failed", error = e)
             }
         }
+        return true
     }
 
     override fun acceptOffer(sdp: String) {
@@ -231,10 +266,17 @@ internal class CoBrowseRtcPeerImpl(
      * The one caller that drops rather than enqueues.
      *
      * rrweb emits continuously and each payload is a DOM mutation batch, so against a peer page that
-     * has stopped answering this would grow [BoundedBrowserCall.backlog] without limit, holding every
-     * frame's JSON - and then run them all in a burst if the page ever recovered. That is exactly the
-     * hazard cited for leaving `dispatchCoBrowseInput` on Main in BrowserHandleImpl, and the argument
-     * has to point the same way here: same shape, bigger payloads.
+     * has stopped answering this would grow without limit, holding every frame's JSON - and then run
+     * them all in a burst if the page ever recovered. That is exactly the hazard cited for leaving
+     * `dispatchCoBrowseInput` on Main in BrowserHandleImpl, and the argument has to point the same
+     * way here: same shape, bigger payloads.
+     *
+     * **Both queues, not just the executor's.** The first version gated on
+     * [BoundedBrowserCall.backlog] alone, which a peer page that has not answered never reaches:
+     * [runJs] appends to [pending] and returns while `ready` is false, so the guard was bypassed in
+     * precisely the state it describes - an unreachable `RtcHostServer` or a load that never
+     * finishes grew [pending] for the whole life of the share, silently. The cap now lives in [runJs]
+     * and applies to whichever queue the frame would land on.
      *
      * Dropping is safe in the way that matters. A peer page that is not answering is not mirroring
      * anything to a viewer either, so these frames have nowhere to be displayed; the share is already
@@ -243,18 +285,22 @@ internal class CoBrowseRtcPeerImpl(
      * viewer's mirror needs first.
      */
     override fun sendDom(json: String) {
-        if (browserCall.backlog >= MAX_DOM_BACKLOG) {
+        if (closed) return
+        val accepted = runJs("window.__bossRtcSendDom && window.__bossRtcSendDom(${jsStr(json)});", domFrame = true)
+        if (!accepted) {
             if (domDropWarned.compareAndSet(false, true)) {
                 logger.warn(
                     LogCategory.BROWSER,
                     "WebRTC peer is not draining DOM frames - dropping until it catches up",
-                    mapOf("backlog" to browserCall.backlog.toString()),
+                    mapOf("backlog" to browserCall.backlog.toString(), "pending" to pendingDomFrames.toString()),
                 )
             }
             return
         }
-        domDropWarned.set(false)
-        runJs("window.__bossRtcSendDom && window.__bossRtcSendDom(${jsStr(json)});")
+        // A drained queue, not merely an accepted frame. [MAX_DOM_BACKLOG] is small, so a peer
+        // draining just fast enough to sit at the cap crosses it constantly, and clearing on every
+        // accept turns "one warning per stall" into one per crossing.
+        if (browserCall.backlog == 0 && pendingDomFrames == 0) domDropWarned.set(false)
     }
 
     override fun startVideo(targetTitle: String) {
@@ -276,6 +322,13 @@ internal class CoBrowseRtcPeerImpl(
         bridge.onState = null
         bridge.onVideoError = null
         bridge.onVideoState = null
+        // A peer that closed before its page ever answered still holds every op that raced ahead of
+        // it, DOM payloads included, until the object itself is collected. `closed` already stops
+        // anything from being flushed, so these are dead weight.
+        synchronized(pending) {
+            pending.clear()
+            pendingDomFrames = 0
+        }
         scope.launch {
             try {
                 browser?.takeIf { !it.isClosed }?.close()
@@ -295,7 +348,8 @@ internal class CoBrowseRtcPeerImpl(
 
     private companion object {
         /**
-         * How many un-started DOM frames may sit on the peer's thread before new ones are dropped.
+         * How many un-started DOM frames may be waiting - on the peer's thread, or in [pending]
+         * before the page has answered - before new ones are dropped.
          *
          * Small on purpose: anything past a handful means the peer page is not draining, and the
          * frames behind it are already too stale to be worth the memory.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
@@ -78,9 +78,15 @@ internal class CoBrowseRtcPeerImpl(
 
     @Volatile private var browser: Browser? = null
 
-    // Atomic rather than @Volatile: injection is now posted off the callback thread, so a plain
-    // read-then-write would let two LoadFinished events both see "not injected" and queue it twice.
+    // Two flags, not one, now that injection is posted off the callback thread.
+    //
+    // [injected] is the DONE state and is only ever set on success. [injectQueued] keeps a second
+    // LoadFinished from queueing a duplicate while one is in flight, and is released in a finally.
+    // Collapsing them into a single claim-before-launch was wrong in the other direction: a failed
+    // attempt released the claim only after the events that would have retried it had already been
+    // dropped, and a page that loads once never fires a third.
     private val injected = AtomicBoolean(false)
+    private val injectQueued = AtomicBoolean(false)
 
     @Volatile private var ready = false
 
@@ -127,37 +133,39 @@ internal class CoBrowseRtcPeerImpl(
                 )
                 // Inject the bridge + init the peer once the served page (and its
                 // script) has finished loading.
-                b.navigation().on(LoadFinished::class.java) {
-                    // Posted, not run here. LoadFinished is delivered on JxBrowser's RPC thread, and
-                    // [injectInto]'s blocking executeJavaScript made from it re-enters
-                    // RpcThreadCallExecutor and parks on a queue only the thread it is blocking
-                    // could drain - so the reply can never arrive. That is the deadlock PR #268
-                    // fixed for the page helpers; this call site was missed by it.
-                    //
-                    // Claimed before the launch rather than inside it: two LoadFinished events would
-                    // otherwise both see "not injected" and queue a second injection. Released again
-                    // on failure, so a frame that was not there yet does not cost this peer its one
-                    // chance to initialize.
-                    if (!injected.compareAndSet(false, true)) return@on
-                    scope.launch {
-                        try {
-                            val f = b.mainFrame().orElse(null)
-                            if (f == null) {
-                                injected.set(false)
-                                return@launch
-                            }
-                            injectInto(f)
-                            logger.info(LogCategory.BROWSER, "WebRTC peer initialized")
-                        } catch (e: Exception) {
-                            injected.set(false)
-                            logger.warn(LogCategory.BROWSER, "WebRTC peer init failed", error = e)
-                        }
-                    }
-                }
+                b.navigation().on(LoadFinished::class.java) { injectWhenReady(b) }
                 b.navigation().loadUrl(RtcHostServer.baseUrl())
             } catch (e: Throwable) {
                 logger.warn(LogCategory.BROWSER, "WebRTC peer browser init failed", error = e)
                 runCatching { onState(false) }
+            }
+        }
+    }
+
+    /**
+     * Inject on the peer's own thread, once, when a load lands.
+     *
+     * Posted rather than run on the caller's thread: `LoadFinished` is delivered on JxBrowser's RPC
+     * thread, and [injectInto]'s blocking `executeJavaScript` made from there re-enters
+     * `RpcThreadCallExecutor` and parks on a queue only the thread it is blocking could drain, so
+     * the reply can never arrive. That is the deadlock PR #268 fixed for the page helpers, at a call
+     * site it missed.
+     */
+    private fun injectWhenReady(b: Browser) {
+        if (injected.get()) return
+        if (!injectQueued.compareAndSet(false, true)) return
+        scope.launch {
+            try {
+                val frame = b.mainFrame().orElse(null) ?: return@launch
+                injectInto(frame)
+                // Only here. A frame that was not there yet, or a throw, leaves this false so the
+                // next LoadFinished tries again rather than the peer sitting dead.
+                injected.set(true)
+                logger.info(LogCategory.BROWSER, "WebRTC peer initialized")
+            } catch (e: Exception) {
+                logger.warn(LogCategory.BROWSER, "WebRTC peer init failed", error = e)
+            } finally {
+                injectQueued.set(false)
             }
         }
     }
@@ -235,9 +243,14 @@ internal class CoBrowseRtcPeerImpl(
             }
             browser = null
         }
-        // shutdown() not shutdownNow(): the close above is already queued and must still run, and a
-        // call parked inside JxBrowser cannot be interrupted anyway. The thread is daemon, so a
-        // wedged peer cannot hold up exit.
+        // shutdown(), not shutdownNow(), and deliberately no scope.cancel(): the browser close above
+        // is already queued on this executor and cancelling would drop it. A call parked inside
+        // JxBrowser cannot be interrupted anyway.
+        //
+        // Known cost: if a wedged JS call is holding the thread, that queued close never runs and
+        // this peer's hidden browser leaks until process exit. One browser per failed share, against
+        // a frozen application - the trade this whole change is making, and bounded because the
+        // thread is daemon.
         callExecutor.shutdown()
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
@@ -13,12 +13,14 @@ import com.teamdev.jxbrowser.frame.Frame
 import com.teamdev.jxbrowser.js.JsObject
 import com.teamdev.jxbrowser.navigation.event.LoadFinished
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import java.net.InetSocketAddress
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Host-side WebRTC peer running inside a hidden JxBrowser page.
@@ -54,7 +56,20 @@ internal class CoBrowseRtcPeerImpl(
     onState: (Boolean) -> Unit,
 ) : CoBrowseRtcPeer {
     private val logger = CoBrowseRtcProviderImpl.logger
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    // Off-thread executor for this peer's blocking JxBrowser round trips, for the reason
+    // BrowserHandleImpl.handleCallExecutor spells out at length: executeJavaScript and putProperty
+    // block until the renderer answers, nothing can interrupt that wait, and made from
+    // Dispatchers.Main a peer page that stops answering takes the EDT - and with the AppKit main
+    // thread parked behind it, the whole application and the macOS menu bar.
+    //
+    // One thread, and daemon, so a wedged peer page costs one parked thread and the ops that queue
+    // behind it are this peer's own - which is the right blast radius for a share that has failed.
+    private val callExecutor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "boss-rtc-peer-call").apply { isDaemon = true }
+        }
+    private val scope = CoroutineScope(SupervisorJob() + callExecutor.asCoroutineDispatcher())
     private val bridge =
         CoBrowseRtcBridge(onAnswer, onIce, onInput, onState).also {
             it.onVideoError = { msg -> logger.warn(LogCategory.BROWSER, "WebRTC video capture error: $msg") }
@@ -63,7 +78,9 @@ internal class CoBrowseRtcPeerImpl(
 
     @Volatile private var browser: Browser? = null
 
-    @Volatile private var injected = false
+    // Atomic rather than @Volatile: injection is now posted off the callback thread, so a plain
+    // read-then-write would let two LoadFinished events both see "not injected" and queue it twice.
+    private val injected = AtomicBoolean(false)
 
     @Volatile private var ready = false
 
@@ -111,17 +128,30 @@ internal class CoBrowseRtcPeerImpl(
                 // Inject the bridge + init the peer once the served page (and its
                 // script) has finished loading.
                 b.navigation().on(LoadFinished::class.java) {
-                    try {
-                        if (!injected) {
+                    // Posted, not run here. LoadFinished is delivered on JxBrowser's RPC thread, and
+                    // [injectInto]'s blocking executeJavaScript made from it re-enters
+                    // RpcThreadCallExecutor and parks on a queue only the thread it is blocking
+                    // could drain - so the reply can never arrive. That is the deadlock PR #268
+                    // fixed for the page helpers; this call site was missed by it.
+                    //
+                    // Claimed before the launch rather than inside it: two LoadFinished events would
+                    // otherwise both see "not injected" and queue a second injection. Released again
+                    // on failure, so a frame that was not there yet does not cost this peer its one
+                    // chance to initialize.
+                    if (!injected.compareAndSet(false, true)) return@on
+                    scope.launch {
+                        try {
                             val f = b.mainFrame().orElse(null)
-                            if (f != null) {
-                                injectInto(f)
-                                injected = true
-                                logger.info(LogCategory.BROWSER, "WebRTC peer initialized")
+                            if (f == null) {
+                                injected.set(false)
+                                return@launch
                             }
+                            injectInto(f)
+                            logger.info(LogCategory.BROWSER, "WebRTC peer initialized")
+                        } catch (e: Exception) {
+                            injected.set(false)
+                            logger.warn(LogCategory.BROWSER, "WebRTC peer init failed", error = e)
                         }
-                    } catch (e: Exception) {
-                        logger.warn(LogCategory.BROWSER, "WebRTC peer init failed", error = e)
                     }
                 }
                 b.navigation().loadUrl(RtcHostServer.baseUrl())
@@ -205,6 +235,10 @@ internal class CoBrowseRtcPeerImpl(
             }
             browser = null
         }
+        // shutdown() not shutdownNow(): the close above is already queued and must still run, and a
+        // call parked inside JxBrowser cannot be interrupted anyway. The thread is daemon, so a
+        // wedged peer cannot hold up exit.
+        callExecutor.shutdown()
     }
 
     private companion object {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
@@ -55,15 +55,23 @@ internal class CoBrowseRtcPeerImpl(
 ) : CoBrowseRtcPeer {
     private val logger = CoBrowseRtcProviderImpl.logger
 
-    // Every blocking JxBrowser round trip this peer makes, off the EDT and on a deadline - see
-    // [BoundedBrowserCall]. One instance per peer, so a share whose page stops answering costs its
-    // own thread and nobody else's.
+    // Every blocking JxBrowser round trip this peer makes, off the EDT. NOT on a deadline: this
+    // class takes only [BoundedBrowserCall.dispatcher] and calls `executeJavaScript` / `putProperty`
+    // directly, so DEFAULT_TIMEOUT_MS never applies here. That is deliberate - nothing awaits these
+    // calls, so there is no wait to bound, and a wedged peer page costs one parked daemon thread and
+    // nothing more. Routing them through `call()` would be worse, not better: this scope runs ON that
+    // dispatcher, and awaiting a call from its own dispatcher is the hang [BoundedBrowserCall] warns
+    // about.
+    //
+    // One instance per peer, so a share whose page stops answering costs its own thread and nobody
+    // else's - and the thread carries an id, because the WARN's thread name is the only thing that
+    // says WHICH share wedged when several are live.
     //
     // This moves `Engine.newBrowser()` and `browser.close()` off the EDT too, which is safe for the
     // reason that is easy to lose: JxBrowser's `Browser` API is thread-safe, and this peer is
     // HEADLESS - no `BrowserView`, no AWT anywhere in the class. A peer that ever acquires a view
     // has to put the view's lifecycle back on the EDT; the rest can stay here.
-    private val browserCall = BoundedBrowserCall("boss-rtc-peer-call")
+    private val browserCall = BoundedBrowserCall("boss-rtc-peer-call-${System.identityHashCode(this)}")
     private val scope = CoroutineScope(SupervisorJob() + browserCall.dispatcher)
     private val bridge =
         CoBrowseRtcBridge(onAnswer, onIce, onInput, onState).also {
@@ -89,6 +97,9 @@ internal class CoBrowseRtcPeerImpl(
     // are written down here because this comment is where the next reader will look.
     private val injected = AtomicBoolean(false)
     private val injectQueued = AtomicBoolean(false)
+
+    /** One warning per stall, not one per dropped frame. */
+    private val domDropWarned = AtomicBoolean(false)
 
     @Volatile private var ready = false
 
@@ -216,7 +227,33 @@ internal class CoBrowseRtcPeerImpl(
         runJs("window.__bossRtcAddIce && window.__bossRtcAddIce(${jsStr(candidate)});")
     }
 
+    /**
+     * The one caller that drops rather than enqueues.
+     *
+     * rrweb emits continuously and each payload is a DOM mutation batch, so against a peer page that
+     * has stopped answering this would grow [BoundedBrowserCall.backlog] without limit, holding every
+     * frame's JSON - and then run them all in a burst if the page ever recovered. That is exactly the
+     * hazard cited for leaving `dispatchCoBrowseInput` on Main in BrowserHandleImpl, and the argument
+     * has to point the same way here: same shape, bigger payloads.
+     *
+     * Dropping is safe in the way that matters. A peer page that is not answering is not mirroring
+     * anything to a viewer either, so these frames have nowhere to be displayed; the share is already
+     * dead and this only decides whether it also costs memory. Newest-dropped rather than
+     * oldest-dropped because rrweb is incremental - the frames already queued are the ones the
+     * viewer's mirror needs first.
+     */
     override fun sendDom(json: String) {
+        if (browserCall.backlog >= MAX_DOM_BACKLOG) {
+            if (domDropWarned.compareAndSet(false, true)) {
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "WebRTC peer is not draining DOM frames - dropping until it catches up",
+                    mapOf("backlog" to browserCall.backlog.toString()),
+                )
+            }
+            return
+        }
+        domDropWarned.set(false)
         runJs("window.__bossRtcSendDom && window.__bossRtcSendDom(${jsStr(json)});")
     }
 
@@ -238,6 +275,7 @@ internal class CoBrowseRtcPeerImpl(
         bridge.onInput = null
         bridge.onState = null
         bridge.onVideoError = null
+        bridge.onVideoState = null
         scope.launch {
             try {
                 browser?.takeIf { !it.isClosed }?.close()
@@ -256,6 +294,14 @@ internal class CoBrowseRtcPeerImpl(
     }
 
     private companion object {
+        /**
+         * How many un-started DOM frames may sit on the peer's thread before new ones are dropped.
+         *
+         * Small on purpose: anything past a handful means the peer page is not draining, and the
+         * frames behind it are already too stale to be worth the memory.
+         */
+        const val MAX_DOM_BACKLOG = 8
+
         fun jsStr(s: String): String = Json.encodeToString(String.serializer(), s)
 
         // Must stay in lockstep with the plugin's BrowserShareManager.iceServers():

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/CoBrowseRtcPeerImpl.kt
@@ -14,12 +14,10 @@ import com.teamdev.jxbrowser.js.JsObject
 import com.teamdev.jxbrowser.navigation.event.LoadFinished
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import java.net.InetSocketAddress
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -57,19 +55,16 @@ internal class CoBrowseRtcPeerImpl(
 ) : CoBrowseRtcPeer {
     private val logger = CoBrowseRtcProviderImpl.logger
 
-    // Off-thread executor for this peer's blocking JxBrowser round trips, for the reason
-    // BrowserHandleImpl.handleCallExecutor spells out at length: executeJavaScript and putProperty
-    // block until the renderer answers, nothing can interrupt that wait, and made from
-    // Dispatchers.Main a peer page that stops answering takes the EDT - and with the AppKit main
-    // thread parked behind it, the whole application and the macOS menu bar.
+    // Every blocking JxBrowser round trip this peer makes, off the EDT and on a deadline - see
+    // [BoundedBrowserCall]. One instance per peer, so a share whose page stops answering costs its
+    // own thread and nobody else's.
     //
-    // One thread, and daemon, so a wedged peer page costs one parked thread and the ops that queue
-    // behind it are this peer's own - which is the right blast radius for a share that has failed.
-    private val callExecutor =
-        Executors.newSingleThreadExecutor { runnable ->
-            Thread(runnable, "boss-rtc-peer-call").apply { isDaemon = true }
-        }
-    private val scope = CoroutineScope(SupervisorJob() + callExecutor.asCoroutineDispatcher())
+    // This moves `Engine.newBrowser()` and `browser.close()` off the EDT too, which is safe for the
+    // reason that is easy to lose: JxBrowser's `Browser` API is thread-safe, and this peer is
+    // HEADLESS - no `BrowserView`, no AWT anywhere in the class. A peer that ever acquires a view
+    // has to put the view's lifecycle back on the EDT; the rest can stay here.
+    private val browserCall = BoundedBrowserCall("boss-rtc-peer-call")
+    private val scope = CoroutineScope(SupervisorJob() + browserCall.dispatcher)
     private val bridge =
         CoBrowseRtcBridge(onAnswer, onIce, onInput, onState).also {
             it.onVideoError = { msg -> logger.warn(LogCategory.BROWSER, "WebRTC video capture error: $msg") }
@@ -81,10 +76,17 @@ internal class CoBrowseRtcPeerImpl(
     // Two flags, not one, now that injection is posted off the callback thread.
     //
     // [injected] is the DONE state and is only ever set on success. [injectQueued] keeps a second
-    // LoadFinished from queueing a duplicate while one is in flight, and is released in a finally.
-    // Collapsing them into a single claim-before-launch was wrong in the other direction: a failed
-    // attempt released the claim only after the events that would have retried it had already been
-    // dropped, and a page that loads once never fires a third.
+    // LoadFinished from queueing a duplicate while one is in flight. Collapsing them into a single
+    // claim-before-launch was wrong in the other direction: a failed attempt released the claim only
+    // after the events that would have retried it had already been dropped, and a page that loads
+    // once never fires a third.
+    //
+    // Two things the pair does NOT promise. [injectQueued]'s finally does not run if the dispatch
+    // itself is rejected - after close() shuts the executor down, kotlinx cancels the child before
+    // its body starts - so the flag can stay latched; harmless only because `closed` short-circuits
+    // every path that would look at it again. And [injected] is never reset, so a *reload* of the
+    // peer page leaves the new document without the bridge. Both were true before this change; they
+    // are written down here because this comment is where the next reader will look.
     private val injected = AtomicBoolean(false)
     private val injectQueued = AtomicBoolean(false)
 
@@ -243,15 +245,14 @@ internal class CoBrowseRtcPeerImpl(
             }
             browser = null
         }
-        // shutdown(), not shutdownNow(), and deliberately no scope.cancel(): the browser close above
-        // is already queued on this executor and cancelling would drop it. A call parked inside
-        // JxBrowser cannot be interrupted anyway.
+        // Deliberately no scope.cancel(): the browser close above is already queued on this thread
+        // and cancelling would drop it before it starts.
         //
         // Known cost: if a wedged JS call is holding the thread, that queued close never runs and
         // this peer's hidden browser leaks until process exit. One browser per failed share, against
         // a frozen application - the trade this whole change is making, and bounded because the
         // thread is daemon.
-        callExecutor.shutdown()
+        browserCall.shutdown()
     }
 
     private companion object {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
@@ -64,6 +64,37 @@ class BoundedBrowserCallTest {
     }
 
     /**
+     * A wedge has to be *reportable*, not just survivable.
+     *
+     * The first version answered null on timeout and told nobody: `onError` was reachable only
+     * through the success path's `getOrElse`, and `withTimeoutOrNull` returning null short-circuited
+     * straight past it. That turns "the app froze" into "plugin JS silently returns null forever",
+     * which is better to live with and much worse to diagnose.
+     */
+    @Test
+    fun `a timeout is reported, and is not reported as an error`() {
+        val call = BoundedBrowserCall("test-bounded-report")
+        val release = CountDownLatch(1)
+        var timedOut = 0
+        val errors = mutableListOf<Throwable>()
+        try {
+            runBlocking {
+                assertNull(
+                    call.call(timeout, onError = { errors += it }, onTimeout = { timedOut++ }) {
+                        release.await()
+                        "never"
+                    },
+                )
+            }
+            assertEquals(1, timedOut, "the timeout produced no report at all")
+            assertTrue(errors.isEmpty(), "a timeout was reported as a thrown error: $errors")
+        } finally {
+            release.countDown()
+            call.shutdown()
+        }
+    }
+
+    /**
      * The trade the KDoc describes: the wedged call keeps the thread, so later calls do NOT get
      * through - they queue behind it and answer null on time. Degradation, not a freeze.
      */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
@@ -40,6 +40,31 @@ class BoundedBrowserCallTest {
         }
     }
 
+    /**
+     * The property this class exists for, and the only one every other test here takes for granted.
+     *
+     * Everything else is about the *wait*. If a refactor ran `block()` inline in the caller's context
+     * the deadline tests would all still pass and the EDT would be back in the blocking call - which
+     * is the entire bug.
+     */
+    @Test
+    fun `the block runs on the dedicated thread, not the caller's`() {
+        val call = BoundedBrowserCall("test-bounded-thread")
+        try {
+            runBlocking {
+                // startsWith, not equals: with coroutine debug on, kotlinx appends "@coroutine#N" to
+                // the thread name. The prefix is the assertion - it says which thread ran the block.
+                val ranOn = call.call(generous) { Thread.currentThread().name }.orEmpty()
+                assertTrue(
+                    ranOn.startsWith("test-bounded-thread"),
+                    "block ran on \"$ranOn\" - it must run on the dedicated thread, not the caller's",
+                )
+            }
+        } finally {
+            call.shutdown()
+        }
+    }
+
     @Test
     fun `a call that never answers gives up on schedule`() {
         val call = BoundedBrowserCall("test-bounded-wedge")
@@ -56,7 +81,10 @@ class BoundedBrowserCallTest {
                         )
                     }
                 }
+            // Both sides: `< generous` proves the wait ended, `>= timeout` proves the DEADLINE is what
+            // ended it rather than the call quietly answering null for some unrelated reason.
             assertTrue(elapsed < generous, "waited ${elapsed}ms - the deadline did not bound the call")
+            assertTrue(elapsed >= timeout, "returned after ${elapsed}ms, before its own ${timeout}ms deadline")
         } finally {
             release.countDown()
             call.shutdown()
@@ -112,6 +140,7 @@ class BoundedBrowserCallTest {
                 )
                 val elapsed = measureTimeMillis { assertNull(call.call(timeout) { "queued behind it" }) }
                 assertTrue(elapsed < generous, "the second call waited ${elapsed}ms rather than its own deadline")
+                assertTrue(elapsed >= timeout, "the second call returned after ${elapsed}ms, before its deadline")
             }
         } finally {
             release.countDown()
@@ -146,6 +175,7 @@ class BoundedBrowserCallTest {
                     }
                 }
             assertTrue(elapsed < generous, "waited ${elapsed}ms - the caller's dispatcher still decides the bound")
+            assertTrue(elapsed >= timeout, "returned after ${elapsed}ms, before its own deadline")
         } finally {
             release.countDown()
             call.shutdown()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
@@ -1,0 +1,184 @@
+package ai.rever.boss.plugin.browser
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * What the deadline actually buys, pinned without a Chromium.
+ *
+ * The freeze this class exists to prevent needs a real renderer that stops answering, which no unit
+ * test can arrange. What it *can* arrange is the shape: a call that never returns, on the one thread
+ * it is confined to. Everything the KDoc promises about that is checked here, because the promise
+ * was wrong once already - the wait used to run in the caller's context, so a caller that happened
+ * to be single-threaded lost the bound with nothing in the signature to say so.
+ */
+class BoundedBrowserCallTest {
+    private val timeout = 300L
+
+    /** Long enough that a *bounded* wait cannot reach it, short enough to fail a test run fast. */
+    private val generous = 10_000L
+
+    @Test
+    fun `a call that returns is answered with its value`() {
+        val call = BoundedBrowserCall("test-bounded-ok")
+        try {
+            runBlocking { assertEquals("answered", call.call(generous) { "answered" }) }
+        } finally {
+            call.shutdown()
+        }
+    }
+
+    @Test
+    fun `a call that never answers gives up on schedule`() {
+        val call = BoundedBrowserCall("test-bounded-wedge")
+        val release = CountDownLatch(1)
+        try {
+            val elapsed =
+                measureTimeMillis {
+                    runBlocking {
+                        assertNull(
+                            call.call(timeout) {
+                                release.await()
+                                "never"
+                            },
+                        )
+                    }
+                }
+            assertTrue(elapsed < generous, "waited ${elapsed}ms - the deadline did not bound the call")
+        } finally {
+            release.countDown()
+            call.shutdown()
+        }
+    }
+
+    /**
+     * The trade the KDoc describes: the wedged call keeps the thread, so later calls do NOT get
+     * through - they queue behind it and answer null on time. Degradation, not a freeze.
+     */
+    @Test
+    fun `later calls still answer on schedule while one is wedged`() {
+        val call = BoundedBrowserCall("test-bounded-queue")
+        val release = CountDownLatch(1)
+        try {
+            runBlocking {
+                assertNull(
+                    call.call(timeout) {
+                        release.await()
+                        "never"
+                    },
+                )
+                val elapsed = measureTimeMillis { assertNull(call.call(timeout) { "queued behind it" }) }
+                assertTrue(elapsed < generous, "the second call waited ${elapsed}ms rather than its own deadline")
+            }
+        } finally {
+            release.countDown()
+            call.shutdown()
+        }
+    }
+
+    /**
+     * The regression that matters: the bound must not depend on where the caller runs.
+     *
+     * A caller confined to its own single thread - which is what `coBrowseScope` and `pageEventScope`
+     * are - used to lose the deadline entirely, because `withTimeoutOrNull { await() }` ran in the
+     * caller's context and resuming it needed a dispatch this class had no say over.
+     */
+    @Test
+    fun `the bound holds for a caller confined to its own single thread`() {
+        val call = BoundedBrowserCall("test-bounded-confined")
+        val callerThread = Executors.newSingleThreadExecutor { r -> Thread(r, "test-confined-caller") }
+        val release = CountDownLatch(1)
+        try {
+            val elapsed =
+                measureTimeMillis {
+                    runBlocking {
+                        withContext(callerThread.asCoroutineDispatcher()) {
+                            assertNull(
+                                call.call(timeout) {
+                                    release.await()
+                                    "never"
+                                },
+                            )
+                        }
+                    }
+                }
+            assertTrue(elapsed < generous, "waited ${elapsed}ms - the caller's dispatcher still decides the bound")
+        } finally {
+            release.countDown()
+            call.shutdown()
+            callerThread.shutdownNow()
+        }
+    }
+
+    /**
+     * After [BoundedBrowserCall.shutdown] the executor rejects the dispatch and kotlinx cancels the
+     * job. That cancellation belongs to this class, not to the caller, so it owes a null rather than
+     * throwing into a plugin's coroutine - which is what every other failure path here answers.
+     */
+    @Test
+    fun `a call after shutdown answers null rather than throwing`() {
+        val call = BoundedBrowserCall("test-bounded-shutdown")
+        call.shutdown()
+        runBlocking { assertNull(call.call(generous) { "unreachable" }) }
+    }
+
+    /** A throwing call is a null answer plus one report, not a propagated exception. */
+    @Test
+    fun `a throwing call is reported and answered with null`() {
+        val call = BoundedBrowserCall("test-bounded-throw")
+        val seen = mutableListOf<Throwable>()
+        try {
+            runBlocking {
+                assertNull(call.call(generous, onError = { seen += it }) { error("renderer said no") })
+            }
+            assertEquals(1, seen.size, "expected exactly one reported failure, got $seen")
+        } finally {
+            call.shutdown()
+        }
+    }
+
+    /** The caller's own cancellation is not swallowed by the shutdown handling above. */
+    @Test
+    fun `a caller's cancellation still propagates`() {
+        val call = BoundedBrowserCall("test-bounded-cancel")
+        val release = CountDownLatch(1)
+        val entered = CountDownLatch(1)
+        try {
+            var propagated = false
+            runBlocking {
+                val job =
+                    launch {
+                        try {
+                            call.call(generous) {
+                                entered.countDown()
+                                release.await()
+                                "never"
+                            }
+                        } catch (_: CancellationException) {
+                            propagated = true
+                        }
+                    }
+                // Cancel only once the blocking body is genuinely in flight, so this tests the
+                // await being cancelled rather than the job never having started.
+                withContext(Dispatchers.IO) { entered.await() }
+                job.cancelAndJoin()
+            }
+            assertTrue(propagated, "the caller's cancellation was swallowed and answered as null")
+        } finally {
+            release.countDown()
+            call.shutdown()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
@@ -1,5 +1,10 @@
 package ai.rever.boss.plugin.browser
 
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.logging.LogEntry
+import ai.rever.boss.utils.logging.LogLevel
+import ai.rever.boss.utils.logging.LogListener
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -206,6 +211,73 @@ class BoundedBrowserCallTest {
             }
             assertEquals(1, seen.size, "expected exactly one reported failure, got $seen")
         } finally {
+            call.shutdown()
+        }
+    }
+
+    /**
+     * [BoundedBrowserCall.backlog] is load-bearing, not diagnostic: `CoBrowseRtcPeerImpl.sendDom`
+     * decides whether to drop a DOM frame by reading it. Nothing pinned it, so a refactor that had
+     * it answer 0 - the queue swapped, the count taken after the poll - would silently turn the drop
+     * policy back into the unbounded growth it replaced, with every other test still green.
+     */
+    @Test
+    fun `backlog counts the work queued behind a wedged call`() {
+        val call = BoundedBrowserCall("test-bounded-backlog")
+        val release = CountDownLatch(1)
+        val entered = CountDownLatch(1)
+        try {
+            assertEquals(0, call.backlog, "an idle instance reported queued work")
+            call.post {
+                entered.countDown()
+                release.await()
+            }
+            entered.await()
+            // Queued, not started: the one thread is inside the post above.
+            call.post { }
+            call.post { }
+            assertEquals(2, call.backlog, "backlog did not count the work waiting behind the wedge")
+        } finally {
+            release.countDown()
+            call.shutdown()
+        }
+    }
+
+    /**
+     * The one documented way to reintroduce a permanent hang, pinned at the moment it is written
+     * rather than at the moment a renderer wedges.
+     *
+     * `coBrowseScope`, `pageEventScope` and `call` all share one dispatcher, so an edit that awaits
+     * a call from inside one of those scopes hangs forever - and only once a page stops answering,
+     * which is why the warning is eager and why it needs to stay that way.
+     */
+    @Test
+    fun `awaiting a call from its own dispatcher is warned about`() {
+        val call = BoundedBrowserCall("test-bounded-confinement-warning")
+        val seen = mutableListOf<LogEntry>()
+        val listener = LogListener { entry -> synchronized(seen) { seen += entry } }
+        val previousLevel = BossLogger.globalLevel
+        BossLogger.setGlobalLevel(LogLevel.WARN)
+        BossLogger.setCategoryLevel(LogCategory.BROWSER, LogLevel.WARN)
+        BossLogger.addListener(listener)
+        try {
+            // A block that completes, so the call itself succeeds. The warning is about the shape,
+            // not the outcome: on the happy path awaiting from this dispatcher works, which is
+            // exactly why nothing but an eager warning would ever surface it.
+            runBlocking {
+                withContext(call.dispatcher) { assertEquals("fine", call.call(generous) { "fine" }) }
+            }
+            val warnings = synchronized(seen) { seen.filter { it.message.contains("awaited from its own dispatcher") } }
+            assertEquals(1, warnings.size, "no warning for a call awaited from its own dispatcher: $seen")
+            assertEquals(
+                "test-bounded-confinement-warning",
+                warnings.single().data?.get("thread"),
+                "the warning did not name the instance whose dispatcher was awaited from",
+            )
+        } finally {
+            BossLogger.removeListener(listener)
+            BossLogger.clearCategoryLevel(LogCategory.BROWSER)
+            BossLogger.setGlobalLevel(previousLevel)
             call.shutdown()
         }
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
@@ -44,9 +44,12 @@ class BrowserMainThreadRoundTripTest {
      * Without that distinction this guard flagged `DefaultPlugin`'s adapter, which only delegates to
      * the wrapper and is exactly what a caller is *supposed* to do.
      *
-     * Known gap: a JxBrowser call whose type argument was inferred from an expected type would read
-     * as the wrapper and be missed. There are none today, and writing one is not the natural style
-     * here - but it is the way this check goes blind, so it belongs in writing.
+     * Known gaps, both of which are how this check goes blind, so both belong in writing:
+     *  - a JxBrowser call whose type argument was inferred from an expected type reads as the
+     *    wrapper and is missed. There are none today, and it is not the natural style here.
+     *  - indirection more than **one** call deep. A Main block calling a local helper that blocks is
+     *    caught (see [roundTripFunctions]) - that is the exact shape of the bug this change fixes -
+     *    but a helper calling a second helper is not.
      */
     private val rendererRoundTrips = listOf(".executeJavaScript<", ".putProperty(")
 
@@ -58,7 +61,7 @@ class BrowserMainThreadRoundTripTest {
      * `Dispatchers.Main.immediate`, `SwingUtilities.invokeLater`, and this package's own `onEdt`
      * helper are all the same hazard wearing different syntax.
      */
-    private val mainThreadMarkers = listOf("Dispatchers.Main", "invokeLater", "onEdt")
+    private val mainThreadMarkers = listOf("Dispatchers.Main", "Dispatchers.Swing", "invokeLater", "onEdt")
 
     /**
      * Scope constructions that put every launch into them on the EDT, allowed only where reviewed.
@@ -77,6 +80,9 @@ class BrowserMainThreadRoundTripTest {
     /** How far a `{` may sit from its marker before it plainly belongs to something else. */
     private val markerToBrace = 60
 
+    /** How long a function header may run before its `{` stops plausibly being its body. */
+    private val funHeaderLimit = 400
+
     private fun repoRoot(): File? =
         generateSequence(File("").absoluteFile) { it.parentFile }
             .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile }
@@ -87,9 +93,16 @@ class BrowserMainThreadRoundTripTest {
             .filter { it.isDirectory }
             .flatMap { it.walkTopDown() }
             .filter { it.isFile && it.extension == "kt" }
+            .map { it.path.replace(File.separatorChar, '/') to it }
             // Build output holds generated copies of the same sources; scanning them doubles the
             // walk and reports names that are not source files anyone can fix.
-            .filterNot { it.path.replace(File.separatorChar, '/').contains("/build/") }
+            .filterNot { (path, _) -> path.contains("/build/") }
+            // Test sources are excluded on purpose. This guards the product, and a test that
+            // deliberately drives JxBrowser from the EDT to prove something about it should fail on
+            // its own merits, not here - BrowserClipboardCommandsTest already calls
+            // `.executeJavaScript<` in code position.
+            .filterNot { (path, _) -> path.contains("Test/kotlin/") || path.contains("/test/") }
+            .map { (_, file) -> file }
             .toList()
 
     // ---- lexing -------------------------------------------------------------------------------
@@ -185,6 +198,24 @@ class BrowserMainThreadRoundTripTest {
 
     // ---- block finding ------------------------------------------------------------------------
 
+    /**
+     * Names of functions declared in this file whose own body makes a renderer round trip.
+     *
+     * This is the one hop that matters. Guard 1 used to match round-trip *literals* inside the
+     * dispatched block only, so `withContext(Dispatchers.Main) { injectPageEventScript(frame) }`
+     * read as clean - and that is precisely the shape of the freeze this change fixes, one frame
+     * down. Collecting the local blockers and treating a call to one as a round trip closes it for
+     * every site in the diff.
+     */
+    private fun roundTripFunctions(code: String): Set<String> =
+        Regex("""fun ([A-Za-z_][A-Za-z0-9_]*)\s*\(""")
+            .findAll(code)
+            .mapNotNull { match ->
+                val open = code.indexOf('{', match.range.last)
+                val body = if (open < 0 || open - match.range.last > funHeaderLimit) null else blockAt(code, open)
+                match.groupValues[1].takeIf { body != null && rendererRoundTrips.any { body.contains(it) } }
+            }.toSet()
+
     /** The source of every lambda dispatched onto the EDT, braces balanced. */
     private fun mainThreadBlocks(code: String): List<String> =
         mainThreadMarkers
@@ -250,9 +281,13 @@ class BrowserMainThreadRoundTripTest {
 
         val offenders =
             scanned.flatMap { file ->
-                mainThreadBlocks(codeOf(file))
-                    .filter { block -> rendererRoundTrips.any { block.contains(it) } }
-                    .map { block -> "${file.name}: ${block.take(160)}" }
+                val code = codeOf(file)
+                val blockers = roundTripFunctions(code)
+                mainThreadBlocks(code)
+                    .filter { block ->
+                        rendererRoundTrips.any { block.contains(it) } ||
+                            blockers.any { block.contains("$it(") }
+                    }.map { block -> "${file.name}: ${block.take(160)}" }
             }
 
         assertTrue(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
@@ -14,187 +14,286 @@ import kotlin.test.assertTrue
  * interrupt the wait - `executeJavaScript` has no suspension point, so a `withTimeoutOrNull` placed
  * around it is not a bound.
  *
- * Made from `Dispatchers.Main` that is not a slow call, it is a dead application: the EDT parks
- * forever, AppKit's main thread parks behind it, and the macOS menu bar goes with the window. Force
- * quit is the only exit. It happened twice in one morning on 9.5.7 - once through the plugin-facing
- * `executeJavaScript`, once through the co-browse page-event injection's `putProperty` - and the
- * user-visible symptom is indistinguishable from a hung machine.
+ * Made from the EDT that is not a slow call, it is a dead application: the EDT parks forever, AppKit's
+ * main thread parks behind it, and the macOS menu bar goes with the window. Force quit is the only
+ * exit. It happened twice in one morning on 9.5.7, and the user-visible symptom is indistinguishable
+ * from a hung machine.
  *
- * The fix is the pattern the rest of [BrowserHandleImpl] already uses in three places: make the
- * blocking call on a dedicated single daemon thread and, where a result is needed, bound the *wait*
- * from a different one. A wedged renderer then costs one parked thread per tab.
+ * The fix is [BoundedBrowserCall]: the blocking call on a dedicated single daemon thread, and the
+ * wait bounded from a different one.
  *
  * A source check rather than a behaviour one, for the reason [InjectJsCallbackOwnershipTest] gives:
- * the failure mode is a *new call site*, and observing it at runtime needs a real Chromium and a
- * page that genuinely stops answering. Reading the source catches it as it is written.
+ * the failure mode is a *call site*, and observing it at runtime needs a real Chromium and a page
+ * that genuinely stops answering.
  *
- * PR #268 fixed this same hazard for JxBrowser's RPC thread and left the EDT sites in place, which
- * is precisely the kind of half-fix a guard exists to stop. If a Main-thread round trip is ever
- * genuinely wanted, argue with this test - do not route around it.
+ * **Scope: every Kotlin source in the repo.** The first draft walked only `.../plugin/browser`, and
+ * review promptly found a fourth live site one directory over - `DesktopBrowserAccessor`, reached by
+ * plugins through a shipped API - which the guard reported as clean. "The failure mode is a new call
+ * site" is exactly as true of an existing one the walk could not see.
  */
 class BrowserMainThreadRoundTripTest {
-    /** Blocking calls into the renderer. Neither can be interrupted once entered. */
-    private val rendererRoundTrips = listOf("executeJavaScript", "putProperty")
+    /**
+     * Blocking calls into the renderer, matched in call position.
+     *
+     * The leading `.` keeps a declaration (`override suspend fun executeJavaScript(`) or an
+     * interface's signature from reading as a call - there are several, and none of them block.
+     *
+     * The `<` is what separates JxBrowser's blocking `Frame.executeJavaScript` from *our own*
+     * suspend wrapper of the same name. JxBrowser's is generic (`<T> T executeJavaScript(String)`),
+     * so every call to it in this repo spells the type argument out; the suspend wrapper takes none.
+     * Without that distinction this guard flagged `DefaultPlugin`'s adapter, which only delegates to
+     * the wrapper and is exactly what a caller is *supposed* to do.
+     *
+     * Known gap: a JxBrowser call whose type argument was inferred from an expected type would read
+     * as the wrapper and be missed. There are none today, and writing one is not the natural style
+     * here - but it is the way this check goes blind, so it belongs in writing.
+     */
+    private val rendererRoundTrips = listOf(".executeJavaScript<", ".putProperty(")
+
+    /**
+     * Anything that puts the following lambda on the EDT.
+     *
+     * A token list rather than a list of opener forms, because the opener is the part that keeps
+     * changing: `withContext(Dispatchers.Main)`, `launch(Dispatchers.Main)`, `async(...)`,
+     * `Dispatchers.Main.immediate`, `SwingUtilities.invokeLater`, and this package's own `onEdt`
+     * helper are all the same hazard wearing different syntax.
+     */
+    private val mainThreadMarkers = listOf("Dispatchers.Main", "invokeLater", "onEdt")
+
+    /**
+     * Scope constructions that put every launch into them on the EDT, allowed only where reviewed.
+     *
+     * A window of surrounding source has to contain one of these verbatim. Whole-file allowlisting
+     * would have let the very scopes this change moved - `coBrowseScope`, `pageEventScope` - back in
+     * unnoticed, since they lived in a file that has legitimate Main use as well.
+     */
+    private val allowedMainScopes =
+        setOf(
+            // Compose view state for the browser widget. Belongs to the EDT, and makes no renderer
+            // round trip of its own - it drives the AWT component, not the page.
+            "BrowserViewState(browser, MainScope(), awtWindow)",
+        )
+
+    /** How far a `{` may sit from its marker before it plainly belongs to something else. */
+    private val markerToBrace = 60
 
     private fun repoRoot(): File? =
         generateSequence(File("").absoluteFile) { it.parentFile }
             .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile }
 
-    private fun browserSources(root: File): List<File> =
-        File(root, "composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser")
-            .walkTopDown()
+    private fun kotlinSources(root: File): List<File> =
+        sequenceOf("composeApp/src", "plugin-platform", "modules", "server/src")
+            .map { File(root, it) }
+            .filter { it.isDirectory }
+            .flatMap { it.walkTopDown() }
             .filter { it.isFile && it.extension == "kt" }
+            // Build output holds generated copies of the same sources; scanning them doubles the
+            // walk and reports names that are not source files anyone can fix.
+            .filterNot { it.path.replace(File.separatorChar, '/').contains("/build/") }
             .toList()
 
-    /**
-     * Comments and string literals removed, whitespace collapsed.
-     *
-     * Comments go for the reason [InjectJsCallbackOwnershipTest] gives - this KDoc names both the
-     * dispatcher and the call, and matching raw text would flag the explanation as the offence.
-     * String literals go because the brace scan below counts braces: an injected script, or a string
-     * template's own braces, are not block structure, and one of those inside a scanned block would
-     * end it early and make this guard quietly stop guarding.
-     */
-    private fun codeOf(file: File): String =
-        stripStrings(
-            file
-                .readText()
-                .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), " ")
-                .lines()
-                // Not substringBefore("//"): that cuts at the "//" inside "https://…" too, which is
-                // a false negative in a guard whose whole value is catching one occurrence.
-                .joinToString(" ") { line -> line.split(Regex("(?<!:)//")).first() },
-        ).replace(Regex("\\s+"), " ")
+    // ---- lexing -------------------------------------------------------------------------------
 
     /**
-     * Every string literal replaced by an empty one, scanned by hand rather than matched.
+     * The file's code with comments and string literals removed, then whitespace collapsed.
      *
-     * The obvious regex - `"(?:\\.|[^"\\])*"` - is a `(?:A|B)*` loop, which java.util.regex walks
-     * recursively: against the multi-kilobyte injected scripts in this package it overflows the
-     * stack, and a guard that dies is worse than one that is wrong. A single pass costs nothing and
-     * handles the raw `"""…"""` strings those scripts are written as, which the regex did not.
+     * One pass, handling all four of line comment / block comment / string / raw string together.
+     * Doing it in two passes - comments first, then strings - was wrong in a way that would have
+     * gone unnoticed: a `//` inside a raw string truncated that physical line, and a JS `//` comment
+     * on a line that also closed its `\"\"\"` would send the string scan to end-of-file and silently
+     * switch this whole guard off. Comments go because this file names both a dispatcher and a
+     * round trip in prose; strings go because an injected script's braces are not block structure.
      */
-    private fun stripStrings(code: String): String {
-        val out = StringBuilder(code.length)
+    private fun codeOf(file: File): String {
+        val src = file.readText()
+        val out = StringBuilder(src.length)
         var i = 0
-        while (i < code.length) {
+        while (i < src.length) {
             i =
                 when {
-                    code.startsWith("\"\"\"", i) -> skipRaw(code, i, out)
-                    code[i] == '"' -> skipQuoted(code, i, out)
-                    else -> copyChar(code, i, out)
+                    src.startsWith("//", i) -> skipLineComment(src, i, out)
+                    src.startsWith("/*", i) -> skipBlockComment(src, i, out)
+                    src.startsWith("\"\"\"", i) -> skipRawString(src, i, out)
+                    src[i] == '"' -> skipString(src, i, out)
+                    src[i] == '\'' -> skipCharLiteral(src, i, out)
+                    else -> copyChar(src, i, out)
                 }
         }
-        return out.toString()
+        return out.toString().replace(Regex("\\s+"), " ")
     }
 
-    /** Past the closing `"""`, or to the end if it is unterminated. */
-    private fun skipRaw(
-        code: String,
+    private fun skipLineComment(
+        src: String,
+        start: Int,
+        out: StringBuilder,
+    ): Int {
+        out.append(' ')
+        val end = src.indexOf('\n', start)
+        return if (end < 0) src.length else end
+    }
+
+    private fun skipBlockComment(
+        src: String,
+        start: Int,
+        out: StringBuilder,
+    ): Int {
+        out.append(' ')
+        val end = src.indexOf("*/", start + 2)
+        return if (end < 0) src.length else end + 2
+    }
+
+    private fun skipRawString(
+        src: String,
         start: Int,
         out: StringBuilder,
     ): Int {
         out.append("\"\"")
-        val end = code.indexOf("\"\"\"", start + 3)
-        return if (end < 0) code.length else end + 3
+        val end = src.indexOf("\"\"\"", start + 3)
+        return if (end < 0) src.length else end + 3
     }
 
-    /** Past the closing `"`, honouring backslash escapes. */
-    private fun skipQuoted(
-        code: String,
+    private fun skipString(
+        src: String,
         start: Int,
         out: StringBuilder,
     ): Int {
         out.append("\"\"")
-        var j = start + 1
-        while (j < code.length && code[j] != '"') j += if (code[j] == '\\') 2 else 1
-        return if (j >= code.length) code.length else j + 1
+        var i = start + 1
+        while (i < src.length && src[i] != '"' && src[i] != '\n') i += if (src[i] == '\\') 2 else 1
+        return if (i >= src.length) src.length else i + 1
+    }
+
+    private fun skipCharLiteral(
+        src: String,
+        start: Int,
+        out: StringBuilder,
+    ): Int {
+        out.append("''")
+        var i = start + 1
+        while (i < src.length && src[i] != '\'' && src[i] != '\n') i += if (src[i] == '\\') 2 else 1
+        return if (i >= src.length) src.length else i + 1
     }
 
     private fun copyChar(
-        code: String,
+        src: String,
         at: Int,
         out: StringBuilder,
     ): Int {
-        out.append(code[at])
+        out.append(src[at])
         return at + 1
     }
 
-    /** The source of every `withContext(Dispatchers.Main) { … }` block in [code], braces balanced. */
-    private fun mainThreadBlocks(code: String): List<String> {
-        val opener = Regex("""withContext\( ?Dispatchers\.Main ?\) ?\{""")
-        return opener
-            .findAll(code)
-            .map { match ->
-                var depth = 0
-                var end = match.range.last
-                for (i in match.range.last until code.length) {
-                    when (code[i]) {
-                        '{' -> {
-                            depth++
-                        }
+    // ---- block finding ------------------------------------------------------------------------
 
-                        '}' -> {
-                            depth--
-                            if (depth == 0) {
-                                end = i
-                                break
-                            }
-                        }
-                    }
-                }
-                code.substring(match.range.first, end + 1)
-            }.toList()
+    /** The source of every lambda dispatched onto the EDT, braces balanced. */
+    private fun mainThreadBlocks(code: String): List<String> =
+        mainThreadMarkers
+            .flatMap { marker -> markerIndices(code, marker) }
+            .mapNotNull { at -> dispatchedBlockAt(code, at) }
+
+    private fun markerIndices(
+        code: String,
+        marker: String,
+    ): List<Int> =
+        generateSequence(code.indexOf(marker)) { prev ->
+            code.indexOf(marker, prev + marker.length).takeIf { it >= 0 }
+        }.takeWhile { it >= 0 }
+            .toList()
+
+    /**
+     * The lambda this marker dispatches, or null when the marker does not open one.
+     *
+     * A `}` or a `fun ` between the marker and the brace means the brace opens something else - most
+     * often the next declaration after a scope built on Main, which is not a dispatched lambda.
+     */
+    private fun dispatchedBlockAt(
+        code: String,
+        at: Int,
+    ): String? {
+        val open = code.indexOf('{', at)
+        val opensALambda =
+            open >= 0 &&
+                open - at <= markerToBrace &&
+                code.substring(at, open).let { between -> !between.contains('}') && !between.contains("fun ") }
+        return if (opensALambda) blockAt(code, open) else null
     }
 
+    private fun blockAt(
+        code: String,
+        open: Int,
+    ): String {
+        var depth = 0
+        for (i in open until code.length) {
+            if (code[i] == '{') depth++
+            if (code[i] == '}') {
+                depth--
+                if (depth == 0) return code.substring(open, i + 1)
+            }
+        }
+        return code.substring(open)
+    }
+
+    private fun windowAround(
+        code: String,
+        at: Int,
+    ): String = code.substring(maxOf(0, at - 80), minOf(code.length, at + 80))
+
+    // ---- the guards ---------------------------------------------------------------------------
+
     @Test
-    fun `no renderer round trip runs inside a Main-thread block`() {
+    fun `no renderer round trip runs on the EDT`() {
         val root = assertNotNull(repoRoot(), "could not locate the repository root")
-        val scanned = browserSources(root)
+        val scanned = kotlinSources(root)
 
         // Deliberately not a skip: a guard that passes when it cannot see the tree is decoration.
-        assertTrue(scanned.size > 5, "only ${scanned.size} files scanned - the walk is not seeing the source")
+        assertTrue(scanned.size > 100, "only ${scanned.size} files scanned - the walk is not seeing the source")
 
         val offenders =
             scanned.flatMap { file ->
                 mainThreadBlocks(codeOf(file))
                     .filter { block -> rendererRoundTrips.any { block.contains(it) } }
-                    .map { block -> "${file.name}: ${block.take(140)}" }
+                    .map { block -> "${file.name}: ${block.take(160)}" }
             }
 
         assertTrue(
             offenders.isEmpty(),
-            "blocking renderer round trip inside withContext(Dispatchers.Main): $offenders. " +
-                "A renderer that does not answer parks the EDT forever, and the AppKit main thread " +
-                "parks behind it - the whole app and the menu bar freeze. Make the call on a " +
-                "dedicated daemon thread (see handleCallDispatcher) and bound the wait from another.",
+            "blocking renderer round trip dispatched onto the EDT: $offenders. A renderer that does " +
+                "not answer parks the EDT forever and the AppKit main thread parks behind it - the " +
+                "whole app and the macOS menu bar freeze. Route it through BoundedBrowserCall.",
         )
     }
 
     @Test
-    fun `no handle scope is built on the Main dispatcher`() {
+    fun `no scope that makes renderer round trips is built on the EDT`() {
         val root = assertNotNull(repoRoot(), "could not locate the repository root")
-        val scanned = browserSources(root)
-        assertTrue(scanned.size > 5, "only ${scanned.size} files scanned - the walk is not seeing the source")
+        val scanned = kotlinSources(root)
+        assertTrue(scanned.size > 100, "only ${scanned.size} files scanned - the walk is not seeing the source")
 
-        // Every scope declared here drives browser work, so a Main-dispatched one puts the round
-        // trips of whatever launches into it on the EDT - which is how the co-browse and page-event
-        // scopes came to freeze the app without any single call site looking wrong.
-        val mainScopes =
-            scanned
-                // A bounded window, not `[^)]*`: the context is built as
-                // `CoroutineScope(SupervisorJob() + Dispatchers.Main)`, and a negated-paren run
-                // stops dead at SupervisorJob's own `)` - so the first version of this guard matched
-                // nothing at all and passed against the very code it was written to catch.
-                .filter { codeOf(it).contains(Regex("""CoroutineScope\(.{0,120}?Dispatchers\.Main""")) }
-                .map { it.name }
-                .sorted()
+        val mainScopePattern = Regex("""MainScope\(\)|CoroutineScope\(.{0,160}?Dispatchers\.Main""")
+
+        val offenders =
+            scanned.flatMap { file ->
+                val code = codeOf(file)
+                // Only files that actually block on a renderer. Main-dispatched scopes are ordinary
+                // and correct throughout the UI; they are a hazard only where a round trip can be
+                // launched into one, which is how coBrowseScope and pageEventScope froze the app.
+                if (rendererRoundTrips.none { code.contains(it) }) {
+                    emptyList()
+                } else {
+                    mainScopePattern
+                        .findAll(code)
+                        .map { windowAround(code, it.range.first) }
+                        .filterNot { window -> allowedMainScopes.any { window.contains(it) } }
+                        .map { "${file.name}: …${it.trim()}…" }
+                        .toList()
+                }
+            }
 
         assertTrue(
-            mainScopes.isEmpty(),
-            "browser scope built on Dispatchers.Main: $mainScopes. Anything launched into it makes " +
-                "its blocking JxBrowser calls on the EDT. Dispatch the scope onto a dedicated " +
-                "thread instead, as coBrowseScope and pageEventScope now are.",
+            offenders.isEmpty(),
+            "EDT-dispatched scope in a file that blocks on the renderer: $offenders. Anything " +
+                "launched into it makes its blocking JxBrowser calls on the EDT. Build it on " +
+                "BoundedBrowserCall.dispatcher, or add the reviewed site to allowedMainScopes.",
         )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
@@ -59,9 +59,11 @@ class BrowserMainThreadRoundTripTest {
      * A token list rather than a list of opener forms, because the opener is the part that keeps
      * changing: `withContext(Dispatchers.Main)`, `launch(Dispatchers.Main)`, `async(...)`,
      * `Dispatchers.Main.immediate`, `SwingUtilities.invokeLater`, and this package's own `onEdt`
-     * helper are all the same hazard wearing different syntax.
+     * helper are all the same hazard wearing different syntax. `invokeAndWait` is the worst of them -
+     * it parks the caller *and* the EDT - so it is here even though nothing in the tree does it today.
      */
-    private val mainThreadMarkers = listOf("Dispatchers.Main", "Dispatchers.Swing", "invokeLater", "onEdt")
+    private val mainThreadMarkers =
+        listOf("Dispatchers.Main", "Dispatchers.Swing", "invokeLater", "invokeAndWait", "onEdt")
 
     /**
      * Scope constructions that put every launch into them on the EDT, allowed only where reviewed.
@@ -208,7 +210,10 @@ class BrowserMainThreadRoundTripTest {
      * every site in the diff.
      */
     private fun roundTripFunctions(code: String): Set<String> =
-        Regex("""fun ([A-Za-z_][A-Za-z0-9_]*)\s*\(""")
+        // `(?:<[^>]*>\s*)?` is what lets a GENERIC helper be seen. Requiring the identifier straight
+        // after `fun ` meant `private fun <T> helper(` never matched, so a generic blocking helper was
+        // invisible to the one hop - and this very file declares `fun <T> syncCall(` and `fun <T> call(`.
+        Regex("""fun (?:<[^>]*>\s*)?([A-Za-z_][A-Za-z0-9_]*)\s*\(""")
             .findAll(code)
             .mapNotNull { match ->
                 val open = code.indexOf('{', match.range.last)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.plugin.browser
 
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -44,12 +45,19 @@ class BrowserMainThreadRoundTripTest {
      * Without that distinction this guard flagged `DefaultPlugin`'s adapter, which only delegates to
      * the wrapper and is exactly what a caller is *supposed* to do.
      *
-     * Known gaps, both of which are how this check goes blind, so both belong in writing:
+     * Known gaps, every one of which is how this check goes blind, so every one belongs in writing:
      *  - a JxBrowser call whose type argument was inferred from an expected type reads as the
      *    wrapper and is missed. There are none today, and it is not the natural style here.
      *  - indirection more than **one** call deep. A Main block calling a local helper that blocks is
      *    caught (see [roundTripFunctions]) - that is the exact shape of the bug this change fixes -
      *    but a helper calling a second helper is not.
+     *  - a round trip written *inside* a `${…}` string template. [endOfString] discards an
+     *    interpolation with the literal that holds it, so a call in there is not seen at all. The
+     *    alternative - lexing template expressions back into the code stream - buys a shape nothing
+     *    in this repo writes, at the cost of the recursion being load-bearing rather than defensive.
+     *  - a round trip reached only from a **non-suspend** function whose caller supplies the EDT.
+     *    There is no Main marker at such a call site, so nothing here can see it; that is how
+     *    `requestPictureInPicture` survived this guard, and why it is posted rather than inline.
      */
     private val rendererRoundTrips = listOf(".executeJavaScript<", ".putProperty(")
 
@@ -173,8 +181,70 @@ class BrowserMainThreadRoundTripTest {
         out: StringBuilder,
     ): Int {
         out.append("\"\"")
+        return endOfString(src, start)
+    }
+
+    /**
+     * Just past the closing quote of the string literal at [start], or its line end.
+     *
+     * Interpolations are skipped as a unit, which is the whole point: stopping at the first `"` it
+     * met made a template like `"…${f("x")}…"` re-pair every quote for the rest of that physical
+     * line, so what is code read as string and vice versa. Newline-bounded, so it could not switch
+     * the file off - but it could swallow the tail of a line, and if that tail carried an unmatched
+     * brace then [blockAt]'s depth count is wrong and a block either truncates (a missed detection)
+     * or runs to EOF (a false positive). Not hypothetical: `"Co-browse control ${if (granted)
+     * "granted" else "revoked"}"` is in one of the files this guard is pointed at.
+     */
+    private fun endOfString(
+        src: String,
+        start: Int,
+    ): Int {
         var i = start + 1
-        while (i < src.length && src[i] != '"' && src[i] != '\n') i += if (src[i] == '\\') 2 else 1
+        while (i < src.length && src[i] != '\n') {
+            i =
+                when {
+                    src[i] == '\\' -> i + 2
+                    src.startsWith("\${", i) -> endOfTemplateExpression(src, i)
+                    src[i] == '"' -> return i + 1
+                    else -> i + 1
+                }
+        }
+        return minOf(i, src.length)
+    }
+
+    /**
+     * Just past the `}` that closes the `${…}` at [start].
+     *
+     * Brace-counted, with nested string and char literals skipped whole - either can hold a brace of
+     * its own (`wrap("}")`), and counting one of those would desync the caller's depth just as
+     * surely as mis-pairing a quote.
+     */
+    private fun endOfTemplateExpression(
+        src: String,
+        start: Int,
+    ): Int {
+        var i = start + 2
+        var depth = 1
+        while (i < src.length && depth > 0 && src[i] != '\n') {
+            if (src[i] == '{') depth++
+            if (src[i] == '}') depth--
+            i =
+                when (src[i]) {
+                    '\\' -> i + 2
+                    '"' -> endOfString(src, i)
+                    '\'' -> endOfCharLiteral(src, i)
+                    else -> i + 1
+                }
+        }
+        return minOf(i, src.length)
+    }
+
+    private fun endOfCharLiteral(
+        src: String,
+        start: Int,
+    ): Int {
+        var i = start + 1
+        while (i < src.length && src[i] != '\'' && src[i] != '\n') i += if (src[i] == '\\') 2 else 1
         return if (i >= src.length) src.length else i + 1
     }
 
@@ -184,9 +254,7 @@ class BrowserMainThreadRoundTripTest {
         out: StringBuilder,
     ): Int {
         out.append("''")
-        var i = start + 1
-        while (i < src.length && src[i] != '\'' && src[i] != '\n') i += if (src[i] == '\\') 2 else 1
-        return if (i >= src.length) src.length else i + 1
+        return endOfCharLiteral(src, start)
     }
 
     private fun copyChar(
@@ -301,6 +369,40 @@ class BrowserMainThreadRoundTripTest {
                 "not answer parks the EDT forever and the AppKit main thread parks behind it - the " +
                 "whole app and the macOS menu bar freeze. Route it through BoundedBrowserCall.",
         )
+    }
+
+    /**
+     * The lexer itself, because a guard that reads its input wrong is worse than no guard.
+     *
+     * The fixture is the minimal shape that used to hide an offender rather than merely report a
+     * confusing one: a nested-quote template holding a `}`. Under the old single-pass `skipString`
+     * the quotes re-paired, that `}` was read as *code*, and it closed the dispatched block one
+     * statement early - so the round trip below it fell outside the block and the file reported
+     * clean. Verified red against the previous lexer before this was added.
+     */
+    @Test
+    fun `the lexer does not desync on a nested-quote string template`() {
+        val fixture = File.createTempFile("round-trip-lexer", ".kt")
+        try {
+            fixture.writeText(
+                """
+                fun b(frame: Frame) {
+                    withContext(Dispatchers.Main) {
+                        logger.warn("closing: ${'$'}{wrap("}")}")
+                        frame.executeJavaScript<Any?>("x")
+                    }
+                }
+                """.trimIndent(),
+            )
+            val blocks = mainThreadBlocks(codeOf(fixture))
+            assertEquals(1, blocks.size, "the dispatched block was not found at all: $blocks")
+            assertTrue(
+                rendererRoundTrips.any { blocks.single().contains(it) },
+                "the template truncated the dispatched block and hid the round trip in it: ${blocks.single()}",
+            )
+        } finally {
+            fixture.delete()
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserMainThreadRoundTripTest.kt
@@ -1,0 +1,200 @@
+package ai.rever.boss.plugin.browser
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * No blocking renderer round trip may be made from the EDT.
+ *
+ * `Frame.executeJavaScript` and `JsObject.putProperty` block until the *renderer* answers, and a
+ * renderer has every right not to: one parked on a modal `window.prompt` cannot run script until the
+ * dialog is answered, and one being swapped out mid-redirect never answers at all. Nothing can
+ * interrupt the wait - `executeJavaScript` has no suspension point, so a `withTimeoutOrNull` placed
+ * around it is not a bound.
+ *
+ * Made from `Dispatchers.Main` that is not a slow call, it is a dead application: the EDT parks
+ * forever, AppKit's main thread parks behind it, and the macOS menu bar goes with the window. Force
+ * quit is the only exit. It happened twice in one morning on 9.5.7 - once through the plugin-facing
+ * `executeJavaScript`, once through the co-browse page-event injection's `putProperty` - and the
+ * user-visible symptom is indistinguishable from a hung machine.
+ *
+ * The fix is the pattern the rest of [BrowserHandleImpl] already uses in three places: make the
+ * blocking call on a dedicated single daemon thread and, where a result is needed, bound the *wait*
+ * from a different one. A wedged renderer then costs one parked thread per tab.
+ *
+ * A source check rather than a behaviour one, for the reason [InjectJsCallbackOwnershipTest] gives:
+ * the failure mode is a *new call site*, and observing it at runtime needs a real Chromium and a
+ * page that genuinely stops answering. Reading the source catches it as it is written.
+ *
+ * PR #268 fixed this same hazard for JxBrowser's RPC thread and left the EDT sites in place, which
+ * is precisely the kind of half-fix a guard exists to stop. If a Main-thread round trip is ever
+ * genuinely wanted, argue with this test - do not route around it.
+ */
+class BrowserMainThreadRoundTripTest {
+    /** Blocking calls into the renderer. Neither can be interrupted once entered. */
+    private val rendererRoundTrips = listOf("executeJavaScript", "putProperty")
+
+    private fun repoRoot(): File? =
+        generateSequence(File("").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile }
+
+    private fun browserSources(root: File): List<File> =
+        File(root, "composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser")
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .toList()
+
+    /**
+     * Comments and string literals removed, whitespace collapsed.
+     *
+     * Comments go for the reason [InjectJsCallbackOwnershipTest] gives - this KDoc names both the
+     * dispatcher and the call, and matching raw text would flag the explanation as the offence.
+     * String literals go because the brace scan below counts braces: an injected script, or a string
+     * template's own braces, are not block structure, and one of those inside a scanned block would
+     * end it early and make this guard quietly stop guarding.
+     */
+    private fun codeOf(file: File): String =
+        stripStrings(
+            file
+                .readText()
+                .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), " ")
+                .lines()
+                // Not substringBefore("//"): that cuts at the "//" inside "https://…" too, which is
+                // a false negative in a guard whose whole value is catching one occurrence.
+                .joinToString(" ") { line -> line.split(Regex("(?<!:)//")).first() },
+        ).replace(Regex("\\s+"), " ")
+
+    /**
+     * Every string literal replaced by an empty one, scanned by hand rather than matched.
+     *
+     * The obvious regex - `"(?:\\.|[^"\\])*"` - is a `(?:A|B)*` loop, which java.util.regex walks
+     * recursively: against the multi-kilobyte injected scripts in this package it overflows the
+     * stack, and a guard that dies is worse than one that is wrong. A single pass costs nothing and
+     * handles the raw `"""…"""` strings those scripts are written as, which the regex did not.
+     */
+    private fun stripStrings(code: String): String {
+        val out = StringBuilder(code.length)
+        var i = 0
+        while (i < code.length) {
+            i =
+                when {
+                    code.startsWith("\"\"\"", i) -> skipRaw(code, i, out)
+                    code[i] == '"' -> skipQuoted(code, i, out)
+                    else -> copyChar(code, i, out)
+                }
+        }
+        return out.toString()
+    }
+
+    /** Past the closing `"""`, or to the end if it is unterminated. */
+    private fun skipRaw(
+        code: String,
+        start: Int,
+        out: StringBuilder,
+    ): Int {
+        out.append("\"\"")
+        val end = code.indexOf("\"\"\"", start + 3)
+        return if (end < 0) code.length else end + 3
+    }
+
+    /** Past the closing `"`, honouring backslash escapes. */
+    private fun skipQuoted(
+        code: String,
+        start: Int,
+        out: StringBuilder,
+    ): Int {
+        out.append("\"\"")
+        var j = start + 1
+        while (j < code.length && code[j] != '"') j += if (code[j] == '\\') 2 else 1
+        return if (j >= code.length) code.length else j + 1
+    }
+
+    private fun copyChar(
+        code: String,
+        at: Int,
+        out: StringBuilder,
+    ): Int {
+        out.append(code[at])
+        return at + 1
+    }
+
+    /** The source of every `withContext(Dispatchers.Main) { … }` block in [code], braces balanced. */
+    private fun mainThreadBlocks(code: String): List<String> {
+        val opener = Regex("""withContext\( ?Dispatchers\.Main ?\) ?\{""")
+        return opener
+            .findAll(code)
+            .map { match ->
+                var depth = 0
+                var end = match.range.last
+                for (i in match.range.last until code.length) {
+                    when (code[i]) {
+                        '{' -> {
+                            depth++
+                        }
+
+                        '}' -> {
+                            depth--
+                            if (depth == 0) {
+                                end = i
+                                break
+                            }
+                        }
+                    }
+                }
+                code.substring(match.range.first, end + 1)
+            }.toList()
+    }
+
+    @Test
+    fun `no renderer round trip runs inside a Main-thread block`() {
+        val root = assertNotNull(repoRoot(), "could not locate the repository root")
+        val scanned = browserSources(root)
+
+        // Deliberately not a skip: a guard that passes when it cannot see the tree is decoration.
+        assertTrue(scanned.size > 5, "only ${scanned.size} files scanned - the walk is not seeing the source")
+
+        val offenders =
+            scanned.flatMap { file ->
+                mainThreadBlocks(codeOf(file))
+                    .filter { block -> rendererRoundTrips.any { block.contains(it) } }
+                    .map { block -> "${file.name}: ${block.take(140)}" }
+            }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "blocking renderer round trip inside withContext(Dispatchers.Main): $offenders. " +
+                "A renderer that does not answer parks the EDT forever, and the AppKit main thread " +
+                "parks behind it - the whole app and the menu bar freeze. Make the call on a " +
+                "dedicated daemon thread (see handleCallDispatcher) and bound the wait from another.",
+        )
+    }
+
+    @Test
+    fun `no handle scope is built on the Main dispatcher`() {
+        val root = assertNotNull(repoRoot(), "could not locate the repository root")
+        val scanned = browserSources(root)
+        assertTrue(scanned.size > 5, "only ${scanned.size} files scanned - the walk is not seeing the source")
+
+        // Every scope declared here drives browser work, so a Main-dispatched one puts the round
+        // trips of whatever launches into it on the EDT - which is how the co-browse and page-event
+        // scopes came to freeze the app without any single call site looking wrong.
+        val mainScopes =
+            scanned
+                // A bounded window, not `[^)]*`: the context is built as
+                // `CoroutineScope(SupervisorJob() + Dispatchers.Main)`, and a negated-paren run
+                // stops dead at SupervisorJob's own `)` - so the first version of this guard matched
+                // nothing at all and passed against the very code it was written to catch.
+                .filter { codeOf(it).contains(Regex("""CoroutineScope\(.{0,120}?Dispatchers\.Main""")) }
+                .map { it.name }
+                .sorted()
+
+        assertTrue(
+            mainScopes.isEmpty(),
+            "browser scope built on Dispatchers.Main: $mainScopes. Anything launched into it makes " +
+                "its blocking JxBrowser calls on the EDT. Dispatch the scope onto a dedicated " +
+                "thread instead, as coBrowseScope and pageEventScope now are.",
+        )
+    }
+}

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -470,6 +470,62 @@ viewModelScope.launch {
 
 JxBrowser uses internal RPC (Remote Procedure Call) requiring careful threading.
 
+### Never make a renderer round trip on the EDT or the RPC thread
+
+`Frame.executeJavaScript` and `JsObject.putProperty` **block until the renderer
+answers**, and a renderer is entitled not to answer: one parked on a modal
+`window.prompt` cannot run script until the dialog is dismissed, and one being
+swapped out mid-navigation never answers at all. Nothing can interrupt the wait -
+the call has no suspension point, so `withTimeoutOrNull` wrapped *around* it is
+not a bound.
+
+Two threads must never make that call:
+
+- **The EDT** (`Dispatchers.Main`). It parks forever, the AppKit main thread parks
+  behind it inside `menuWillOpen:`, and the window *and* the macOS menu bar freeze
+  together. Force quit is the only way out.
+- **JxBrowser's RPC thread**, where `NavigationFinished` / `InjectJsCallback` are
+  delivered. A blocking call there re-enters `RpcThreadCallExecutor` and parks on a
+  queue only the thread it is blocking could drain, so the reply can never arrive.
+
+Route it through `BoundedBrowserCall` instead, which owns both halves of the rule:
+the blocking call goes on a dedicated single daemon thread, and the *wait* is
+bounded from a **different** one. Both on one thread and the timeout cannot fire -
+resuming the awaiting continuation needs a dispatch onto the very thread the call
+is holding.
+
+```kotlin
+// ❌ Freezes the whole app when the page stops answering
+withContext(Dispatchers.Main) {
+    browser.mainFrame().map { it.executeJavaScript<Any?>(script) }.orElse(null)
+}
+
+// ✅ One parked daemon thread per tab, and an answer either way
+private val handleCall = BoundedBrowserCall("boss-browser-call-$id")
+
+suspend fun executeJavaScript(script: String): Any? =
+    handleCall.call { browser.mainFrame().map { it.executeJavaScript<Any?>(script) }.orElse(null) }
+```
+
+Notes:
+
+- **Give each thing that can wedge independently its own instance** - a tab, a
+  peer, an integration. A shared one turns "this tab stopped answering" into
+  "every call in the process costs a full deadline", for as long as a dialog
+  nobody knows about stays open.
+- **Do not `await` a call from a coroutine running on that instance's own
+  dispatcher.** It works until a renderer wedges and then hangs forever, because
+  resuming needs the thread the call is holding. `BoundedBrowserCall` warns at
+  runtime when it sees this.
+- **Fire-and-forget streams must drop, not enqueue.** The queue is unbounded, and
+  nothing cancels work that is never awaited. Check `backlog` first.
+- Browser-*process* calls (`loadUrl`, `browser.url()`, `browser.dispatch`) are not
+  this hazard - they are answered by a process page JS cannot block.
+
+`BrowserMainThreadRoundTripTest` enforces this across the repo, including one hop
+through a local helper. It is a source check, because reproducing the failure
+needs a real page that stops answering.
+
 ### Browser Disposal
 
 ```kotlin

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -517,8 +517,14 @@ Notes:
   dispatcher.** It works until a renderer wedges and then hangs forever, because
   resuming needs the thread the call is holding. `BoundedBrowserCall` warns at
   runtime when it sees this.
+- **A non-suspend caller uses `post`, not an inline call.** A `fun` that returns
+  Unit and blocks on the renderer inline runs on whatever thread its caller is on,
+  and for a plugin-facing API that can be the EDT one module away - which no source
+  guard can see. `post` puts it on the instance's thread and returns immediately.
 - **Fire-and-forget streams must drop, not enqueue.** The queue is unbounded, and
-  nothing cancels work that is never awaited. Check `backlog` first.
+  nothing cancels work that is never awaited. Check `backlog` first - and if the
+  caller holds a queue of its own upstream (ops buffered until a page is ready),
+  cap that too, or the check reads zero in exactly the state it was written for.
 - Browser-*process* calls (`loadUrl`, `browser.url()`, `browser.dispatch`) are not
   this hazard - they are answered by a process page JS cannot block.
 


### PR DESCRIPTION
## The freeze

BOSS 9.5.7 hard-freezes - window **and** the macOS menu bar - and force quit is the only way out. Reproduced twice in one morning and captured with `jstack` both times.

`Frame.executeJavaScript` and `JsObject.putProperty` block until the **renderer** answers. A renderer has every right not to: one parked on a modal `window.prompt` cannot run script until the dialog is answered, and one being swapped out mid-redirect never answers at all. Nothing can interrupt the wait - the call has no suspension point, so a `withTimeoutOrNull` wrapped *around* it is not a bound.

Made from `Dispatchers.Main`, that is not a slow call. It is a dead application: the EDT parks forever, the AppKit main thread parks behind it inside `menuWillOpen:`, and the menu bar goes with the window.

```
"AWT-EventQueue-0" #35  cpu=3075.39ms   WAITING (parking)
  - parking to wait for <0x0000000789237c98> (a CountDownLatch$Sync)
  at ...rpc.transport.CommonThreadResponseConsumer.await(CommonThreadResponseConsumer.java:49)
  at ...frame.internal.FrameImpl.executeJavaScript(FrameImpl.java:359)
  at ...js.internal.JsObjectImpl.putProperty(JsObjectImpl.java:155)
  at ai.rever.boss.plugin.browser.BrowserHandleImpl.injectPageEventScript(BrowserHandleImpl.kt:2005)
```

Two samples 24s apart: identical park address, identical `cpu=`. A deadlock, not a spin.

## The sites

| Where | How it is reached | Found by |
|---|---|---|
| `BrowserHandleImpl.executeJavaScript` | the plugin-facing suspend API | the `jstack` traces |
| `BrowserHandleImpl.injectPageEventScript` | `putProperty` → `newJsProxyObject`, from `pageEventScope` | the `jstack` traces |
| `CoBrowseRtcPeerImpl` | a `Dispatchers.Main` scope whose launches evaluate script | the `jstack` traces |
| `DesktopBrowserAccessor` | a shipped plugin API one directory over | review, once the guard was widened to the whole repo |
| `BrowserHandleImpl.requestPictureInPicture` | a **non-suspend** override on the public `BrowserHandle`, blocking inline | review |

`coBrowseScope` and `pageEventScope` were the load-bearing part: both were built on `Dispatchers.Main`, so every round trip launched into them ran on the EDT without any single call site looking wrong.

`requestPictureInPicture` is the one the guard structurally cannot see: there is no `Dispatchers.Main` marker at the call site, because the EDT-ness comes from a plugin's caller a module away. It is posted onto the tab's thread now via `BoundedBrowserCall.post`, and the blind spot is written into the guard's own known-gaps list.

## Why #268 did not cover it

#268 fixed this same hazard for JxBrowser's **RPC thread** and moved the page helpers and the frame probe onto dedicated daemon threads. Those threads (`boss-page-inject-*`, `boss-frame-probe-*`) are parked in both traces - harmlessly, which is exactly the point. It left the EDT family alone, and that is the one that takes the application down.

`CoBrowseRtcPeerImpl` additionally injected straight from its `LoadFinished` callback, which JxBrowser delivers on the RPC thread - #268's *original* bug at a call site it missed.

## The fix

The pattern already in `BrowserHandleImpl`, applied to the sites it skipped:

- blocking calls go on a dedicated single **daemon** thread (`handleCallExecutor`, `boss-browser-call-$id`; the RTC peer gets its own);
- where a result is needed the **wait** is bounded from a *different* thread - both on one thread and the timeout cannot fire, as `contextMenuScope` already documents;
- the RTC peer's injection is posted off the RPC thread, with `injected` claimed via `compareAndSet` so two `LoadFinished` events cannot queue a second injection.

A wedged renderer now costs **one parked thread per tab**; later calls on that tab answer null on schedule. Per-tab degradation instead of a dead app.

Browser-process calls are deliberately left alone - `loadUrl`, `browser.url()`, `dispatch` are answered by a process page JS cannot block, so `loadUrlAndWait` keeps its Main-thread hop.

## The guard

`BrowserMainThreadRoundTripTest` is a source check, for the reason `InjectJsCallbackOwnershipTest` gives: the failure mode is a *new call site*, and observing it at runtime needs a real Chromium and a page that genuinely stops answering.

**It was verified to fail against all four visible sites as they stood before this commit** - both files reverted to `origin/main`, both tests red, restored, both green. Its first draft used `CoroutineScope\([^)]*Dispatchers\.Main`, which stops dead at `SupervisorJob()`'s own paren and so matched nothing at all; that hole is fixed and called out in the test.

## For plugin authors

`executeJavaScript` used to wait forever; it now answers `null` after 10s. That `null` is indistinguishable from a script that legitimately evaluated to `null`, so a plugin treating `null` as "no such element" will occasionally see it on a page slow enough to miss the deadline. Every timeout is logged with the tab's thread name, which is the only way to tell the two apart from outside.

## Checks

`:composeApp:desktopTest` (3440 tests), `ktlintCheck`, `detekt` - all green.

## Verified live

Dev instance built from this branch, the exact wedging bookmark seeded into Favorites, page loaded twice - **app stayed alive both times**. `AWT-EventQueue-0` on an ordinary `ConditionObject` idle wait, zero threads in `CommonThreadResponseConsumer.await`, UI interactive throughout. Full evidence, including the contrasting pre-fix stack, is in the comment below.

Remaining gap: no thread was observed parked in `boss-browser-call-*`, so the run proved *the EDT is no longer the blocking thread* but did not exercise `JS_CALL_TIMEOUT_MS` firing against a renderer that never answers at all. That path rests on the unit suite and on reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


