### PR TITLE
URL suggestions: ghost-text completion, and address-bar style matching

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -152,9 +152,19 @@ enum class TabType(
  * Internal so the suggestion provider builds its search row with the same encoder the
  * confirm path uses - they produced different URLs for the same text, so clicking the row
  * and pressing Enter searched for different things.
+ *
+ * Order is load-bearing, and both leading replacements are there because of a character
+ * this used to pass through:
+ *  - `%` goes FIRST, or the escapes the later replacements introduce get re-escaped. Left
+ *    out entirely, searching for `100%` sent Google a truncated escape and `a%26b` reached
+ *    it as `a&b` - the user's literal text read back as a separator.
+ *  - `+` goes before the space, or the `+` this line writes for a space is turned back into
+ *    a literal plus. Left out, `a + b` became `a+++b`, which Google reads as `a   b`.
  */
 internal fun encodeUrlParameter(input: String): String =
     input
+        .replace("%", "%25")
+        .replace("+", "%2B")
         .replace(" ", "+")
         .replace("&", "%26")
         .replace("#", "%23")
@@ -343,6 +353,13 @@ fun NewTabDialog(
     // completion after a delete for the same reason. Only an edit that ADDS characters
     // re-arms it.
     var completionAllowed by remember { mutableStateOf(true) }
+    // The text a dismissal applies to, or null. Escape and an accepted completion both put
+    // the list away, but neither of them can do that by writing `showUrlDropdown` alone:
+    // the suggestion lookup is debounced, so a lookup already in flight - or the one an
+    // accept starts by rewriting the field - lands afterwards and re-opens the list from
+    // under them. Held as the TEXT rather than a flag so it expires the moment the user
+    // types something else, which is exactly when the list should come back.
+    var suggestionsDismissedFor by remember { mutableStateOf<String?>(null) }
     // Two suppressions, both DERIVED rather than written into state:
     //  - over a selection the ghost reads as field content that escaped the highlight, and
     //    Enter would commit the very text the user selected in order to replace it.
@@ -395,7 +412,8 @@ fun NewTabDialog(
             // stored entry, which is milliseconds at the 1000-entry cap but is still work
             // that has no business between a keystroke and its frame.
             urlSuggestions = withContext(Dispatchers.Default) { UrlHistoryProvider.getSuggestions(urlText) }
-            showUrlDropdown = urlSuggestions.isNotEmpty()
+            // Read after the delay, so a dismissal made DURING the debounce is honoured.
+            showUrlDropdown = urlSuggestions.isNotEmpty() && urlText != suggestionsDismissedFor
             selectedSuggestionIndex = -1
         } else {
             urlSuggestions = emptyList()
@@ -1217,6 +1235,10 @@ fun NewTabDialog(
                                     }
                                     urlField = newValue
                                     if (!textChanged) return@OutlinedTextField
+                                    // Typing is what un-dismisses the list: a dismissal is
+                                    // about the text it was made against, and this is no
+                                    // longer that text.
+                                    suggestionsDismissedFor = null
                                     inputText = newValue.text
                                     urlText = newValue.text
                                     // Recomputed HERE, against the suggestions already in
@@ -1309,7 +1331,13 @@ fun NewTabDialog(
                                                             // Accepting moves past the list, so it
                                                             // closes with the proposal - the same
                                                             // as the address bar's Right path.
+                                                            // Recorded against the accepted text
+                                                            // too: the write above re-keys the
+                                                            // suggestion effect, which would
+                                                            // otherwise re-open the list one
+                                                            // debounce later.
                                                             showUrlDropdown = false
+                                                            suggestionsDismissedFor = completion.display
                                                             true
                                                         } else {
                                                             // Nothing to accept: Tab has to keep
@@ -1341,6 +1369,10 @@ fun NewTabDialog(
                                                     Key.Escape -> {
                                                         if (showUrlDropdown || urlCompletion != null) {
                                                             showUrlDropdown = false
+                                                            // A lookup still inside the debounce
+                                                            // would otherwise land and re-open
+                                                            // the list Escape just closed.
+                                                            suggestionsDismissedFor = urlField.text
                                                             // The ghost is a proposal, so the key
                                                             // that rejects the list rejects it
                                                             // too. Leaving it behind meant Escape

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -153,24 +153,41 @@ enum class TabType(
  * confirm path uses - they produced different URLs for the same text, so clicking the row
  * and pressing Enter searched for different things.
  *
- * Order is load-bearing, and both leading replacements are there because of a character
- * this used to pass through:
- *  - `%` goes FIRST, or the escapes the later replacements introduce get re-escaped. Left
- *    out entirely, searching for `100%` sent Google a truncated escape and `a%26b` reached
- *    it as `a&b` - the user's literal text read back as a separator.
- *  - `+` goes before the space, or the `+` this line writes for a space is turned back into
- *    a literal plus. Left out, `a + b` became `a+++b`, which Google reads as `a   b`.
+ * An ALLOWLIST, deliberately. This was a chain of `replace` calls, and each review round
+ * found another character missing from it: `&` and `#` in one, then `%` and `+` in the next
+ * (`100%` went out as a truncated escape, `a%26b` reached Google as `a&b`, `a + b` as
+ * `a+++b`), with quotes, angle brackets, braces, backslash and every non-ASCII character
+ * still passing through raw. Naming what is SAFE ends that sequence: RFC 3986 unreserved
+ * characters survive, a space becomes `+` because that is the `?q=` convention, and
+ * everything else goes out as the percent-encoded UTF-8 bytes it is made of - which is also
+ * what makes a CJK or emoji query correct rather than merely tolerated.
  */
 internal fun encodeUrlParameter(input: String): String =
-    input
-        .replace("%", "%25")
-        .replace("+", "%2B")
-        .replace(" ", "+")
-        .replace("&", "%26")
-        .replace("#", "%23")
-        .replace("?", "%3F")
-        .replace("=", "%3D")
-        .replace("/", "%2F")
+    buildString {
+        for (byte in input.encodeToByteArray()) {
+            val char = byte.toInt().toChar()
+            when {
+                char in UNRESERVED -> append(char)
+
+                char == ' ' -> append('+')
+
+                // `and 0xFF` because a Byte is signed and every byte above 0x7F - which is
+                // every byte of a multi-byte UTF-8 sequence - would otherwise format as a
+                // negative number.
+                else -> append('%').append(HEX[(byte.toInt() shr 4) and 0x0F]).append(HEX[byte.toInt() and 0x0F])
+            }
+        }
+    }
+
+/**
+ * RFC 3986's unreserved set: the characters a `?q=` parameter carries verbatim.
+ *
+ * A Set rather than the concatenated ranges it is built from, because `in` on a List is a
+ * linear scan and this is consulted once per byte of the query.
+ */
+private val UNRESERVED = (('a'..'z') + ('A'..'Z') + ('0'..'9') + listOf('-', '.', '_', '~')).toSet()
+
+private const val HEX = "0123456789ABCDEF"
 
 /**
  * A spec that declares no input at all (blank label and placeholder, input
@@ -381,8 +398,8 @@ fun NewTabDialog(
     //  2. the ghost completion, guarded exactly as it is drawn, so the address the field
     //     shows and the address that opens cannot come apart.
     //  3. what they typed.
-    // Written once because it was previously written twice, and only one of the two
-    // honoured the highlighted row - so Enter and the confirm button disagreed.
+    // One value rather than one per commit path, so Enter and the confirm button cannot
+    // disagree about which of the three signals wins.
     val urlToOpen =
         urlSuggestions.getOrNull(selectedSuggestionIndex)?.url
             ?: urlCompletionTarget(ghostCompletion, urlField.text)?.target
@@ -407,13 +424,18 @@ fun NewTabDialog(
     // Update suggestions when URL text changes
     LaunchedEffect(urlText, selectedType) {
         if (selectedType == TabType.URL && urlText.isNotEmpty()) {
+            // Captured before the delay. Read inside `withContext` it would resolve against
+            // the worker thread's snapshot rather than the value that keyed this effect;
+            // cancellation makes that benign today, and capturing makes the dismissal check
+            // below provably about the string the lookup actually ran for.
+            val query = urlText
             delay(URL_SUGGESTION_DEBOUNCE_MS)
             // Off the composition thread: the lookup canonicalises and word-scans every
             // stored entry, which is milliseconds at the 1000-entry cap but is still work
             // that has no business between a keystroke and its frame.
-            urlSuggestions = withContext(Dispatchers.Default) { UrlHistoryProvider.getSuggestions(urlText) }
+            urlSuggestions = withContext(Dispatchers.Default) { UrlHistoryProvider.getSuggestions(query) }
             // Read after the delay, so a dismissal made DURING the debounce is honoured.
-            showUrlDropdown = urlSuggestions.isNotEmpty() && urlText != suggestionsDismissedFor
+            showUrlDropdown = urlSuggestions.isNotEmpty() && query != suggestionsDismissedFor
             selectedSuggestionIndex = -1
         } else {
             urlSuggestions = emptyList()
@@ -528,6 +550,13 @@ fun NewTabDialog(
                                     selectedPluginType = null
                                     selectedType = TabType.URL
                                     inputText = urlText
+                                    // The field itself, not just the two mirrors of it.
+                                    // An accepted completion deliberately splits them -
+                                    // `urlText` holds the display, `inputText` the target -
+                                    // so without this, accepting "git" to "github.com",
+                                    // switching to File and switching back rendered the
+                                    // field's own stale value.
+                                    urlField = TextFieldValue(urlText, TextRange(urlText.length))
                                 },
                                 modifier = Modifier.weight(1f),
                             )
@@ -1373,7 +1402,16 @@ fun NewTabDialog(
                                                     }
 
                                                     Key.Escape -> {
-                                                        if (showUrlDropdown || urlCompletion != null) {
+                                                        // `ghostCompletion`, not `urlCompletion`:
+                                                        // a completion suppressed by a selection
+                                                        // or a highlighted row is not on screen,
+                                                        // and Escape consuming the key with
+                                                        // nothing visibly changing is how a key
+                                                        // that should have closed the dialog did
+                                                        // nothing at all. Every other read of the
+                                                        // completion already goes through this
+                                                        // one; this was the last that did not.
+                                                        if (showUrlDropdown || ghostCompletion != null) {
                                                             showUrlDropdown = false
                                                             // A lookup still inside the debounce
                                                             // would otherwise land and re-open

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -386,8 +386,14 @@ fun NewTabDialog(
     // in `onValueChange`: every keystroke typed with a row highlighted set the completion
     // and an effect immediately cleared it, so the tail flickered off for a whole debounce
     // and the accept keys did nothing in that window.
-    val ghostCompletion =
-        urlCompletion?.takeIf { urlField.selection.collapsed && selectedSuggestionIndex < 0 }
+    // `derivedStateOf`, not a plain `val`: the key handler and the Done action are lambdas
+    // that outlive the composition that built them, and they read `selectedSuggestionIndex`
+    // and `urlSuggestions` LIVE through their delegates. A captured value would disagree
+    // with those live guards inside a single frame - Down then Enter before a recomposition
+    // passed the `index >= 0` guard while committing a target computed before the Down.
+    val ghostCompletion by remember {
+        derivedStateOf { urlCompletion?.takeIf { urlField.selection.collapsed && selectedSuggestionIndex < 0 } }
+    }
     // Read once and passed as a key: `CoreTextField` memoises on the VisualTransformation
     // instance, so a new one per recomposition re-runs the filter and re-lays out the text
     // on every hover and every arrow key.
@@ -400,10 +406,13 @@ fun NewTabDialog(
     //  3. what they typed.
     // One value rather than one per commit path, so Enter and the confirm button cannot
     // disagree about which of the three signals wins.
-    val urlToOpen =
-        urlSuggestions.getOrNull(selectedSuggestionIndex)?.url
-            ?: urlCompletionTarget(ghostCompletion, urlField.text)?.target
-            ?: inputText
+    val urlToOpen by remember {
+        derivedStateOf {
+            urlSuggestions.getOrNull(selectedSuggestionIndex)?.url
+                ?: urlCompletionTarget(ghostCompletion, urlField.text)?.target
+                ?: inputText
+        }
+    }
 
     // File picker for browsing files
     val filePicker =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -165,16 +165,15 @@ enum class TabType(
 internal fun encodeUrlParameter(input: String): String =
     buildString {
         for (byte in input.encodeToByteArray()) {
-            val char = byte.toInt().toChar()
+            // Masked once, up front. A Byte is signed, so every byte of a multi-byte UTF-8
+            // sequence is negative; relying on the sign bit landing outside [UNRESERVED]
+            // happens to work and says nothing about why.
+            val code = byte.toInt() and 0xFF
+            val char = Char(code)
             when {
                 char in UNRESERVED -> append(char)
-
                 char == ' ' -> append('+')
-
-                // `and 0xFF` because a Byte is signed and every byte above 0x7F - which is
-                // every byte of a multi-byte UTF-8 sequence - would otherwise format as a
-                // negative number.
-                else -> append('%').append(HEX[(byte.toInt() shr 4) and 0x0F]).append(HEX[byte.toInt() and 0x0F])
+                else -> append('%').append(HEX[code shr 4]).append(HEX[code and 0x0F])
             }
         }
     }
@@ -392,7 +391,18 @@ fun NewTabDialog(
     // with those live guards inside a single frame - Down then Enter before a recomposition
     // passed the `index >= 0` guard while committing a target computed before the Down.
     val ghostCompletion by remember {
-        derivedStateOf { urlCompletion?.takeIf { urlField.selection.collapsed && selectedSuggestionIndex < 0 } }
+        derivedStateOf {
+            urlCompletion?.takeIf {
+                // At the END of the input, not merely collapsed. The ghost is drawn after
+                // the text, so with the caret anywhere else it describes an insertion point
+                // it does not belong to - and Tab accepted it there while Right, which
+                // computed its own `atEnd`, correctly did not. One rule now, so the two
+                // gestures agree and the ghost goes away on a caret move, as Chrome's does.
+                urlField.selection.collapsed &&
+                    urlField.selection.start == urlField.text.length &&
+                    selectedSuggestionIndex < 0
+            }
+        }
     }
     // Read once and passed as a key: `CoreTextField` memoises on the VisualTransformation
     // instance, so a new one per recomposition re-runs the filter and re-lays out the text
@@ -1346,17 +1356,17 @@ fun NewTabDialog(
                                                                 ghostCompletion,
                                                                 urlField.text,
                                                             )
-                                                        val atEnd =
-                                                            urlField.selection.collapsed &&
-                                                                urlField.selection.start == urlField.text.length
                                                         // A modified key is a different
                                                         // gesture: Shift+Right extends a
                                                         // selection, Shift+Tab moves focus
                                                         // backwards, Cmd/Alt+Right jumps a
                                                         // word. None of them mean "accept".
                                                         val plain = !event.hasModifiers()
-                                                        val acceptGesture = event.key == Key.Tab || atEnd
-                                                        if (plain && completion != null && acceptGesture) {
+                                                        // No separate `atEnd`: `ghostCompletion`
+                                                        // is null unless the caret is at the end,
+                                                        // so a non-null completion already means
+                                                        // Right is where it may accept.
+                                                        if (plain && completion != null) {
                                                             urlField =
                                                                 TextFieldValue(
                                                                     completion.display,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -68,8 +68,10 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -144,8 +146,14 @@ enum class TabType(
     JUPYTER(JupyterTabInfo.TYPE_ID),
 }
 
-// Simple URL parameter encoding
-private fun encodeUrlParameter(input: String): String =
+/**
+ * Encoding for a search query going into a `?q=` parameter.
+ *
+ * Internal so the suggestion provider builds its search row with the same encoder the
+ * confirm path uses - they produced different URLs for the same text, so clicking the row
+ * and pressing Enter searched for different things.
+ */
+internal fun encodeUrlParameter(input: String): String =
     input
         .replace(" ", "+")
         .replace("&", "%26")
@@ -172,6 +180,17 @@ private fun encodeUrlParameter(input: String): String =
  * ships in the external artifact and so needs an api release.
  */
 internal fun NewTabSpec.needsNoInput(): Boolean = inputOptional && inputLabel.isBlank() && inputPlaceholder.isBlank()
+
+/** Whether any modifier is held - a modified key is a different gesture, never an accept. */
+private fun KeyEvent.hasModifiers(): Boolean = isShiftPressed || isMetaPressed || isCtrlPressed || isAltPressed
+
+/**
+ * How long the URL field waits before asking history for suggestions.
+ *
+ * Named so the tests that have to outlast it advance the clock by a multiple of it rather
+ * than by a literal that silently stops being enough.
+ */
+internal const val URL_SUGGESTION_DEBOUNCE_MS = 100L
 
 // Platform-specific URL history provider
 expect object UrlHistoryProvider {
@@ -312,6 +331,46 @@ fun NewTabDialog(
     var selectedSuggestionIndex by remember { mutableStateOf(-1) }
     val listState = rememberLazyListState()
 
+    // The URL field holds a TextFieldValue rather than a plain String for the CURSOR: Right
+    // accepts the completion only at the very end of the input, and anywhere else it has to
+    // stay an ordinary cursor move. The value itself is only ever what the user typed.
+    var urlField by remember { mutableStateOf(TextFieldValue("")) }
+    // The completion the ghost text is offering, or null. Held apart from the field so it
+    // can never feed itself a longer query and walk down the URL one character at a time.
+    var urlCompletion by remember { mutableStateOf<UrlCompletion?>(null) }
+    // A deletion must NOT re-complete: backspacing towards a shorter address should not be
+    // fought by a completion that fills it straight back in. Chrome suppresses inline
+    // completion after a delete for the same reason. Only an edit that ADDS characters
+    // re-arms it.
+    var completionAllowed by remember { mutableStateOf(true) }
+    // Two suppressions, both DERIVED rather than written into state:
+    //  - over a selection the ghost reads as field content that escaped the highlight, and
+    //    Enter would commit the very text the user selected in order to replace it.
+    //  - while a dropdown row is highlighted, that row is the proposal; two on screen at
+    //    once is one too many.
+    // Deriving them is what keeps the ghost steady. As state writes they fought the write
+    // in `onValueChange`: every keystroke typed with a row highlighted set the completion
+    // and an effect immediately cleared it, so the tail flickered off for a whole debounce
+    // and the accept keys did nothing in that window.
+    val ghostCompletion =
+        urlCompletion?.takeIf { urlField.selection.collapsed && selectedSuggestionIndex < 0 }
+    // Read once and passed as a key: `CoreTextField` memoises on the VisualTransformation
+    // instance, so a new one per recomposition re-runs the filter and re-lays out the text
+    // on every hover and every arrow key.
+    val ghostColor = BossTheme.colors.textSecondary
+    // Where a commit goes. ONE derived value read by Enter, by the confirm button and by
+    // the dialog's Done action, in the order the user's own signals rank:
+    //  1. a row they arrowed onto - the most explicit choice on screen.
+    //  2. the ghost completion, guarded exactly as it is drawn, so the address the field
+    //     shows and the address that opens cannot come apart.
+    //  3. what they typed.
+    // Written once because it was previously written twice, and only one of the two
+    // honoured the highlighted row - so Enter and the confirm button disagreed.
+    val urlToOpen =
+        urlSuggestions.getOrNull(selectedSuggestionIndex)?.url
+            ?: urlCompletionTarget(ghostCompletion, urlField.text)?.target
+            ?: inputText
+
     // File picker for browsing files
     val filePicker =
         rememberFilePicker(
@@ -331,14 +390,34 @@ fun NewTabDialog(
     // Update suggestions when URL text changes
     LaunchedEffect(urlText, selectedType) {
         if (selectedType == TabType.URL && urlText.isNotEmpty()) {
-            delay(100) // Small debounce
-            urlSuggestions = UrlHistoryProvider.getSuggestions(urlText)
+            delay(URL_SUGGESTION_DEBOUNCE_MS)
+            // Off the composition thread: the lookup canonicalises and word-scans every
+            // stored entry, which is milliseconds at the 1000-entry cap but is still work
+            // that has no business between a keystroke and its frame.
+            urlSuggestions = withContext(Dispatchers.Default) { UrlHistoryProvider.getSuggestions(urlText) }
             showUrlDropdown = urlSuggestions.isNotEmpty()
             selectedSuggestionIndex = -1
         } else {
             urlSuggestions = emptyList()
             showUrlDropdown = false
+            // Or a stale index keeps gating the completion off after the field is cleared.
+            selectedSuggestionIndex = -1
         }
+    }
+
+    // Re-offer the completion when a NEW suggestion list lands.
+    //
+    // The keystroke path in `onValueChange` is the primary writer - it has to be, or the
+    // ghost trails the debounce - and this only catches up the case where the list arrived
+    // after the character that asked for it. Keyed on the list alone: adding the other
+    // pieces of state made this a second, differently-gated writer racing the first.
+    LaunchedEffect(urlSuggestions, selectedType) {
+        urlCompletion =
+            if (selectedType == TabType.URL && completionAllowed) {
+                inlineUrlCompletion(urlField.text, urlSuggestions)
+            } else {
+                null
+            }
     }
 
     // Auto-scroll to selected suggestion when using arrow keys
@@ -1124,10 +1203,35 @@ fun NewTabDialog(
                         } else {
                             // URL input
                             OutlinedTextField(
-                                value = inputText,
+                                value = urlField,
                                 onValueChange = { newValue ->
-                                    inputText = newValue
-                                    urlText = newValue
+                                    // Compose fires this for SELECTION-only changes too - a
+                                    // click, a drag, an arrow key, even Cmd+C collapsing a
+                                    // selection. Treating those as edits disarmed the
+                                    // completion on a bare cursor move, which killed the
+                                    // accept gesture the ghost had just invited.
+                                    val textChanged = newValue.text != urlField.text
+                                    // Only an edit that ADDS characters may complete.
+                                    if (textChanged) {
+                                        completionAllowed = newValue.text.length > urlField.text.length
+                                    }
+                                    urlField = newValue
+                                    if (!textChanged) return@OutlinedTextField
+                                    inputText = newValue.text
+                                    urlText = newValue.text
+                                    // Recomputed HERE, against the suggestions already in
+                                    // hand, rather than left to the effect below. The
+                                    // lookup is debounced, so waiting for it made the ghost
+                                    // trail the keystroke by 100ms and blink out whenever a
+                                    // character diverged from the candidate - and left a
+                                    // window where a commit took a completion the field was
+                                    // no longer showing.
+                                    urlCompletion =
+                                        if (completionAllowed) {
+                                            inlineUrlCompletion(newValue.text, urlSuggestions)
+                                        } else {
+                                            null
+                                        }
                                 },
                                 label = {
                                     Text(
@@ -1165,15 +1269,69 @@ fun NewTabDialog(
                                                         true
                                                     }
 
+                                                    // Tab, and Right at the very end of the
+                                                    // input, accept the ghost text - the same two
+                                                    // gestures the browser's address bar accepts
+                                                    // it with. Anywhere else Right is an ordinary
+                                                    // cursor move and must stay one.
+                                                    Key.Tab, Key.DirectionRight -> {
+                                                        val completion =
+                                                            urlCompletionTarget(
+                                                                ghostCompletion,
+                                                                urlField.text,
+                                                            )
+                                                        val atEnd =
+                                                            urlField.selection.collapsed &&
+                                                                urlField.selection.start == urlField.text.length
+                                                        // A modified key is a different
+                                                        // gesture: Shift+Right extends a
+                                                        // selection, Shift+Tab moves focus
+                                                        // backwards, Cmd/Alt+Right jumps a
+                                                        // word. None of them mean "accept".
+                                                        val plain = !event.hasModifiers()
+                                                        val acceptGesture = event.key == Key.Tab || atEnd
+                                                        if (plain && completion != null && acceptGesture) {
+                                                            urlField =
+                                                                TextFieldValue(
+                                                                    completion.display,
+                                                                    TextRange(completion.display.length),
+                                                                )
+                                                            inputText = completion.target
+                                                            urlText = completion.display
+                                                            urlCompletion = null
+                                                            // An accepted completion is where the
+                                                            // user stopped, so nothing may extend
+                                                            // it until they type again. Without
+                                                            // this, accepting "github.com" ghosts
+                                                            // the most-visited page under it and
+                                                            // Enter goes somewhere else entirely.
+                                                            completionAllowed = false
+                                                            // Accepting moves past the list, so it
+                                                            // closes with the proposal - the same
+                                                            // as the address bar's Right path.
+                                                            showUrlDropdown = false
+                                                            true
+                                                        } else {
+                                                            // Nothing to accept: Tab has to keep
+                                                            // moving focus, or the dialog's own
+                                                            // buttons become unreachable from the
+                                                            // keyboard. The address bar returns
+                                                            // false here for the same reason.
+                                                            false
+                                                        }
+                                                    }
+
                                                     Key.Enter -> {
                                                         if (selectedSuggestionIndex >= 0 &&
                                                             selectedSuggestionIndex < urlSuggestions.size
                                                         ) {
-                                                            val suggestion = urlSuggestions[selectedSuggestionIndex]
-                                                            inputText = suggestion.url
-                                                            urlText = suggestion.url
                                                             showUrlDropdown = false
-                                                            handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
+                                                            handleCreateTab(
+                                                                selectedType,
+                                                                urlToOpen,
+                                                                onCreateTab,
+                                                                onDismiss,
+                                                            )
                                                             true
                                                         } else {
                                                             false
@@ -1181,8 +1339,15 @@ fun NewTabDialog(
                                                     }
 
                                                     Key.Escape -> {
-                                                        if (showUrlDropdown) {
+                                                        if (showUrlDropdown || urlCompletion != null) {
                                                             showUrlDropdown = false
+                                                            // The ghost is a proposal, so the key
+                                                            // that rejects the list rejects it
+                                                            // too. Leaving it behind meant Escape
+                                                            // then Enter opened the completion the
+                                                            // user had just dismissed.
+                                                            urlCompletion = null
+                                                            completionAllowed = false
                                                             true
                                                         } else {
                                                             false
@@ -1197,6 +1362,10 @@ fun NewTabDialog(
                                                 false
                                             }
                                         },
+                                visualTransformation =
+                                    remember(ghostCompletion, ghostColor) {
+                                        ghostTextTransformation(ghostCompletion, ghostColor)
+                                    },
                                 colors =
                                     TextFieldDefaults.outlinedTextFieldColors(
                                         textColor = BossTheme.colors.textPrimary,
@@ -1209,14 +1378,7 @@ fun NewTabDialog(
                                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                                 keyboardActions =
                                     KeyboardActions(
-                                        onDone = {
-                                            if (selectedSuggestionIndex >= 0 && selectedSuggestionIndex < urlSuggestions.size) {
-                                                val suggestion = urlSuggestions[selectedSuggestionIndex]
-                                                handleCreateTab(selectedType, suggestion.url, onCreateTab, onDismiss)
-                                            } else {
-                                                handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
-                                            }
-                                        },
+                                        onDone = { handleCreateTab(selectedType, urlToOpen, onCreateTab, onDismiss) },
                                     ),
                             )
 
@@ -1249,8 +1411,9 @@ fun NewTabDialog(
                                                                 Color.Transparent
                                                             },
                                                         ).clickable {
-                                                            inputText = suggestion.url
-                                                            urlText = suggestion.url
+                                                            // A click names its own row, so this
+                                                            // is the one commit path that does
+                                                            // not read `urlToOpen`.
                                                             showUrlDropdown = false
                                                             handleCreateTab(TabType.URL, suggestion.url, onCreateTab, onDismiss)
                                                         }.padding(horizontal = 16.dp, vertical = 10.dp),
@@ -1348,7 +1511,14 @@ fun NewTabDialog(
                             if (selectedPluginTypeInfo != null) {
                                 confirmPluginTab()
                             } else {
-                                val input = if (selectedType == TabType.TERMINAL) terminalCommand else inputText
+                                // Same rule as Enter: a ghost completion on screen is what the
+                                // field reads as, so confirming takes it.
+                                val input =
+                                    when (selectedType) {
+                                        TabType.TERMINAL -> terminalCommand
+                                        TabType.URL -> urlToOpen
+                                        else -> inputText
+                                    }
                                 handleCreateTab(selectedType, input, onCreateTab, onDismiss)
                             }
                         },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -1239,6 +1239,12 @@ fun NewTabDialog(
                                     // about the text it was made against, and this is no
                                     // longer that text.
                                     suggestionsDismissedFor = null
+                                    // And it drops the highlighted row, which belongs to a
+                                    // list built for text that no longer exists. The effect
+                                    // below resets this too, but only after the debounce,
+                                    // and `urlToOpen` reads the row FIRST - so Enter inside
+                                    // that window committed a row from the previous list.
+                                    selectedSuggestionIndex = -1
                                     inputText = newValue.text
                                     urlText = newValue.text
                                     // Recomputed HERE, against the suggestions already in
@@ -1373,6 +1379,12 @@ fun NewTabDialog(
                                                             // would otherwise land and re-open
                                                             // the list Escape just closed.
                                                             suggestionsDismissedFor = urlField.text
+                                                            // The highlighted row goes with the
+                                                            // list. It outranks the ghost in
+                                                            // `urlToOpen`, so leaving it behind
+                                                            // meant Escape then Enter opened a
+                                                            // row that was no longer on screen.
+                                                            selectedSuggestionIndex = -1
                                                             // The ghost is a proposal, so the key
                                                             // that rejects the list rejects it
                                                             // too. Leaving it behind meant Escape
@@ -1484,6 +1496,10 @@ fun NewTabDialog(
                                                         UrlHistoryProvider.deleteUrl(suggestion.url)
                                                         // Update suggestions
                                                         urlSuggestions = urlSuggestions.filterNot { it.url == suggestion.url }
+                                                        // The index addressed a row in the OLD
+                                                        // list; every row after the deleted one
+                                                        // has shifted under it.
+                                                        selectedSuggestionIndex = -1
                                                         if (urlSuggestions.isEmpty()) {
                                                             showUrlDropdown = false
                                                         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -80,6 +80,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import kotlin.coroutines.CoroutineContext
 
 private val newTabDialogLogger = BossLogger.forComponent("NewTabDialog")
 
@@ -217,6 +218,20 @@ private fun KeyEvent.hasModifiers(): Boolean = isShiftPressed || isMetaPressed |
  * than by a literal that silently stops being enough.
  */
 internal const val URL_SUGGESTION_DEBOUNCE_MS = 100L
+
+/**
+ * Where the suggestion lookup runs.
+ *
+ * [Dispatchers.Default] in the app, because the lookup canonicalises and word-scans every
+ * stored entry and that has no business between a keystroke and its frame. Overridable
+ * because a real thread pool is not driven by the test clock: `advanceTimeBy` releases the
+ * debounce, but nothing then guarantees the pool has finished and posted its result back
+ * before the assertion runs. The lookup is sub-millisecond so it almost always wins, and
+ * "almost always", across two dozen tests on a contended CI runner, is how a flake is born.
+ * Tests set this to [EmptyCoroutineContext] so `withContext` stays on the composition's own
+ * dispatcher and the whole effect is deterministic under the test clock.
+ */
+internal var urlSuggestionContext: CoroutineContext = Dispatchers.Default
 
 // Platform-specific URL history provider
 expect object UrlHistoryProvider {
@@ -452,7 +467,7 @@ fun NewTabDialog(
             // Off the composition thread: the lookup canonicalises and word-scans every
             // stored entry, which is milliseconds at the 1000-entry cap but is still work
             // that has no business between a keystroke and its frame.
-            urlSuggestions = withContext(Dispatchers.Default) { UrlHistoryProvider.getSuggestions(query) }
+            urlSuggestions = withContext(urlSuggestionContext) { UrlHistoryProvider.getSuggestions(query) }
             // Read after the delay, so a dismissal made DURING the debounce is honoured.
             showUrlDropdown = urlSuggestions.isNotEmpty() && query != suggestionsDismissedFor
             selectedSuggestionIndex = -1
@@ -569,13 +584,21 @@ fun NewTabDialog(
                                     selectedPluginType = null
                                     selectedType = TabType.URL
                                     inputText = urlText
-                                    // The field itself, not just the two mirrors of it.
-                                    // An accepted completion deliberately splits them -
-                                    // `urlText` holds the display, `inputText` the target -
-                                    // so without this, accepting "git" to "github.com",
-                                    // switching to File and switching back rendered the
-                                    // field's own stale value.
-                                    urlField = TextFieldValue(urlText, TextRange(urlText.length))
+                                    // `urlField` is deliberately NOT rewritten from `urlText`
+                                    // here, and the reason is the display/target split rather
+                                    // than an oversight.
+                                    //
+                                    // After an accepted completion the field holds the DISPLAY
+                                    // (`192.168.4.20:8123`) while `urlText`/`inputText` hold
+                                    // the TARGET (`http://192.168.4.20:8123`) - two strings on
+                                    // purpose, because re-deriving the target from the display
+                                    // sends it through `processUrlInput` as `https://`. The
+                                    // field is remembered across a type switch, so leaving it
+                                    // alone is what keeps BOTH: the user sees what they
+                                    // accepted, and the commit still opens what history stored.
+                                    // Syncing it here rendered the target in the field, and
+                                    // syncing `urlText` from the field instead would lose the
+                                    // target on the way back.
                                 },
                                 modifier = Modifier.weight(1f),
                             )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
@@ -1,0 +1,215 @@
+package ai.rever.boss.components.dialogs
+
+import ai.rever.boss.plugin.browser.canonicalUrlKey
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.withStyle
+
+/**
+ * An inline completion: what the field SHOWS, and where accepting it actually goes.
+ *
+ * The two are not the same string and that is the point. [display] is canonical - no scheme,
+ * no `www.`, no trailing slash - because that is the spelling the user is typing towards.
+ * [target] is the address as history recorded it. Collapsing them into one string meant a
+ * stored `http://192.168.4.20:8123/lovelace` was completed to `192.168.4.20:8123` and then
+ * re-derived as `https://…` by `processUrlInput`, which fails the handshake; a stored
+ * `https://www.example.com/x` became `example.com/x` and opened a host the certificate does
+ * not cover.
+ */
+internal data class UrlCompletion(
+    val display: String,
+    val target: String,
+)
+
+/** The scheme of a stored URL, or null when it has no `scheme://` prefix. */
+private fun schemeOf(url: String): String? = url.substringBefore("://", "").takeIf { it.isNotEmpty() }
+
+/** The authority of a stored URL exactly as recorded, `www.` and port included. */
+private fun storedAuthority(url: String): String = url.substringAfter("://").substringBefore('/').substringBefore('?')
+
+/** The authority of a [canonicalUrlKey]-shaped address: everything before the path or query. */
+private fun hostOf(canonical: String): String = canonical.substringBefore('/').substringBefore('?')
+
+/**
+ * Text that must never reach the field through a completion.
+ *
+ * A visited page controls its own URL, so a stored path or query can carry a bidirectional
+ * override or a zero-width character. Splicing one into the field would let the address the
+ * user READS differ from the address Enter opens, which is the one thing inline completion
+ * has to be trusted not to do. This does NOT cover script homoglyphs (a Cyrillic `а` in a
+ * lookalike domain); that needs a punycode/confusables policy, not a character class.
+ */
+private fun String.hasInvisibleCharacters(): Boolean = any { it.isISOControl() || it.category == CharCategory.FORMAT }
+
+/**
+ * Whether this stored address is unfit to be offered as a completion at all.
+ *
+ * Empty: nothing to key on. Invisible characters: see [hasInvisibleCharacters]. A query
+ * string: a stored OAuth URL is hundreds of characters of dead `state=` parameters, so its
+ * tail would be longer than the field it is drawn in - and opening it replays an expired
+ * request.
+ */
+private fun String.isUnofferable(): Boolean = isEmpty() || hasInvisibleCharacters() || contains('?')
+
+/**
+ * Whether [candidate] is a completion of [typed] - a strict extension of it, with the host
+ * matched case-insensitively and the path matched case-SENSITIVELY.
+ *
+ * The split casing is not fussiness. [canonicalUrlKey] lowercases the authority and leaves
+ * the path alone, so matching a path case-insensitively and then splicing the user's own
+ * casing onto the stored tail produced an address that existed in neither place: typing
+ * `github.com/risa-labs-inc/boss` against a stored `…/BossConsole/pulls` offered
+ * `…/bossConsole/pulls`, a 404 on any case-sensitive server.
+ */
+private fun extendsTyped(
+    candidate: String,
+    typed: String,
+): Boolean {
+    if (candidate.length <= typed.length) return false
+    val pathStart = typed.indexOf('/')
+    return if (pathStart < 0) {
+        candidate.startsWith(typed, ignoreCase = true)
+    } else {
+        candidate.regionMatches(0, typed, 0, pathStart, ignoreCase = true) &&
+            candidate.startsWith(typed.substring(pathStart), pathStart)
+    }
+}
+
+/**
+ * The completion the URL field should offer for [typed], or null.
+ *
+ * This is Chrome's inline completion, and the rules below are what make it usable rather
+ * than infuriating - or dangerous:
+ *  - the typed text must be a PREFIX of the candidate, matched against the canonical
+ *    spelling so typing "git" reaches an entry stored as `https://github.com/`.
+ *  - a HOST completes before a path does. The best-ranked entry for "git" is whichever
+ *    github page was visited most, so completing to the full URL would fill in
+ *    "github.com/risa-labs-inc/BossConsole/pulls" in exchange for three characters. Chrome
+ *    offers the host and leaves the deep pages to the list underneath.
+ *  - **the host is only ever completed while the typed text names no host at all - no `.`
+ *    and no `:` in it. After that, a completion may only add a PATH under the host that was
+ *    typed.** This is a security rule, not a taste one. History is attacker-influenceable:
+ *    one drive-by visit to `paypal.com-login.evil.example` puts it in the suggestion list,
+ *    and a bare prefix extension would then turn a typed `paypal.com` - or `paypal.c`, or
+ *    `paypal.` - into somebody else's domain, which Enter would take. Guarding only a host
+ *    that "looks finished" left every prefix on the way to it open, and left `192.168.4`
+ *    free to complete to `192.168.4.20:8123`, a different machine. The cost is no ghost
+ *    while a dotted host is half-typed; the dropdown still lists the match.
+ *  - a candidate carrying a query string is not offered: a stored OAuth URL is 500-2000
+ *    characters of dead `state=` parameters, and it makes the ghost longer than the field.
+ *  - text with whitespace in it is a search, never an address, and the "Search Google for
+ *    …" row is never a completion candidate.
+ *
+ * Candidate order follows the suggestion list, which is already ranked.
+ *
+ * Pure, and separate from the composable, so these rules are pinned by tests rather than by
+ * typing into the dialog.
+ */
+internal fun inlineUrlCompletion(
+    typed: String,
+    suggestions: List<UrlSuggestion>,
+): UrlCompletion? {
+    if (typed.isBlank() || typed.any { it.isWhitespace() } || typed.hasInvisibleCharacters()) return null
+
+    val entries =
+        suggestions
+            .filterNot { it.isSearchSuggestion }
+            .mapNotNull { suggestion ->
+                val canonical = canonicalUrlKey(suggestion.url)
+                val scheme = schemeOf(suggestion.url)
+                if (scheme == null || canonical.isUnofferable()) {
+                    null
+                } else {
+                    Triple(canonical, suggestion.url, scheme)
+                }
+            }
+
+    val typedHost = hostOf(typed)
+    // No dot and no colon means no host has been named yet, so the host is still the thing
+    // being completed. Anything else and the user has committed to a host.
+    val hostStillOpen = typed.none { it == '.' || it == ':' }
+
+    val candidates =
+        if (hostStillOpen) {
+            // Hosts first, then the full addresses, as a Sequence so a hit on the first host
+            // does not pay for the rest.
+            entries.asSequence().map { (canonical, url, scheme) ->
+                UrlCompletion(display = hostOf(canonical), target = "$scheme://${storedAuthority(url)}")
+            } + entries.asSequence().map { (canonical, url, _) -> UrlCompletion(canonical, url) }
+        } else {
+            entries
+                .asSequence()
+                .filter { (canonical, _, _) -> hostOf(canonical).equals(typedHost, ignoreCase = true) }
+                .map { (canonical, url, _) -> UrlCompletion(canonical, url) }
+        }
+
+    return candidates
+        .firstOrNull { extendsTyped(it.display, typed) }
+        // The user's own casing survives in the host, which is case-insensitive anyway; the
+        // path comes through verbatim because `extendsTyped` matched it exactly.
+        ?.let { it.copy(display = typed + it.display.substring(typed.length)) }
+}
+
+/**
+ * Draws [completion]'s tail after the typed text in [color], without putting it in the
+ * field's value.
+ *
+ * Gray ghost text rather than a highlighted selection, because that is what the browser's
+ * own address bar shows for the same gesture (the `autocompleteSuggestion` path in the
+ * fluck-browser plugin's `FluckBrowserTabComponent`) and the two URL inputs in the app
+ * should not disagree about what a completion looks like.
+ *
+ * Being a VISUAL transformation is the load-bearing part: the completion is never part of
+ * the value, so Backspace deletes a character the user typed instead of first having to
+ * clear a completion they never asked to be there, and every existing reader of the field's
+ * text still sees exactly what was typed.
+ *
+ * The prefix guard here is the same one [urlCompletionTarget] applies before navigating, so
+ * what is drawn and where Enter goes cannot come apart.
+ */
+internal fun ghostTextTransformation(
+    completion: UrlCompletion?,
+    color: Color,
+): VisualTransformation =
+    VisualTransformation { text ->
+        val tail = completion?.display?.takeIf { it.extends(text.text) }?.substring(text.length)
+        if (tail == null) {
+            TransformedText(text, OffsetMapping.Identity)
+        } else {
+            TransformedText(
+                buildAnnotatedString {
+                    append(text)
+                    withStyle(SpanStyle(color = color)) { append(tail) }
+                },
+                // The ghost sits entirely past the end of the value, so an offset in the
+                // value maps to itself, and an offset inside the ghost belongs to the end
+                // of the value - which is where the cursor has to stay.
+                object : OffsetMapping {
+                    override fun originalToTransformed(offset: Int) = offset
+
+                    override fun transformedToOriginal(offset: Int) = offset.coerceAtMost(text.length)
+                },
+            )
+        }
+    }
+
+/**
+ * The address a completion is still offering for [typed], or null.
+ *
+ * Shared by the renderer and by every path that navigates, so a completion left over from
+ * the previous keystroke can neither be drawn nor opened: the suggestion lookup is
+ * debounced, so there is a window where [typed] has already moved on from the completion it
+ * produced, and in that window the field correctly shows no ghost while a commit would have
+ * taken the stale address.
+ */
+internal fun urlCompletionTarget(
+    completion: UrlCompletion?,
+    typed: String,
+): UrlCompletion? = completion?.takeIf { it.display.extends(typed) }
+
+/** A strict, case-insensitive extension of [typed] - the one rule both of the above share. */
+private fun String.extends(typed: String): Boolean = length > typed.length && startsWith(typed, true)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
@@ -39,8 +39,20 @@ internal data class UrlCompletion(
 /** The scheme of a stored URL, or null when it has no `scheme://` prefix. */
 private fun schemeOf(url: String): String? = url.substringBefore("://", "").takeIf { it.isNotEmpty() }
 
-/** The authority of a stored URL exactly as recorded, `www.` and port included. */
-private fun storedAuthority(url: String): String = url.substringAfter("://").substringBefore('/').substringBefore('?')
+/**
+ * The authority of a stored URL exactly as recorded, `www.` and port included.
+ *
+ * Cut at the fragment as well as the path and the query. A stored `https://example.com#x`
+ * has no path to cut at, so a HOST completion displaying `example.com` would have targeted
+ * `https://example.com#x` - a fourth way for display and target to differ, and the one the
+ * [UrlCompletion] KDoc does not account for.
+ */
+private fun storedAuthority(url: String): String =
+    url
+        .substringAfter("://")
+        .substringBefore('/')
+        .substringBefore('?')
+        .substringBefore('#')
 
 /**
  * Text that must never reach the field through a completion, and that suppresses one when
@@ -146,6 +158,12 @@ internal fun extendsTyped(
  *    canonical spelling. Without it a typed `https://git` carried a `:`, which read as a
  *    host already named and left the ghost blank on the one input where the dropdown and
  *    the field are easiest to compare side by side.
+ *  - what the ghost DRAWS is always the typed text plus a tail, and the tail is found by
+ *    locating the canonical part inside the typed text rather than by assuming the
+ *    normalization only stripped a prefix. It does not: [canonicalUrlKey] also trims a
+ *    trailing slash and strips a fragment, so subtracting the canonical LENGTH put a second
+ *    slash into a pasted `https://github.com/` - and Tab then wrote that address into the
+ *    field.
  *
  * Candidate order follows the suggestion list, which is already ranked.
  *
@@ -160,11 +178,17 @@ internal fun inlineUrlCompletion(
     // does not have to appear in every stored address for the ghost to appear. The typed
     // text itself is still what the ghost is drawn after, so the scheme stays on screen.
     val matchable = if (typed.contains("://")) canonicalUrlKey(typed) else typed
+    // Where the canonical part begins in the typed text, so a scheme and any `www.` in front
+    // of it survive into the ghost verbatim. LOCATED, not assumed: `matchable` is `typed`
+    // with a prefix removed only when normalization trimmed nothing off the end of it. It
+    // can also be absent entirely - `file://www.a/b` normalizes to `file://a/b`, which is
+    // nowhere in the typed text - and then there is nothing to draw a ghost after.
+    val canonicalAt = typed.indexOf(matchable, ignoreCase = true)
     // Whitespace is part of `hasInvisibleCharacters`, so text with a space in it is a search
     // and completing it would eat what is still being typed. A blank field needs no clause of
     // its own either: an empty one carries no `://`, so it arrives here as an empty
     // `matchable`, and an all-whitespace one is caught by the first clause.
-    if (typed.hasInvisibleCharacters() || matchable.isEmpty()) return null
+    if (typed.hasInvisibleCharacters() || matchable.isEmpty() || canonicalAt < 0) return null
 
     val entries =
         suggestions
@@ -178,6 +202,12 @@ internal fun inlineUrlCompletion(
                     Triple(canonical, suggestion.url, scheme)
                 }
             }
+
+    // The part of the typed text a candidate has to extend. This is `matchable` plus
+    // whatever normalization dropped from the END: the trailing slash of a pasted
+    // `https://github.com/`, which a candidate genuinely has, or a `#fragment`, which no
+    // canonical address has and which therefore correctly matches nothing.
+    val typedTail = typed.substring(canonicalAt)
 
     val typedHost = canonicalAuthority(matchable)
     // No dot and no colon means no host has been named yet, so the host is still the thing
@@ -202,10 +232,10 @@ internal fun inlineUrlCompletion(
         }
 
     return candidates
-        .firstOrNull { extendsTyped(it.display, matchable) }
+        .firstOrNull { extendsTyped(it.display, typedTail) }
         // The user's own casing survives in the host, which is case-insensitive anyway; the
         // path comes through verbatim because `extendsTyped` matched it exactly.
-        ?.let { it.copy(display = typed + it.display.substring(matchable.length)) }
+        ?.let { it.copy(display = typed + it.display.substring(typedTail.length)) }
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.dialogs
 import ai.rever.boss.plugin.browser.canonicalAuthority
 import ai.rever.boss.plugin.browser.canonicalUrlKey
 import ai.rever.boss.plugin.browser.hasUserinfo
+import ai.rever.boss.plugin.browser.suggestableHost
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -148,6 +149,19 @@ internal fun extendsTyped(
  *    that "looks finished" left every prefix on the way to it open, and left `192.168.4`
  *    free to complete to `192.168.4.20:8123`, a different machine. The cost is no ghost
  *    while a dotted host is half-typed; the dropdown still lists the match.
+ *
+ *    **What this does NOT do**, and the KDoc used to imply it did: it does not stop a
+ *    typed prefix with no dot in it from reaching an unfamiliar host. Typing `paypal`
+ *    against that same stored lookalike completes to `paypal.com-login.evil.example`,
+ *    because at that point the user has named no host for the rule to protect. The guard
+ *    protects a host the user has COMMITTED to from being swapped; it does not vouch for a
+ *    host they have not begun to spell. Chrome has the same exposure and gates it on
+ *    `typed_count` - whether the user has ever typed that URL themselves. There is no
+ *    equivalent here to gate on: `visitCount` counts calls to `UrlHistoryManager.addUrl`,
+ *    whose only caller is the browser plugin's TITLE listener, so a page that assigns
+ *    `document.title` twice raises its own count. Closing this properly needs a typed-count
+ *    recorded at the commit sites, which is a schema change and its own piece of work.
+ *    `a bare prefix can still reach an unfamiliar host` pins the boundary meanwhile.
  *  - a candidate ADDRESS carrying a query string is not offered: a stored OAuth URL is
  *    500-2000 characters of dead `state=` parameters, and it makes the ghost longer than
  *    the field. Its host is still offered - see [isUnofferableAddress].
@@ -196,7 +210,13 @@ internal fun inlineUrlCompletion(
             .mapNotNull { suggestion ->
                 val canonical = canonicalUrlKey(suggestion.url)
                 val scheme = schemeOf(suggestion.url)
-                if (scheme == null || canonical.isUnofferable()) {
+                // The same gate `rankMatches` applies, pointing the same way. It gated on a
+                // scheme being PRESENT rather than on it being one we navigate to, so a
+                // `file:///Users/me/notes.html` row - which the list already refuses - had
+                // `canonicalAuthority` read `file:` off it, and typing "fil" ghosted `file:`
+                // targeting `file://`. Unreachable while `UrlHistoryProvider` is the only
+                // producer; not graceful if that stops being true.
+                if (scheme == null || suggestableHost(suggestion.url) == null || canonical.isUnofferable()) {
                     null
                 } else {
                     Triple(canonical, suggestion.url, scheme)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
@@ -35,15 +35,33 @@ private fun storedAuthority(url: String): String = url.substringAfter("://").sub
 private fun hostOf(canonical: String): String = canonical.substringBefore('/').substringBefore('?')
 
 /**
- * Text that must never reach the field through a completion.
+ * Text that must never reach the field through a completion, and that suppresses one when
+ * the user types it.
  *
  * A visited page controls its own URL, so a stored path or query can carry a bidirectional
- * override or a zero-width character. Splicing one into the field would let the address the
- * user READS differ from the address Enter opens, which is the one thing inline completion
- * has to be trusted not to do. This does NOT cover script homoglyphs (a Cyrillic `а` in a
- * lookalike domain); that needs a punycode/confusables policy, not a character class.
+ * override, a zero-width joiner, or a non-breaking space. Splicing one into the field would
+ * let the address the user READS differ from the address Enter opens, which is the one thing
+ * inline completion has to be trusted not to do.
+ *
+ * Whitespace is in here rather than in a clause of its own, and it earns both roles: typed,
+ * it means the field holds a search rather than an address; stored, a U+00A0 in a path is as
+ * invisible as a zero-width joiner. Splitting the two apart is what let them disagree - the
+ * typed side used `Char.isWhitespace`, which counts U+00A0, while the candidate side checked
+ * only controls and `FORMAT`, so the very character that suppressed a completion when typed
+ * could be spliced in from a stored path.
+ *
+ * This does NOT cover script homoglyphs (a Cyrillic `а` in a lookalike domain); that needs a
+ * punycode/confusables policy, not a character class.
  */
-private fun String.hasInvisibleCharacters(): Boolean = any { it.isISOControl() || it.category == CharCategory.FORMAT }
+private fun String.hasInvisibleCharacters(): Boolean = any { it.isWhitespace() || it.category in HIDDEN }
+
+/**
+ * The Unicode categories a completion must never splice, as categories rather than as
+ * `isISOControl()` so the whole test fits one readable line: `CONTROL` is exactly the C0 and
+ * C1 range that call covered, and `FORMAT` is where the bidi overrides and zero-width joiners
+ * live.
+ */
+private val HIDDEN = setOf(CharCategory.CONTROL, CharCategory.FORMAT)
 
 /**
  * Whether this stored address is unfit to be offered as a completion at all, host included.
@@ -138,11 +156,11 @@ internal fun inlineUrlCompletion(
     // does not have to appear in every stored address for the ghost to appear. The typed
     // text itself is still what the ghost is drawn after, so the scheme stays on screen.
     val matchable = if (typed.contains("://")) canonicalUrlKey(typed) else typed
-    // Whitespace means this is a search, not an address, and completing it would eat what is
-    // still being typed. A blank field needs no clause of its own: an empty one carries no
-    // `://`, so it reaches here as an empty [matchable], and an all-whitespace one is caught
-    // by the first clause.
-    if (typed.any { it.isWhitespace() } || typed.hasInvisibleCharacters() || matchable.isEmpty()) return null
+    // Whitespace is part of `hasInvisibleCharacters`, so text with a space in it is a search
+    // and completing it would eat what is still being typed. A blank field needs no clause of
+    // its own either: an empty one carries no `://`, so it arrives here as an empty
+    // `matchable`, and an all-whitespace one is caught by the first clause.
+    if (typed.hasInvisibleCharacters() || matchable.isEmpty()) return null
 
     val entries =
         suggestions
@@ -199,6 +217,12 @@ internal fun inlineUrlCompletion(
  * the value, so Backspace deletes a character the user typed instead of first having to
  * clear a completion they never asked to be there, and every existing reader of the field's
  * text still sees exactly what was typed.
+ *
+ * Its cost, and the address bar pays the same one: Compose reports the TRANSFORMED text as
+ * the node's editable text, so a screen reader announces the ghost as though the field
+ * contained it. That is also why the tests assert on the URL that OPENS rather than on the
+ * field's rendered text - the semantics value cannot tell a ghost apart from an accepted
+ * completion.
  *
  * The prefix guard here is the same one [urlCompletionTarget] applies before navigating, so
  * what is drawn and where Enter goes cannot come apart.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
@@ -46,14 +46,29 @@ private fun hostOf(canonical: String): String = canonical.substringBefore('/').s
 private fun String.hasInvisibleCharacters(): Boolean = any { it.isISOControl() || it.category == CharCategory.FORMAT }
 
 /**
- * Whether this stored address is unfit to be offered as a completion at all.
+ * Whether this stored address is unfit to be offered as a completion at all, host included.
  *
- * Empty: nothing to key on. Invisible characters: see [hasInvisibleCharacters]. A query
- * string: a stored OAuth URL is hundreds of characters of dead `state=` parameters, so its
- * tail would be longer than the field it is drawn in - and opening it replays an expired
- * request.
+ * Empty: nothing to key on. Invisible characters: see [hasInvisibleCharacters]. Userinfo -
+ * a `user@` before the authority ends - because [canonicalUrlKey] keeps it while
+ * `java.net.URL` reads the host as whatever follows the `@`. A stored
+ * `https://github.com@evil.example/` canonicalises to `github.com@evil.example`, which
+ * extends a typed `git` while the host is still open, so one Tab would hand the field a
+ * host the user never named and Enter would open `evil.example`. Chrome strips userinfo
+ * out of the omnibox for the same reason.
  */
-private fun String.isUnofferable(): Boolean = isEmpty() || hasInvisibleCharacters() || contains('?')
+private fun String.isUnofferable(): Boolean = isEmpty() || hasInvisibleCharacters() || hostOf(this).contains('@')
+
+/**
+ * Whether the full stored ADDRESS is unfit to be offered even though its host is fine.
+ *
+ * A stored OAuth URL is hundreds of characters of dead `state=` parameters, so its tail
+ * would be longer than the field it is drawn in - and opening it replays an expired
+ * request. Both reasons are about the address, which is why this is not folded into
+ * [isUnofferable]: an entry whose only visit carries a query still knows what host it is
+ * on, and if the one `accounts.google.com` visit is an OAuth URL then typing "acc" should
+ * still complete to the host.
+ */
+private fun String.isUnofferableAddress(): Boolean = contains('?')
 
 /**
  * Whether [candidate] is a completion of [typed] - a strict extension of it, with the host
@@ -65,7 +80,7 @@ private fun String.isUnofferable(): Boolean = isEmpty() || hasInvisibleCharacter
  * `github.com/risa-labs-inc/boss` against a stored `…/BossConsole/pulls` offered
  * `…/bossConsole/pulls`, a 404 on any case-sensitive server.
  */
-private fun extendsTyped(
+internal fun extendsTyped(
     candidate: String,
     typed: String,
 ): Boolean {
@@ -99,10 +114,16 @@ private fun extendsTyped(
  *    that "looks finished" left every prefix on the way to it open, and left `192.168.4`
  *    free to complete to `192.168.4.20:8123`, a different machine. The cost is no ghost
  *    while a dotted host is half-typed; the dropdown still lists the match.
- *  - a candidate carrying a query string is not offered: a stored OAuth URL is 500-2000
- *    characters of dead `state=` parameters, and it makes the ghost longer than the field.
+ *  - a candidate ADDRESS carrying a query string is not offered: a stored OAuth URL is
+ *    500-2000 characters of dead `state=` parameters, and it makes the ghost longer than
+ *    the field. Its host is still offered - see [isUnofferableAddress].
  *  - text with whitespace in it is a search, never an address, and the "Search Google for
  *    …" row is never a completion candidate.
+ *  - a typed `scheme://` is normalized away before any of the above, the same way
+ *    `rankMatches` normalizes a pasted query, because the entries are matched in their
+ *    canonical spelling. Without it a typed `https://git` carried a `:`, which read as a
+ *    host already named and left the ghost blank on the one input where the dropdown and
+ *    the field are easiest to compare side by side.
  *
  * Candidate order follows the suggestion list, which is already ranked.
  *
@@ -113,7 +134,15 @@ internal fun inlineUrlCompletion(
     typed: String,
     suggestions: List<UrlSuggestion>,
 ): UrlCompletion? {
-    if (typed.isBlank() || typed.any { it.isWhitespace() } || typed.hasInvisibleCharacters()) return null
+    // Matched in the entries' own spelling, so a typed scheme (and the `www.` behind it)
+    // does not have to appear in every stored address for the ghost to appear. The typed
+    // text itself is still what the ghost is drawn after, so the scheme stays on screen.
+    val matchable = if (typed.contains("://")) canonicalUrlKey(typed) else typed
+    // Whitespace means this is a search, not an address, and completing it would eat what is
+    // still being typed. A blank field needs no clause of its own: an empty one carries no
+    // `://`, so it reaches here as an empty [matchable], and an all-whitespace one is caught
+    // by the first clause.
+    if (typed.any { it.isWhitespace() } || typed.hasInvisibleCharacters() || matchable.isEmpty()) return null
 
     val entries =
         suggestions
@@ -128,10 +157,16 @@ internal fun inlineUrlCompletion(
                 }
             }
 
-    val typedHost = hostOf(typed)
+    val typedHost = hostOf(matchable)
     // No dot and no colon means no host has been named yet, so the host is still the thing
     // being completed. Anything else and the user has committed to a host.
-    val hostStillOpen = typed.none { it == '.' || it == ':' }
+    val hostStillOpen = matchable.none { it == '.' || it == ':' }
+
+    val addresses =
+        entries
+            .asSequence()
+            .filterNot { (canonical, _, _) -> canonical.isUnofferableAddress() }
+            .map { (canonical, url, _) -> UrlCompletion(canonical, url) }
 
     val candidates =
         if (hostStillOpen) {
@@ -139,19 +174,16 @@ internal fun inlineUrlCompletion(
             // does not pay for the rest.
             entries.asSequence().map { (canonical, url, scheme) ->
                 UrlCompletion(display = hostOf(canonical), target = "$scheme://${storedAuthority(url)}")
-            } + entries.asSequence().map { (canonical, url, _) -> UrlCompletion(canonical, url) }
+            } + addresses
         } else {
-            entries
-                .asSequence()
-                .filter { (canonical, _, _) -> hostOf(canonical).equals(typedHost, ignoreCase = true) }
-                .map { (canonical, url, _) -> UrlCompletion(canonical, url) }
+            addresses.filter { hostOf(it.display).equals(typedHost, ignoreCase = true) }
         }
 
     return candidates
-        .firstOrNull { extendsTyped(it.display, typed) }
+        .firstOrNull { extendsTyped(it.display, matchable) }
         // The user's own casing survives in the host, which is case-insensitive anyway; the
         // path comes through verbatim because `extendsTyped` matched it exactly.
-        ?.let { it.copy(display = typed + it.display.substring(typed.length)) }
+        ?.let { it.copy(display = typed + it.display.substring(matchable.length)) }
 }
 
 /**
@@ -176,7 +208,7 @@ internal fun ghostTextTransformation(
     color: Color,
 ): VisualTransformation =
     VisualTransformation { text ->
-        val tail = completion?.display?.takeIf { it.extends(text.text) }?.substring(text.length)
+        val tail = completion?.display?.takeIf { extendsTyped(it, text.text) }?.substring(text.length)
         if (tail == null) {
             TransformedText(text, OffsetMapping.Identity)
         } else {
@@ -205,11 +237,13 @@ internal fun ghostTextTransformation(
  * debounced, so there is a window where [typed] has already moved on from the completion it
  * produced, and in that window the field correctly shows no ghost while a commit would have
  * taken the stale address.
+ *
+ * The guard is [extendsTyped] - the same rule that BUILT the display, case-sensitive in the
+ * path and not just in the host. A looser test here would have let this function certify a
+ * string the completion rules would not have produced, which is the one thing it exists to
+ * prevent.
  */
 internal fun urlCompletionTarget(
     completion: UrlCompletion?,
     typed: String,
-): UrlCompletion? = completion?.takeIf { it.display.extends(typed) }
-
-/** A strict, case-insensitive extension of [typed] - the one rule both of the above share. */
-private fun String.extends(typed: String): Boolean = length > typed.length && startsWith(typed, true)
+): UrlCompletion? = completion?.takeIf { extendsTyped(it.display, typed) }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
@@ -37,6 +37,9 @@ internal data class UrlCompletion(
     val target: String,
 )
 
+/** The subdomain canonicalisation drops, so the ghost can put it back in front of a match. */
+private const val WWW = "www."
+
 /** The scheme of a stored URL, or null when it has no `scheme://` prefix. */
 private fun schemeOf(url: String): String? = url.substringBefore("://", "").takeIf { it.isNotEmpty() }
 
@@ -103,7 +106,17 @@ private fun String.isUnofferable(): Boolean = isEmpty() || hasInvisibleCharacter
  * on, and if the one `accounts.google.com` visit is an OAuth URL then typing "acc" should
  * still complete to the host.
  */
-private fun String.isUnofferableAddress(): Boolean = contains('?')
+private fun String.isUnofferableAddress(): Boolean = contains('?') || length > MAX_OFFERABLE_ADDRESS
+
+/**
+ * Longest stored address that may be offered whole.
+ *
+ * The query-string rule above argues from length as much as from replaying a request, and a
+ * path-only URL reaches the same lengths without a `?` in it - a signed asset link or a deep
+ * document path runs for hundreds of characters. The ghost is drawn inside a single-line
+ * field, so past this it is not a proposal the user can read before pressing Tab.
+ */
+private const val MAX_OFFERABLE_ADDRESS = 160
 
 /**
  * Whether [candidate] is a completion of [typed] - a strict extension of it, with the host
@@ -193,16 +206,34 @@ internal fun inlineUrlCompletion(
     // text itself is still what the ghost is drawn after, so the scheme stays on screen.
     val matchable = if (typed.contains("://")) canonicalUrlKey(typed) else typed
     // Where the canonical part begins in the typed text, so a scheme and any `www.` in front
-    // of it survive into the ghost verbatim. LOCATED, not assumed: `matchable` is `typed`
-    // with a prefix removed only when normalization trimmed nothing off the end of it. It
-    // can also be absent entirely - `file://www.a/b` normalizes to `file://a/b`, which is
-    // nowhere in the typed text - and then there is nothing to draw a ghost after.
-    val canonicalAt = typed.indexOf(matchable, ignoreCase = true)
+    // of it survive into the ghost verbatim.
+    //
+    // COMPUTED from what canonicalisation strips, not searched for. `indexOf` finds the
+    // FIRST occurrence, and a one- or two-character `matchable` occurs inside the prefix
+    // itself: `https://s` located the `s` of `https`, made the tail `s://s`, and since no
+    // canonical address contains `://` the ghost went dark - on exactly the input the typed
+    // scheme rule was added for. `https://www.w` did the same on the `w` of `www.`.
+    val afterScheme = if (typed.contains("://")) typed.indexOf("://") + 3 else 0
+    val canonicalAt =
+        if (typed.startsWith("www.", afterScheme, ignoreCase = true) && !matchable.startsWith("www.", true)) {
+            afterScheme + WWW.length
+        } else {
+            afterScheme
+        }
     // Whitespace is part of `hasInvisibleCharacters`, so text with a space in it is a search
     // and completing it would eat what is still being typed. A blank field needs no clause of
     // its own either: an empty one carries no `://`, so it arrives here as an empty
     // `matchable`, and an all-whitespace one is caught by the first clause.
-    if (typed.hasInvisibleCharacters() || matchable.isEmpty() || canonicalAt < 0) return null
+    // The last clause validates the computation above rather than trusting it: a scheme
+    // canonicalisation does NOT strip (`file://www.a/b` normalizes to `file://a/b`) leaves
+    // the canonical part somewhere else entirely, and there is then nothing to draw a ghost
+    // after.
+    if (typed.hasInvisibleCharacters() ||
+        matchable.isEmpty() ||
+        !typed.startsWith(matchable, canonicalAt, ignoreCase = true)
+    ) {
+        return null
+    }
 
     val entries =
         suggestions

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/UrlCompletion.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.browser.canonicalAuthority
 import ai.rever.boss.plugin.browser.canonicalUrlKey
+import ai.rever.boss.plugin.browser.hasUserinfo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -19,6 +21,15 @@ import androidx.compose.ui.text.withStyle
  * re-derived as `https://…` by `processUrlInput`, which fails the handshake; a stored
  * `https://www.example.com/x` became `example.com/x` and opened a host the certificate does
  * not cover.
+ *
+ * A FRAGMENT is the third way they differ, and the one that is easy to miss: [canonicalUrlKey]
+ * strips it, so a stored `https://app.example.com/x#/settings` displays as
+ * `app.example.com/x` and opens with the `#/settings` still on it. That is deliberate - a
+ * hash-routed app serves a real page from that fragment, so dropping it from the target would
+ * open the wrong view - but it does mean the drawn text is a prefix of where Enter goes rather
+ * than a spelling of it. `ghostTextTransformation`'s "cannot come apart" is about the two not
+ * drifting to different PAGES, which the guard enforces; it was never about them being the
+ * same string.
  */
 internal data class UrlCompletion(
     val display: String,
@@ -30,9 +41,6 @@ private fun schemeOf(url: String): String? = url.substringBefore("://", "").take
 
 /** The authority of a stored URL exactly as recorded, `www.` and port included. */
 private fun storedAuthority(url: String): String = url.substringAfter("://").substringBefore('/').substringBefore('?')
-
-/** The authority of a [canonicalUrlKey]-shaped address: everything before the path or query. */
-private fun hostOf(canonical: String): String = canonical.substringBefore('/').substringBefore('?')
 
 /**
  * Text that must never reach the field through a completion, and that suppresses one when
@@ -66,15 +74,11 @@ private val HIDDEN = setOf(CharCategory.CONTROL, CharCategory.FORMAT)
 /**
  * Whether this stored address is unfit to be offered as a completion at all, host included.
  *
- * Empty: nothing to key on. Invisible characters: see [hasInvisibleCharacters]. Userinfo -
- * a `user@` before the authority ends - because [canonicalUrlKey] keeps it while
- * `java.net.URL` reads the host as whatever follows the `@`. A stored
- * `https://github.com@evil.example/` canonicalises to `github.com@evil.example`, which
- * extends a typed `git` while the host is still open, so one Tab would hand the field a
- * host the user never named and Enter would open `evil.example`. Chrome strips userinfo
- * out of the omnibox for the same reason.
+ * Empty: nothing to key on. Invisible characters: see [hasInvisibleCharacters]. Userinfo:
+ * see [hasUserinfo], which is shared with the suggestion matcher because a rule the ghost
+ * refuses and the list beside it accepts only hardens half a surface.
  */
-private fun String.isUnofferable(): Boolean = isEmpty() || hasInvisibleCharacters() || hostOf(this).contains('@')
+private fun String.isUnofferable(): Boolean = isEmpty() || hasInvisibleCharacters() || hasUserinfo(this)
 
 /**
  * Whether the full stored ADDRESS is unfit to be offered even though its host is fine.
@@ -175,7 +179,7 @@ internal fun inlineUrlCompletion(
                 }
             }
 
-    val typedHost = hostOf(matchable)
+    val typedHost = canonicalAuthority(matchable)
     // No dot and no colon means no host has been named yet, so the host is still the thing
     // being completed. Anything else and the user has committed to a host.
     val hostStillOpen = matchable.none { it == '.' || it == ':' }
@@ -191,10 +195,10 @@ internal fun inlineUrlCompletion(
             // Hosts first, then the full addresses, as a Sequence so a hit on the first host
             // does not pay for the rest.
             entries.asSequence().map { (canonical, url, scheme) ->
-                UrlCompletion(display = hostOf(canonical), target = "$scheme://${storedAuthority(url)}")
+                UrlCompletion(display = canonicalAuthority(canonical), target = "$scheme://${storedAuthority(url)}")
             } + addresses
         } else {
-            addresses.filter { hostOf(it.display).equals(typedHost, ignoreCase = true) }
+            addresses.filter { canonicalAuthority(it.display).equals(typedHost, ignoreCase = true) }
         }
 
     return candidates

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/UrlAuthority.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/UrlAuthority.kt
@@ -1,12 +1,12 @@
 package ai.rever.boss.plugin.browser
 
-/**
- * Reading the authority back out of a [canonicalUrlKey], and the one rule that depends on it.
+/*
+ * Reading the authority back out of a canonicalUrlKey, and the one rule that depends on it.
  *
- * [canonicalUrlKey] normalizes a URL into a key; these split that key the way it was built,
- * so a caller never has to guess where the authority ends. Shared across source sets because
- * the URL field's inline completion (commonMain) and the suggestion matcher (desktopMain)
- * have to agree - a host the ghost refuses and the list beside it offers is half a fix.
+ * canonicalUrlKey normalizes a URL into a key; these split that key the way it was built, so
+ * a caller never has to guess where the authority ends. Shared across source sets because the
+ * URL field's inline completion (commonMain) and the suggestion matcher (desktopMain) have to
+ * agree - a host the ghost refuses and the list beside it offers is half a fix.
  */
 
 /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/UrlAuthority.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/UrlAuthority.kt
@@ -1,0 +1,33 @@
+package ai.rever.boss.plugin.browser
+
+/**
+ * Reading the authority back out of a [canonicalUrlKey], and the one rule that depends on it.
+ *
+ * [canonicalUrlKey] normalizes a URL into a key; these split that key the way it was built,
+ * so a caller never has to guess where the authority ends. Shared across source sets because
+ * the URL field's inline completion (commonMain) and the suggestion matcher (desktopMain)
+ * have to agree - a host the ghost refuses and the list beside it offers is half a fix.
+ */
+
+/**
+ * The authority of a [canonicalUrlKey]-shaped address: everything before the path or query.
+ *
+ * Its own file rather than another declaration in `NavigationOutcomeTracker.kt`, which is at
+ * its function budget and is named for something else entirely. Three places need this split
+ * and two of them had spelled it out inline in different source sets - the URL field's
+ * completion rules and the suggestion matcher's userinfo gate - which is the same shape as
+ * the two definitions of "extends" that an earlier review round removed.
+ */
+fun canonicalAuthority(canonical: String): String = canonical.substringBefore('/').substringBefore('?')
+
+/**
+ * Whether a [canonicalUrlKey]-shaped address carries a `user@` before its authority ends.
+ *
+ * `java.net.URL` reads the host of `https://github.com@evil.example/` as `evil.example`,
+ * while [canonicalUrlKey] keeps the `github.com@` - so such an entry passes a
+ * [suggestableHost] gate AND matches a typed "git" at index 0. Both the field's inline
+ * completion and the suggestion list have to refuse it, and they have to refuse it by the
+ * same rule, so the rule lives here rather than once per caller. Chrome strips userinfo out
+ * of the omnibox for the same reason.
+ */
+fun hasUserinfo(canonical: String): Boolean = canonicalAuthority(canonical).contains('@')

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.desktop.kt
@@ -9,10 +9,10 @@ actual object UrlHistoryProvider {
     ): List<UrlSuggestion> {
         val historySuggestions =
             UrlHistoryManager
-                // Floored: `rankMatches` ends in `take`, which throws on a negative count.
-                // No caller passes 0 today, but this is an `expect` declaration with a
-                // defaulted limit, so the next one should get an empty list, not a crash.
-                .getSuggestions(query, (limit - 1).coerceAtLeast(0))
+                // One short, to leave room for the search row appended below. A negative
+                // count is floored inside `rankMatches`, which is the function `take` would
+                // have thrown from.
+                .getSuggestions(query, limit - 1)
                 .map { entry ->
                     UrlSuggestion(
                         url = entry.url,
@@ -42,7 +42,10 @@ actual object UrlHistoryProvider {
             )
         }
 
-        return suggestions.take(limit)
+        // Floored for the same reason: this `take` is the second one a negative limit
+        // reaches, and `getSuggestions` is an `expect` declaration with a defaulted limit,
+        // so a caller that computes one should get an empty list rather than a crash.
+        return suggestions.take(limit.coerceAtLeast(0))
     }
 
     actual fun deleteUrl(url: String) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.desktop.kt
@@ -18,13 +18,21 @@ actual object UrlHistoryProvider {
                     )
                 }
 
-        // Add a Google search suggestion if the query doesn't look like a URL
+        // Offer a web search when the query doesn't look like an address.
+        //
+        // APPENDED, not inserted at the top. History is ranked and the best match is the row
+        // the user is most likely to want - putting the search row above it made every
+        // suggestion list open with the one row that is not a suggestion, and pushed the
+        // match that inline completion has already filled into the field down to second
+        // place. Chrome keeps its search row under the history it found, for the same reason.
         val suggestions = historySuggestions.toMutableList()
         if (!query.contains(".") && !query.startsWith("http")) {
             suggestions.add(
-                0,
                 UrlSuggestion(
-                    url = "https://www.google.com/search?q=${query.replace(" ", "+")}",
+                    // The same encoder `processUrlInput` uses, so this row and Enter on the
+                    // same text search for the same thing. A bare space-to-plus replace let
+                    // `&`, `#` and `%` through verbatim.
+                    url = "https://www.google.com/search?q=${encodeUrlParameter(query)}",
                     title = "Search Google for \"$query\"",
                     isSearchSuggestion = true,
                 ),

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.desktop.kt
@@ -9,7 +9,10 @@ actual object UrlHistoryProvider {
     ): List<UrlSuggestion> {
         val historySuggestions =
             UrlHistoryManager
-                .getSuggestions(query, limit - 1)
+                // Floored: `rankMatches` ends in `take`, which throws on a negative count.
+                // No caller passes 0 today, but this is an `expect` declaration with a
+                // defaulted limit, so the next one should get an empty list, not a crash.
+                .getSuggestions(query, (limit - 1).coerceAtLeast(0))
                 .map { entry ->
                     UrlSuggestion(
                         url = entry.url,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.desktop.kt
@@ -7,12 +7,16 @@ actual object UrlHistoryProvider {
         query: String,
         limit: Int,
     ): List<UrlSuggestion> {
+        // Decided before the lookup, because it decides how many rows history may fill. Asking
+        // for `limit - 1` unconditionally cost a row on exactly the URL-shaped queries this
+        // matching change is for: no search row is appended for them, so the dropdown showed
+        // nine rows where ten were asked for.
+        val offersSearch = !query.contains(".") && !query.startsWith("http")
         val historySuggestions =
             UrlHistoryManager
-                // One short, to leave room for the search row appended below. A negative
-                // count is floored inside `rankMatches`, which is the function `take` would
-                // have thrown from.
-                .getSuggestions(query, limit - 1)
+                // A negative count is floored inside `rankMatches`, which is the function
+                // `take` would have thrown from.
+                .getSuggestions(query, if (offersSearch) limit - 1 else limit)
                 .map { entry ->
                     UrlSuggestion(
                         url = entry.url,
@@ -29,7 +33,7 @@ actual object UrlHistoryProvider {
         // match that inline completion has already filled into the field down to second
         // place. Chrome keeps its search row under the history it found, for the same reason.
         val suggestions = historySuggestions.toMutableList()
-        if (!query.contains(".") && !query.startsWith("http")) {
+        if (offersSearch) {
             suggestions.add(
                 UrlSuggestion(
                     // The same encoder `processUrlInput` uses, so this row and Enter on the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -162,15 +162,21 @@ private fun isWordStart(
 internal fun startsWord(
     haystack: String,
     term: String,
-): Boolean =
-    if (term.isEmpty() || term.length > haystack.length) {
-        false
-    } else {
-        // `any` short-circuits, so a match near the front costs no more than the old loop did.
-        (0..haystack.length - term.length).any { i ->
-            isWordStart(haystack, i) && haystack.startsWith(term, i, ignoreCase = true)
-        }
+): Boolean {
+    if (term.isEmpty() || term.length > haystack.length) return false
+    // An index loop rather than `(0..n).any { }`. `Iterable.any` is inline, so the lambda
+    // costs nothing, but inside it the receiver's static type is `Iterable<Int>` and the
+    // iterator hands back boxed `Integer`s - and past the 127 the box cache covers, that is
+    // an allocation per index, in the innermost loop of the per-keystroke scan.
+    var i = 0
+    var found = false
+    val last = haystack.length - term.length
+    while (!found && i <= last) {
+        found = isWordStart(haystack, i) && haystack.startsWith(term, i, ignoreCase = true)
+        i++
     }
+    return found
+}
 
 /**
  * What matching needs to know about one stored URL, derived from the URL string alone.
@@ -195,7 +201,6 @@ private val urlFacts = ConcurrentHashMap<String, UrlFacts>()
 
 private fun factsFor(url: String): UrlFacts {
     urlFacts[url]?.let { return it }
-    if (urlFacts.size > MAX_ENTRIES + PRUNE_SLACK) urlFacts.clear()
     return urlFacts.getOrPut(url) {
         val address = canonicalUrlKey(url)
         // [hasUserinfo] rather than the same expression spelled out here: the URL field's
@@ -270,6 +275,16 @@ internal fun rankMatches(
     // rejects a negative count, and one of the callers is `DesktopUrlHistoryProvider` -
     // `PluginContext.urlHistoryProvider` - so this limit arrives from plugin code.
     val wanted = limit.coerceAtLeast(0)
+
+    // The memo table is bounded here rather than inside `factsFor`, and by RETAINING what
+    // the store still holds rather than emptying it. Clearing put a cliff on the typing
+    // path: a working set hovering near the cap paid a full rebuild - a thousand
+    // `java.net.URL` constructions, `MalformedURLException` unwinds included - on the
+    // keystroke after one new page was visited. This walks the entries once, and only when
+    // the table has actually drifted past them.
+    if (urlFacts.size > MAX_ENTRIES + PRUNE_SLACK) {
+        urlFacts.keys.retainAll(entries.mapTo(HashSet()) { it.url })
+    }
     val typed = normalized.lowercase()
 
     return entries
@@ -281,7 +296,13 @@ internal fun rankMatches(
             // history file. A `javascript:` or `file://` row in a legacy or tampered file is
             // not something to offer as a completion the field fills in and Enter opens.
             if (!facts.suggestable) return@mapNotNull null
-            val address = facts.address
+            // Capped for the same reason the title is, and the reason is stronger here: a
+            // stored URL is at least as attacker-influenceable as a page's own title, and
+            // the `isUnofferableAddress` KDoc puts a stored OAuth URL at 500-2000
+            // characters - every one of which `startsWord` walked, per term, per keystroke.
+            // What is lost past the cap is a match buried deeper in a URL than anyone types,
+            // which is the noise this matcher exists to stop answering.
+            val address = facts.address.take(MAX_ADDRESS_LENGTH)
             // Capped HERE as well as in `addUrl`, because a file written by an older build
             // can hold a title of any length, and this is the loop the cap exists to bound.
             // Capping in `loadHistory` instead would be destructive: that map is what
@@ -388,6 +409,15 @@ private const val PRUNE_SLACK = 200
  * writes back and would rewrite the user's own file.
  */
 private const val MAX_TITLE_LENGTH = 256
+
+/**
+ * Longest stored address a match will scan.
+ *
+ * Larger than [MAX_TITLE_LENGTH] because a path carries meaning a title does not, and a
+ * legitimate deep link runs longer than a headline. Bounds the same scan for the same
+ * reason, and like the title cap it applies to what is READ, never to what is stored.
+ */
+private const val MAX_ADDRESS_LENGTH = 512
 
 object UrlHistoryManager {
     private val logger = BossLogger.forComponent("UrlHistoryManager")

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -196,7 +196,17 @@ private val urlFacts = ConcurrentHashMap<String, UrlFacts>()
 private fun factsFor(url: String): UrlFacts {
     urlFacts[url]?.let { return it }
     if (urlFacts.size > MAX_ENTRIES + PRUNE_SLACK) urlFacts.clear()
-    return urlFacts.getOrPut(url) { UrlFacts(canonicalUrlKey(url), suggestableHost(url) != null) }
+    return urlFacts.getOrPut(url) {
+        val address = canonicalUrlKey(url)
+        // Userinfo, inline because it is one clause: `java.net.URL` reads the host of
+        // `https://github.com@evil.example/` as `evil.example` while `canonicalUrlKey` keeps
+        // the `github.com@`, so the entry passed the host gate AND matched a typed "git" at
+        // index 0 - a clickable row whose address line reads `github.com@evil.example`. The
+        // field's inline completion refuses these; the list beside it has to refuse them too,
+        // or only half the surface is hardened. Chrome strips userinfo from the omnibox.
+        val userinfo = address.substringBefore('/').substringBefore('?').contains('@')
+        UrlFacts(address = address, suggestable = suggestableHost(url) != null && !userinfo)
+    }
 }
 
 /**
@@ -319,7 +329,12 @@ internal fun rankMatches(
                 { -rankOf(it.entry, now) },
             ),
         ).take(limit)
-        .map { it.entry }
+        // Capped on the way OUT as well as on the way in. `maxLines = 1` truncates what a
+        // dropdown row DRAWS, not what Compose measures, so an uncapped title from an older
+        // file still laid out in full on every keystroke - which is the cost the cap exists
+        // to remove. This copy is the matcher's own return value and never reaches the map
+        // `saveHistory` writes back, so the user's file keeps the title it had.
+        .map { it.entry.copy(title = it.entry.title.take(MAX_TITLE_LENGTH)) }
 }
 
 /**
@@ -366,9 +381,11 @@ private const val PRUNE_SLACK = 200
  * Longest page title a match will scan. Attacker-controlled - a page sets its own
  * `document.title` - and word-scanned on every keystroke of every URL field.
  *
- * Enforced in two places on purpose: `addUrl` caps what is STORED, and [rankMatches] caps
- * what is READ, because a history file written before the cap existed still holds whatever
- * the page put there.
+ * Enforced in three places on purpose, because a history file written before the cap existed
+ * still holds whatever the page put there: `addUrl` caps what is STORED, [rankMatches] caps
+ * what it SCANS, and it caps what it RETURNS so the dropdown does not lay out a paragraph
+ * per row per keystroke. Not capped in `loadHistory`, which feeds the map `saveHistory`
+ * writes back and would rewrite the user's own file.
  */
 private const val MAX_TITLE_LENGTH = 256
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -198,14 +198,10 @@ private fun factsFor(url: String): UrlFacts {
     if (urlFacts.size > MAX_ENTRIES + PRUNE_SLACK) urlFacts.clear()
     return urlFacts.getOrPut(url) {
         val address = canonicalUrlKey(url)
-        // Userinfo, inline because it is one clause: `java.net.URL` reads the host of
-        // `https://github.com@evil.example/` as `evil.example` while `canonicalUrlKey` keeps
-        // the `github.com@`, so the entry passed the host gate AND matched a typed "git" at
-        // index 0 - a clickable row whose address line reads `github.com@evil.example`. The
-        // field's inline completion refuses these; the list beside it has to refuse them too,
-        // or only half the surface is hardened. Chrome strips userinfo from the omnibox.
-        val userinfo = address.substringBefore('/').substringBefore('?').contains('@')
-        UrlFacts(address = address, suggestable = suggestableHost(url) != null && !userinfo)
+        // [hasUserinfo] rather than the same expression spelled out here: the URL field's
+        // completion refuses these by that rule, and a list beside it that accepted them
+        // would harden half a surface.
+        UrlFacts(address = address, suggestable = suggestableHost(url) != null && !hasUserinfo(address))
     }
 }
 
@@ -270,6 +266,10 @@ internal fun rankMatches(
     val normalized = if (query.contains("://")) canonicalUrlKey(query) else query.trim()
     val terms = queryTerms(normalized)
     if (terms.isEmpty()) return emptyList()
+    // Floored HERE, at the function that would throw, rather than at a call site. `take`
+    // rejects a negative count, and one of the callers is `DesktopUrlHistoryProvider` -
+    // `PluginContext.urlHistoryProvider` - so this limit arrives from plugin code.
+    val wanted = limit.coerceAtLeast(0)
     val typed = normalized.lowercase()
 
     return entries
@@ -328,7 +328,7 @@ internal fun rankMatches(
                 { !it.addressMatch },
                 { -rankOf(it.entry, now) },
             ),
-        ).take(limit)
+        ).take(wanted)
         // Capped on the way OUT as well as on the way in. `maxLines = 1` truncates what a
         // dropdown row DRAWS, not what Compose measures, so an uncapped title from an older
         // file still laid out in full on every keystroke - which is the cost the cap exists

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -173,6 +173,33 @@ internal fun startsWord(
     }
 
 /**
+ * What matching needs to know about one stored URL, derived from the URL string alone.
+ *
+ * [canonicalUrlKey] scans and [suggestableHost] constructs a `java.net.URL` - and throws and
+ * unwinds a `MalformedURLException` for every malformed row - and both used to run per entry
+ * per KEYSTROKE. Neither depends on anything but the URL, so the result is memoized on it
+ * and the hot loop is left as string scanning.
+ *
+ * Keyed by the whole URL and never invalidated, because there is nothing to invalidate: the
+ * same string always derives the same facts. That leaves only growth to bound, and the store
+ * these describe is itself capped, so the table is emptied rather than evicted from once it
+ * drifts past the cap - a stale key costs one re-derive, and re-deriving is what this used
+ * to do every time.
+ */
+private class UrlFacts(
+    val address: String,
+    val suggestable: Boolean,
+)
+
+private val urlFacts = ConcurrentHashMap<String, UrlFacts>()
+
+private fun factsFor(url: String): UrlFacts {
+    urlFacts[url]?.let { return it }
+    if (urlFacts.size > MAX_ENTRIES + PRUNE_SLACK) urlFacts.clear()
+    return urlFacts.getOrPut(url) { UrlFacts(canonicalUrlKey(url), suggestableHost(url) != null) }
+}
+
+/**
  * One matched entry with the facts its ranking needs, computed once.
  *
  * [canonicalUrlKey] parses, and reading it from inside a comparator would parse the same URL
@@ -236,26 +263,34 @@ internal fun rankMatches(
     val typed = normalized.lowercase()
 
     return entries
-        // The gate `addUrl` applies to new visits, applied here to what gets SUGGESTED. It
-        // cannot be applied on load: `loadHistory` feeds the map that `saveHistory` writes
-        // back, so dropping an entry there silently purges it from the user's history file.
-        // A `javascript:` or `file://` row in a legacy or tampered file is not something to
-        // offer as a completion the field fills in and Enter opens.
-        .filter { suggestableHost(it.url) != null }
         .mapNotNull { entry ->
-            val address = canonicalUrlKey(entry.url)
+            val facts = factsFor(entry.url)
+            // The gate `addUrl` applies to new visits, applied here to what gets SUGGESTED.
+            // It cannot be applied on load: `loadHistory` feeds the map that `saveHistory`
+            // writes back, so dropping an entry there silently purges it from the user's
+            // history file. A `javascript:` or `file://` row in a legacy or tampered file is
+            // not something to offer as a completion the field fills in and Enter opens.
+            if (!facts.suggestable) return@mapNotNull null
+            val address = facts.address
+            // Capped HERE as well as in `addUrl`, because a file written by an older build
+            // can hold a title of any length, and this is the loop the cap exists to bound.
+            // Capping in `loadHistory` instead would be destructive: that map is what
+            // `saveHistory` writes back, so it would truncate the user's own file.
+            // `take` returns the receiver when it is already short enough, so the common
+            // case allocates nothing.
+            val title = entry.title.take(MAX_TITLE_LENGTH)
             // Per-term address hits, computed ONCE. Falling through to the title used to
             // re-scan the address for every term, which is the common case (most entries
             // do not match) and measured about a third of the whole matching pass.
             val addressHits = terms.map { startsWord(address, it) }
             val addressWordStart = addressHits.all { it }
             val wordStart =
-                addressWordStart || terms.indices.all { addressHits[it] || startsWord(entry.title, terms[it]) }
+                addressWordStart || terms.indices.all { addressHits[it] || startsWord(title, terms[it]) }
             // The fallback: every term appears SOMEWHERE. Only consulted when no word-start
             // reading of the query works, so it can never displace a word-start hit.
             val loose =
                 !wordStart &&
-                    terms.all { address.contains(it, ignoreCase = true) || entry.title.contains(it, ignoreCase = true) }
+                    terms.all { address.contains(it, ignoreCase = true) || title.contains(it, ignoreCase = true) }
             if (!wordStart && !loose) {
                 null
             } else {
@@ -327,7 +362,14 @@ private const val MAX_ENTRIES = 1000
 /** How far past [MAX_ENTRIES] the map may drift before a prune, so pruning stays amortised. */
 private const val PRUNE_SLACK = 200
 
-/** Longest stored page title. Attacker-controlled, and word-scanned on every keystroke. */
+/**
+ * Longest page title a match will scan. Attacker-controlled - a page sets its own
+ * `document.title` - and word-scanned on every keystroke of every URL field.
+ *
+ * Enforced in two places on purpose: `addUrl` caps what is STORED, and [rankMatches] caps
+ * what is READ, because a history file written before the cap existed still holds whatever
+ * the page put there.
+ */
 private const val MAX_TITLE_LENGTH = 256
 
 object UrlHistoryManager {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -288,7 +288,9 @@ internal fun rankMatches(
     if (urlFacts.size > MAX_ENTRIES + PRUNE_SLACK) {
         urlFacts.keys.retainAll(entries.mapTo(HashSet()) { it.url })
     }
-    val typed = normalized.lowercase()
+    // Not lowercased: both readers below pass `ignoreCase = true`, so a second lowercasing
+    // here only made it look as though one of the two were load-bearing.
+    val typed = normalized
 
     return entries
         .mapNotNull { entry ->
@@ -358,7 +360,16 @@ internal fun rankMatches(
         // file still laid out in full on every keystroke - which is the cost the cap exists
         // to remove. This copy is the matcher's own return value and never reaches the map
         // `saveHistory` writes back, so the user's file keeps the title it had.
-        .map { it.entry.copy(title = it.entry.title.take(MAX_TITLE_LENGTH)) }
+        // `copy` only where it changes something: an already-short title is the overwhelming
+        // case, and the surrounding code is careful about exactly this kind of allocation.
+        .map { match ->
+            val entry = match.entry
+            if (entry.title.length <= MAX_TITLE_LENGTH) {
+                entry
+            } else {
+                entry.copy(title = entry.title.take(MAX_TITLE_LENGTH))
+            }
+        }
 }
 
 /**
@@ -372,28 +383,43 @@ internal fun rankMatches(
  *
  * The slack is what keeps this amortised: pruning is a sort, so doing it on every visit past
  * the cap would pay O(n log n) per navigation.
+ *
+ * Keeps the map's OWN keys rather than re-deriving them with [distinctPageKey]. Re-deriving
+ * was correct only while every insertion path keyed by exactly that function - an invariant
+ * held by convention across three call sites, and one whose failure mode is `retainAll`
+ * emptying the store rather than anything visible.
+ *
+ * The read-then-retain is not atomic. An entry recorded by another thread between the sort
+ * and the retain is dropped, which costs one history row; `addUrl` is driven by the browser
+ * plugin's title listener, so that is reachable. Left as is rather than locked, because the
+ * alternative is holding a lock across a sort on the navigation path.
  */
 internal fun pruneIfOversized(
     history: MutableMap<String, UrlHistoryEntry>,
     now: Long = System.currentTimeMillis(),
 ) {
     if (history.size <= MAX_ENTRIES + PRUNE_SLACK) return
-    val keep = bestEntries(history.values, MAX_ENTRIES, now).map { distinctPageKey(it.url) }.toSet()
-    history.keys.retainAll(keep)
+    val survivors = bestEntries(history.entries, MAX_ENTRIES, now) { it.value }.mapTo(HashSet()) { it.key }
+    history.keys.retainAll(survivors)
 }
 
 /**
- * The [limit] best-ranked entries, best first.
+ * The [limit] best-ranked of whatever an entry can be read out of, best first.
  *
  * Top-level and pure so both callers - the file write and the in-memory prune - order the
  * store the same way, and so the ordering is testable without the object's `init` reading
  * the developer's real history file.
+ *
+ * [entryOf] exists so the prune can rank the map's ENTRIES and keep their own keys, rather
+ * than re-deriving a key from each surviving value and trusting that to match how it was
+ * stored.
  */
-internal fun bestEntries(
-    entries: Collection<UrlHistoryEntry>,
+internal fun <T> bestEntries(
+    items: Collection<T>,
     limit: Int,
     now: Long,
-): List<UrlHistoryEntry> = entries.sortedByDescending { rankOf(it, now) }.take(limit)
+    entryOf: (T) -> UrlHistoryEntry,
+): List<T> = items.sortedByDescending { rankOf(entryOf(it), now) }.take(limit)
 
 /** How many entries the store keeps, in memory and on disk. */
 private const val MAX_ENTRIES = 1000
@@ -494,7 +520,7 @@ object UrlHistoryManager {
      */
     private fun entriesToPersist(): List<UrlHistoryEntry> {
         val now = System.currentTimeMillis()
-        return bestEntries(history.values, MAX_ENTRIES, now)
+        return bestEntries(history.values, MAX_ENTRIES, now) { it }
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -124,6 +124,212 @@ internal fun rankOf(
     return (entry.visitCount * 1000.0) + recencyScore
 }
 
+/**
+ * The terms a query asks for: whitespace-separated and lowercased.
+ *
+ * Multi-term input is how a browser finds a page you remember two words of - "boss pulls"
+ * reaching `github.com/risa-labs-inc/BossConsole/pulls` - and it is why matching cannot be a
+ * single `contains`: the query as one string appears nowhere in that URL.
+ */
+private fun queryTerms(query: String): List<String> = query.lowercase().split(WHITESPACE).filter { it.isNotEmpty() }
+
+private val WHITESPACE = Regex("\\s+")
+
+/**
+ * Whether [i] is where a word begins in [text].
+ *
+ * A run of letters or digits is one word, and a term may only match where such a run starts.
+ * That single rule is what keeps "loc" out of `block` and out of the `…%2Flocalhost…` buried
+ * in an OAuth redirect parameter, both of which a substring match surfaced ahead of the page
+ * the user was actually reaching for.
+ *
+ * A lower-to-upper step counts as a word start too, so "console" still finds `BossConsole`.
+ * Upper-to-lower deliberately does NOT: it would put `%2FLocalhost` straight back.
+ */
+private fun isWordStart(
+    text: String,
+    i: Int,
+): Boolean {
+    if (i == 0) return true
+    val previous = text[i - 1]
+    return !previous.isLetterOrDigit() ||
+        ((previous.isLowerCase() || previous.isDigit()) && text[i].isUpperCase())
+}
+
+/**
+ * Whether [term] starts a word anywhere in [haystack], case-insensitively.
+ */
+internal fun startsWord(
+    haystack: String,
+    term: String,
+): Boolean =
+    if (term.isEmpty() || term.length > haystack.length) {
+        false
+    } else {
+        // `any` short-circuits, so a match near the front costs no more than the old loop did.
+        (0..haystack.length - term.length).any { i ->
+            isWordStart(haystack, i) && haystack.startsWith(term, i, ignoreCase = true)
+        }
+    }
+
+/**
+ * One matched entry with the facts its ranking needs, computed once.
+ *
+ * [canonicalUrlKey] parses, and reading it from inside a comparator would parse the same URL
+ * once per comparison rather than once per entry.
+ */
+private class RankedMatch(
+    val entry: UrlHistoryEntry,
+    val completableRoot: Boolean,
+    val addressPrefix: Boolean,
+    val wordStart: Boolean,
+    val addressMatch: Boolean,
+)
+
+/**
+ * The entries that answer [query], best first.
+ *
+ * Matching follows what a browser's address bar does rather than what is easiest to write:
+ *  - EVERY term must match, and each may match in the address or in the page title.
+ *  - a term that matches at the start of a word (see [startsWord]) outranks one that matches
+ *    mid-word. Both are kept: word starts alone put "loc" one keystroke from a PR titled
+ *    "…block…" out of the list, but they also lost "tube" for youtube.com and "hub" for
+ *    github.com. Mid-word matches are answered, just underneath.
+ *  - the address is matched in its canonical spelling - no scheme, no `www.`, no trailing
+ *    slash - so what the user types lines up with what they see.
+ *
+ * Ranking is four tiers. The first exists so the row on top is the row the field's ghost
+ * text has already filled in - two different proposals on screen at once is one too many,
+ * and it is why the most-visited page on a host does not outrank the host itself while the
+ * host is still being typed:
+ *  1. the host root, on a host the query is a prefix of. This is the completable match: it is
+ *     what `inlineUrlCompletion` fills in, because a host completes before a path does.
+ *  2. the address starts with the whole query. This takes over once the host is typed out and
+ *     the completion moves on to paths, and it subsumes "any other page on a matching host":
+ *     an address always begins with its own authority, so a host prefix is an address prefix.
+ *  3. every term matched at the start of a word, rather than mid-word.
+ *  4. the address matches without help from the title. A page whose URL you are typing beats
+ *     one that merely mentions the words somewhere in its title.
+ *  5. frecency - visits, with recency breaking ties. See [rankOf].
+ *
+ * Prefixes are matched case-INSENSITIVELY. [canonicalUrlKey] lowercases the authority but
+ * leaves the path alone, so a case-sensitive test dropped every mixed-case path out of tier 2
+ * the moment the user typed into it - and then the top row disagreed with the ghost text,
+ * which matches case-insensitively.
+ *
+ * Pure, taking [now], so the tiers can be pinned by a test without a clock or a real history
+ * file.
+ */
+internal fun rankMatches(
+    entries: Collection<UrlHistoryEntry>,
+    query: String,
+    limit: Int,
+    now: Long,
+): List<UrlHistoryEntry> {
+    // A pasted address carries a scheme, and maybe a `www.`, neither of which appears in the
+    // canonical form the entries are matched in - so the whole paste became one term longer
+    // than any address and matched nothing at all. Normalizing the query the same way the
+    // entries are is what makes pasting a URL you visit daily find it.
+    val normalized = if (query.contains("://")) canonicalUrlKey(query) else query.trim()
+    val terms = queryTerms(normalized)
+    if (terms.isEmpty()) return emptyList()
+    val typed = normalized.lowercase()
+
+    return entries
+        // The gate `addUrl` applies to new visits, applied here to what gets SUGGESTED. It
+        // cannot be applied on load: `loadHistory` feeds the map that `saveHistory` writes
+        // back, so dropping an entry there silently purges it from the user's history file.
+        // A `javascript:` or `file://` row in a legacy or tampered file is not something to
+        // offer as a completion the field fills in and Enter opens.
+        .filter { suggestableHost(it.url) != null }
+        .mapNotNull { entry ->
+            val address = canonicalUrlKey(entry.url)
+            // Per-term address hits, computed ONCE. Falling through to the title used to
+            // re-scan the address for every term, which is the common case (most entries
+            // do not match) and measured about a third of the whole matching pass.
+            val addressHits = terms.map { startsWord(address, it) }
+            val addressWordStart = addressHits.all { it }
+            val wordStart =
+                addressWordStart || terms.indices.all { addressHits[it] || startsWord(entry.title, terms[it]) }
+            // The fallback: every term appears SOMEWHERE. Only consulted when no word-start
+            // reading of the query works, so it can never displace a word-start hit.
+            val loose =
+                !wordStart &&
+                    terms.all { address.contains(it, ignoreCase = true) || entry.title.contains(it, ignoreCase = true) }
+            if (!wordStart && !loose) {
+                null
+            } else {
+                RankedMatch(
+                    entry = entry,
+                    // `address == domain` is what makes this the host's own root page rather
+                    // than something under it.
+                    completableRoot =
+                        entry.domain.startsWith(typed, ignoreCase = true) && address == entry.domain,
+                    addressPrefix = address.startsWith(typed, ignoreCase = true),
+                    wordStart = wordStart,
+                    addressMatch =
+                        if (wordStart) {
+                            addressWordStart
+                        } else {
+                            terms.all { address.contains(it, ignoreCase = true) }
+                        },
+                )
+            }
+        }.sortedWith(
+            compareBy(
+                { !it.completableRoot },
+                { !it.addressPrefix },
+                { !it.wordStart },
+                { !it.addressMatch },
+                { -rankOf(it.entry, now) },
+            ),
+        ).take(limit)
+        .map { it.entry }
+}
+
+/**
+ * Drop everything past [MAX_ENTRIES] once [history] has drifted [PRUNE_SLACK] past it.
+ *
+ * The cap used to apply only on the way to disk, so the in-memory map grew with every
+ * distinct page visited for the whole life of the process - and BOSS is a long-lived desktop
+ * app. That was survivable while matching was a `contains` per entry; it is not now that
+ * every keystroke canonicalises and word-scans each one (measured 0.4-1.7ms at 1000 entries,
+ * 7-52ms at 10000, which is a visible stall while typing).
+ *
+ * The slack is what keeps this amortised: pruning is a sort, so doing it on every visit past
+ * the cap would pay O(n log n) per navigation.
+ */
+internal fun pruneIfOversized(
+    history: MutableMap<String, UrlHistoryEntry>,
+    now: Long = System.currentTimeMillis(),
+) {
+    if (history.size <= MAX_ENTRIES + PRUNE_SLACK) return
+    val keep = bestEntries(history.values, MAX_ENTRIES, now).map { distinctPageKey(it.url) }.toSet()
+    history.keys.retainAll(keep)
+}
+
+/**
+ * The [limit] best-ranked entries, best first.
+ *
+ * Top-level and pure so both callers - the file write and the in-memory prune - order the
+ * store the same way, and so the ordering is testable without the object's `init` reading
+ * the developer's real history file.
+ */
+internal fun bestEntries(
+    entries: Collection<UrlHistoryEntry>,
+    limit: Int,
+    now: Long,
+): List<UrlHistoryEntry> = entries.sortedByDescending { rankOf(it, now) }.take(limit)
+
+/** How many entries the store keeps, in memory and on disk. */
+private const val MAX_ENTRIES = 1000
+
+/** How far past [MAX_ENTRIES] the map may drift before a prune, so pruning stays amortised. */
+private const val PRUNE_SLACK = 200
+
+/** Longest stored page title. Attacker-controlled, and word-scanned on every keystroke. */
+private const val MAX_TITLE_LENGTH = 256
+
 object UrlHistoryManager {
     private val logger = BossLogger.forComponent("UrlHistoryManager")
 
@@ -196,10 +402,7 @@ object UrlHistoryManager {
      */
     private fun entriesToPersist(): List<UrlHistoryEntry> {
         val now = System.currentTimeMillis()
-        return history.values
-            .toList()
-            .sortedByDescending { rankOf(it, now) }
-            .take(1000) // Keep only top 1000 entries
+        return bestEntries(history.values, MAX_ENTRIES, now)
     }
 
     /**
@@ -250,7 +453,9 @@ object UrlHistoryManager {
                     // Keep the URL the browser committed over one a caller typed: it is
                     // the spelling we will navigate back to.
                     url = if (url.startsWith("https", ignoreCase = true)) url else existing.url,
-                    title = title.ifBlank { existing.title },
+                    // Capped: a page controls its own title, and the whole thing is
+                    // word-scanned on every keystroke of every URL field.
+                    title = title.ifBlank { existing.title }.take(MAX_TITLE_LENGTH),
                     domain = domain,
                     visitCount = existing.visitCount + 1,
                     lastVisited = System.currentTimeMillis(),
@@ -258,41 +463,20 @@ object UrlHistoryManager {
             } else {
                 UrlHistoryEntry(
                     url = url,
-                    title = title,
+                    title = title.take(MAX_TITLE_LENGTH),
                     domain = domain,
                     visitCount = 1,
                     lastVisited = System.currentTimeMillis(),
                 )
             }
+        pruneIfOversized(history)
     }
 
+    /** See [rankMatches] for the matching and ranking rules. */
     fun getSuggestions(
         query: String,
         limit: Int = 10,
-    ): List<UrlHistoryEntry> {
-        if (query.isBlank()) return emptyList()
-
-        val lowerQuery = query.lowercase()
-        val now = System.currentTimeMillis()
-
-        return history.values
-            .filter { entry ->
-                entry.domain.contains(lowerQuery) ||
-                    entry.url.contains(lowerQuery) ||
-                    entry.title.lowercase().contains(lowerQuery)
-            }.sortedWith(
-                compareBy(
-                    // Prioritize domain starts with query
-                    { !it.domain.startsWith(lowerQuery) },
-                    // Then URL starts with query. Matched against the canonical form —
-                    // no scheme, no `www.` — so a stored `www.` doesn't sink an entry the
-                    // user is plainly typing towards.
-                    { !canonicalUrlKey(it.url).startsWith(lowerQuery) },
-                    // Then by visit count, with recency breaking ties
-                    { -rankOf(it, now) },
-                ),
-            ).take(limit)
-    }
+    ): List<UrlHistoryEntry> = rankMatches(history.values, query, limit, System.currentTimeMillis())
 
     /**
      * Forget a single entry — the URL bar's "don't suggest this again".

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -199,16 +199,19 @@ private class UrlFacts(
 
 private val urlFacts = ConcurrentHashMap<String, UrlFacts>()
 
-private fun factsFor(url: String): UrlFacts {
-    urlFacts[url]?.let { return it }
-    return urlFacts.getOrPut(url) {
+private fun factsFor(url: String): UrlFacts =
+    // `computeIfAbsent`, not `getOrPut`. The latter is the plain Map extension - a get, then
+    // a put - so two threads racing the same URL both build a `java.net.URL` and both unwind
+    // a `MalformedURLException` for a malformed row. Not a correctness problem, since this is
+    // a pure function of the key, but paying that twice is the exact cost the table exists to
+    // avoid.
+    urlFacts.computeIfAbsent(url) {
         val address = canonicalUrlKey(url)
         // [hasUserinfo] rather than the same expression spelled out here: the URL field's
         // completion refuses these by that rule, and a list beside it that accepted them
         // would harden half a surface.
         UrlFacts(address = address, suggestable = suggestableHost(url) != null && !hasUserinfo(address))
     }
-}
 
 /**
  * One matched entry with the facts its ranking needs, computed once.
@@ -313,7 +316,7 @@ internal fun rankMatches(
             // Per-term address hits, computed ONCE. Falling through to the title used to
             // re-scan the address for every term, which is the common case (most entries
             // do not match) and measured about a third of the whole matching pass.
-            val addressHits = terms.map { startsWord(address, it) }
+            val addressHits = BooleanArray(terms.size) { startsWord(address, terms[it]) }
             val addressWordStart = addressHits.all { it }
             val wordStart =
                 addressWordStart || terms.indices.all { addressHits[it] || startsWord(title, terms[it]) }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
@@ -301,6 +301,35 @@ class InlineUrlCompletionTest {
     }
 
     @Test
+    fun `a one-character host after a scheme still completes`() {
+        // The canonical part was LOCATED with `indexOf`, which finds the first occurrence -
+        // and a short canonical form occurs inside the prefix that was stripped to make it.
+        // `https://s` found the `s` of `https` at index 4, so the tail became `s://s`, and
+        // since no canonical address contains `://` the ghost went dark on exactly the input
+        // the typed-scheme rule exists for. Every earlier test used `https://git`, where the
+        // first occurrence happens to be the right one.
+        val sites = history("https://stackoverflow.com/", "https://www.wikipedia.org/")
+
+        assertEquals("https://stackoverflow.com", display("https://s", sites))
+        assertEquals("http://stackoverflow.com", display("http://s", sites))
+        // The same trap one level in: `w` occurs in the `www.` that canonicalisation strips.
+        assertEquals("https://www.wikipedia.org", display("https://www.w", sites))
+        assertEquals("https://www.wikipedia.org", display("https://www.wi", sites))
+    }
+
+    @Test
+    fun `an address too long to read is not offered`() {
+        // The query-string rule argues from length as much as from replaying a request, and a
+        // path-only URL reaches the same lengths without a `?` in it. A ghost longer than the
+        // single-line field it is drawn in is not a proposal anyone can check before Tab.
+        val long = history("https://example.com/" + "segment/".repeat(30))
+
+        assertNull(display("example.com/", long))
+        // A deep path that still fits is unaffected.
+        assertEquals("example.com/a/b/c", display("example.com/a", history("https://example.com/a/b/c")))
+    }
+
+    @Test
     fun `a typed fragment completes nothing rather than splicing past it`() {
         // A canonical address never carries a fragment, so there is nothing under `#y` to
         // extend. Subtracting the canonical length spliced the candidate's tail in AFTER the

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
@@ -249,6 +249,19 @@ class InlineUrlCompletionTest {
     }
 
     @Test
+    fun `a fragment stays on the target and off the display`() {
+        // `canonicalUrlKey` strips the fragment, so the ghost draws the address without it
+        // while the target keeps the spelling history recorded. Dropping it from the target
+        // instead would open the wrong view of a hash-routed app - this is the third way
+        // display and target differ, after the scheme and `www.`.
+        val hashRouted = history("https://app.example.com/x#/settings")
+        val completion = inlineUrlCompletion("app.example.com/", hashRouted)
+
+        assertEquals("app.example.com/x", completion?.display)
+        assertEquals("https://app.example.com/x#/settings", completion?.target)
+    }
+
+    @Test
     fun `candidates carrying invisible characters are refused`() {
         // A bidi override in a stored path can reorder the whole rendered line, so the
         // address the user reads is not the address Enter opens.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
@@ -155,6 +155,35 @@ class InlineUrlCompletionTest {
     }
 
     @Test
+    fun `a bare prefix can still reach an unfamiliar host`() {
+        // The boundary of the host-swap rule, pinned so nobody reads the KDoc above it as a
+        // broader promise than it makes. Once the typed text names a host, that host cannot
+        // be swapped - the cases above. BEFORE it does, there is no host to protect, and a
+        // prefix with no dot in it completes to whatever history ranked first.
+        //
+        // Chrome gates this on `typed_count` - whether the user ever typed that URL. There is
+        // no equivalent to gate on here: `visitCount` counts `addUrl` calls, and the only
+        // caller is the browser plugin's TITLE listener, so a page that assigns
+        // `document.title` twice raises its own count. A gate on it would read like
+        // protection and provide none.
+        val lookalike = history("https://paypal.com-login.evil.example/signin")
+
+        assertEquals("paypal.com-login.evil.example", display("paypal", lookalike))
+        assertEquals("paypal.com-login.evil.example", display("pay", lookalike))
+        // And the moment a host IS named, the rule takes over.
+        assertNull(display("paypal.", lookalike))
+    }
+
+    @Test
+    fun `a scheme we would not navigate to is never completed`() {
+        // `rankMatches` keeps only entries with an http(s) host; this gated on a scheme being
+        // PRESENT instead. `canonicalUrlKey` keeps a `file:` scheme, so `canonicalAuthority`
+        // read `file:` off the entry and typing "fil" ghosted `file:` targeting `file://`.
+        assertNull(display("fil", history("file:///Users/me/notes.html")))
+        assertNull(display("jav", history("javascript:alert(1)")))
+    }
+
+    @Test
     fun `a typed host still completes its own paths`() {
         // The rule is about the HOST changing, not about refusing to help.
         val suggestions = history("https://github.com/risa-labs-inc/BossConsole/pulls")

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
@@ -190,6 +190,65 @@ class InlineUrlCompletionTest {
     }
 
     @Test
+    fun `a query string disqualifies the address, not the host it is on`() {
+        // Both reasons for refusing it - a tail longer than the field, and replaying an
+        // expired request - are about the full address. Applied to the entry instead, the
+        // sole `accounts.google.com` visit being an OAuth URL meant typing "acc" offered
+        // nothing at all.
+        val oauth = history("https://accounts.google.com/o/oauth2/v2/auth?client_id=x&state=y")
+
+        assertEquals("accounts.google.com", display("acc", oauth))
+    }
+
+    @Test
+    fun `userinfo in a stored URL never reaches the field`() {
+        // `canonicalUrlKey` keeps a `user@`, while `java.net.URL` reads the host as what
+        // follows it - so a single drive-by visit to this would put `github.com@…` one Tab
+        // away from a typed "git", and Enter would open evil.example.
+        val spoof = history("https://github.com@evil.example/")
+
+        assertNull(display("git", spoof))
+        assertNull(display("github.com", spoof))
+    }
+
+    @Test
+    fun `a typed scheme still completes`() {
+        // `https://git` carries a `:`, which used to read as "a host has been named" and
+        // turned the ghost off entirely - while the dropdown, which canonicalises a pasted
+        // query, found the entry. The two halves disagreed on the easiest input to compare.
+        val suggestions = history("https://github.com/")
+
+        assertEquals("https://github.com", display("https://git", suggestions))
+        assertEquals("http://github.com", display("http://git", suggestions))
+        // And the security rule survives the normalization: a scheme does not reopen the
+        // host once the typed text names one.
+        assertNull(display("https://paypal.com", history("https://paypal.com-login.evil.example/")))
+    }
+
+    @Test
+    fun `a typed scheme completes a path under the typed host`() {
+        val suggestions = history("https://github.com/risa-labs-inc/BossConsole/pulls")
+
+        assertEquals(
+            "https://github.com/risa-labs-inc/BossConsole/pulls",
+            display("https://github.com/risa", suggestions),
+        )
+    }
+
+    @Test
+    fun `the navigation guard uses the same rule that built the display`() {
+        // `urlCompletionTarget` exists to keep the drawn text and the opened address
+        // together, so it cannot certify a string the completion rules would have refused:
+        // the path is case-SENSITIVE on both sides.
+        val deep = UrlCompletion("github.com/BossConsole/pulls", "https://github.com/BossConsole/pulls")
+
+        assertEquals(deep, urlCompletionTarget(deep, "github.com/Boss"))
+        assertNull(urlCompletionTarget(deep, "github.com/boss"))
+        // The host stays case-insensitive, which is what a host is.
+        assertEquals(deep, urlCompletionTarget(deep, "GitHub.com/Boss"))
+    }
+
+    @Test
     fun `candidates carrying invisible characters are refused`() {
         // A bidi override in a stored path can reorder the whole rendered line, so the
         // address the user reads is not the address Enter opens.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
@@ -1,0 +1,200 @@
+package ai.rever.boss.components.dialogs
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The prefix rules behind the URL field's inline completion.
+ *
+ * Worth pinning here rather than through the dialog because every one of these is a case
+ * that made the field unusable in an earlier shape of it: completing into a search URL
+ * while the user was still typing a query, completing a whole PR path in exchange for
+ * three characters, and rewriting the case of what the user had already typed.
+ */
+class InlineUrlCompletionTest {
+    private fun history(vararg urls: String) = urls.map { UrlSuggestion(url = it, title = "") }
+
+    private val githubCompletion = UrlCompletion("github.com", "https://github.com/")
+
+    /** The completion's displayed text - what the ghost draws. */
+    private fun display(
+        typed: String,
+        suggestions: List<UrlSuggestion>,
+    ) = inlineUrlCompletion(typed, suggestions)?.display
+
+    @Test
+    fun `completes a prefix to the host, not to the deepest page`() {
+        val suggestions =
+            history(
+                "https://github.com/risa-labs-inc/BossConsole/pulls",
+                "https://github.com/",
+            )
+
+        assertEquals("github.com", display("git", suggestions))
+    }
+
+    @Test
+    fun `completes the path once the host is typed out`() {
+        val suggestions = history("https://github.com/risa-labs-inc/BossConsole/pulls")
+
+        assertEquals(
+            "github.com/risa-labs-inc/BossConsole/pulls",
+            display("github.com/risa", suggestions),
+        )
+    }
+
+    @Test
+    fun `matches through the stored spelling's scheme and www`() {
+        // The entry is stored as the browser committed it; the user types neither prefix.
+        assertEquals("youtube.com", display("you", history("https://www.youtube.com/")))
+    }
+
+    @Test
+    fun `keeps the case the user typed`() {
+        assertEquals("GitHub.com", display("GitHub", history("https://github.com/")))
+    }
+
+    @Test
+    fun `offers nothing for a search`() {
+        val suggestions = history("https://github.com/risa-labs-inc/BossConsole")
+
+        // Whitespace means this is a query, and completing it would eat what is still being typed.
+        assertNull(display("git commit", suggestions))
+        assertNull(display("", suggestions))
+        assertNull(display("   ", suggestions))
+    }
+
+    @Test
+    fun `never completes towards a search suggestion`() {
+        val searchRow =
+            listOf(
+                UrlSuggestion(
+                    url = "https://www.google.com/search?q=git",
+                    title = "Search Google for \"git\"",
+                    isSearchSuggestion = true,
+                ),
+            )
+
+        assertNull(display("git", searchRow))
+    }
+
+    @Test
+    fun `offers nothing once the address is fully typed`() {
+        // Equal, not longer: a completion of zero characters would leave an empty selection
+        // and make the next keystroke's behaviour depend on it.
+        assertNull(display("github.com", history("https://github.com/")))
+    }
+
+    @Test
+    fun `follows the ranked order of the suggestions`() {
+        // Both hosts match "g"; the list is already ranked, so the first one wins.
+        val suggestions = history("https://gmail.com/", "https://github.com/")
+
+        assertEquals("gmail.com", display("g", suggestions))
+    }
+
+    @Test
+    fun `ghost text draws the tail and keeps the cursor inside the value`() {
+        val transformed =
+            ghostTextTransformation(
+                UrlCompletion("github.com", "https://github.com/"),
+                Color.Gray,
+            ).filter(AnnotatedString("git"))
+
+        assertEquals("github.com", transformed.text.text)
+        assertEquals(3, transformed.offsetMapping.originalToTransformed(3))
+        // An offset inside the ghost maps back to the end of the value: the cursor must never
+        // land in text the field does not actually contain.
+        assertEquals(3, transformed.offsetMapping.transformedToOriginal(10))
+    }
+
+    @Test
+    fun `nothing is drawn without a completion, or once it stops matching`() {
+        val none = ghostTextTransformation(null, Color.Gray).filter(AnnotatedString("git"))
+        assertEquals("git", none.text.text)
+
+        // A completion left over from an earlier keystroke must not be drawn against text it
+        // no longer extends.
+        val stale =
+            ghostTextTransformation(githubCompletion, Color.Gray).filter(AnnotatedString("xyz"))
+        assertEquals("xyz", stale.text.text)
+    }
+
+    @Test
+    fun `a path completion keeps the stored spelling, not the typed case`() {
+        val suggestions = history("https://github.com/risa-labs-inc/BossConsole/pulls")
+
+        // Splicing the user's casing onto the stored tail produced
+        // "github.com/risa-labs-inc/bossConsole/pulls" - an address in neither history nor
+        // the field, and a 404 on any case-sensitive server. A path must match exactly.
+        assertNull(display("github.com/risa-labs-inc/boss", suggestions))
+        assertEquals(
+            "github.com/risa-labs-inc/BossConsole/pulls",
+            display("github.com/risa-labs-inc/Boss", suggestions),
+        )
+    }
+
+    @Test
+    fun `a host is never swapped for a different one, at any prefix`() {
+        // One drive-by visit is all it takes to put a lookalike in history. Extending a
+        // typed host by bare prefix would hand the user somebody else's domain, and Enter
+        // would take it. Guarding only a host that "looks finished" left every prefix on
+        // the way to it wide open, which is every host anyone ever types.
+        val lookalike = history("https://paypal.com-login.evil.example/signin")
+
+        assertNull(display("paypal.com", lookalike))
+        assertNull(display("paypal.c", lookalike))
+        assertNull(display("paypal.", lookalike))
+        // Same rule when the lookalike merely adds a label.
+        assertNull(display("github.com", history("https://github.com.evil.example/")))
+        // And with no attacker at all: a different port is a different machine.
+        assertNull(display("192.168.4.2", history("http://192.168.4.20:8123/lovelace")))
+    }
+
+    @Test
+    fun `a typed host still completes its own paths`() {
+        // The rule is about the HOST changing, not about refusing to help.
+        val suggestions = history("https://github.com/risa-labs-inc/BossConsole/pulls")
+
+        assertEquals(
+            "github.com/risa-labs-inc/BossConsole/pulls",
+            display("github.com/", suggestions),
+        )
+    }
+
+    @Test
+    fun `accepting navigates to the address history stored, not the canonical one`() {
+        // The display is canonical so it lines up with what the user types; the target has
+        // to be what history recorded, or `processUrlInput` re-derives a scheme of its own.
+        val intranet = inlineUrlCompletion("192", history("http://192.168.4.20:8123/lovelace"))
+        assertEquals("192.168.4.20:8123", intranet?.display)
+        assertEquals("http://192.168.4.20:8123", intranet?.target)
+
+        // `www.` is stripped for display and kept for navigation - dropping it opens a host
+        // the certificate may not cover.
+        val www = inlineUrlCompletion("exa", history("https://www.example.com/x"))
+        assertEquals("example.com", www?.display)
+        assertEquals("https://www.example.com", www?.target)
+    }
+
+    @Test
+    fun `a candidate with a query string is not offered`() {
+        // A stored OAuth URL is hundreds of characters of dead state parameters, and its
+        // tail would be longer than the field.
+        val oauth = history("https://accounts.google.com/o/oauth2/v2/auth?client_id=x&state=y")
+
+        assertNull(display("accounts.google.com/o", oauth))
+    }
+
+    @Test
+    fun `candidates carrying invisible characters are refused`() {
+        // A bidi override in a stored path can reorder the whole rendered line, so the
+        // address the user reads is not the address Enter opens.
+        val bidi = history("https://github.com/a\u202Eb")
+
+        assertNull(display("github.com/a", bidi))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/InlineUrlCompletionTest.kt
@@ -249,6 +249,51 @@ class InlineUrlCompletionTest {
     }
 
     @Test
+    fun `a typed scheme with a trailing slash does not double the slash`() {
+        // `canonicalUrlKey` trims a trailing slash as well as stripping the scheme, so
+        // subtracting the canonical LENGTH from the typed text spliced the candidate in one
+        // character early: `https://github.com/` completed to `https://github.com//risa-...`.
+        // Cosmetic in the ghost, permanent once Tab wrote it into the field.
+        //
+        // Every earlier typed-scheme case ended without a slash and every trailing-slash case
+        // had no scheme - which is exactly the pair where the canonical form IS the typed
+        // text with a prefix removed, so nothing caught it.
+        val deep = history("https://github.com/risa-labs-inc/BossConsole/pulls")
+
+        assertEquals("https://github.com/risa-labs-inc/BossConsole/pulls", display("https://github.com/", deep))
+        assertEquals(
+            "https://www.github.com/risa-labs-inc/BossConsole/pulls",
+            display("https://www.github.com/", deep),
+        )
+        assertEquals(
+            "https://github.com/risa-labs-inc/BossConsole/pulls",
+            display("https://github.com/risa-labs-inc/", deep),
+        )
+    }
+
+    @Test
+    fun `a typed fragment completes nothing rather than splicing past it`() {
+        // A canonical address never carries a fragment, so there is nothing under `#y` to
+        // extend. Subtracting the canonical length spliced the candidate's tail in AFTER the
+        // fragment, producing an address that exists nowhere.
+        val deep = history("https://github.com/x/y")
+
+        assertNull(display("https://github.com/x#y", deep))
+    }
+
+    @Test
+    fun `a host completion drops a stored fragment from its target`() {
+        // `storedAuthority` cut at the path and the query but not the fragment, and an entry
+        // with no path has nothing else to cut at - so a completion DISPLAYING `example.com`
+        // targeted `https://example.com#x`.
+        val fragmentOnly = history("https://example.com#x")
+        val completion = inlineUrlCompletion("exa", fragmentOnly)
+
+        assertEquals("example.com", completion?.display)
+        assertEquals("https://example.com", completion?.target)
+    }
+
+    @Test
     fun `a fragment stays on the target and off the display`() {
         // `canonicalUrlKey` strips the fragment, so the ghost draws the address without it
         // while the target keeps the spelling history recorded. Dropping it from the target

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
@@ -327,10 +327,36 @@ class NewTabUrlFieldTest {
     }
 
     @Test
-    fun `a limit of zero returns nothing instead of throwing`() {
-        // The provider asks history for `limit - 1`, and `rankMatches` ends in `take`, which
-        // throws on a negative count.
+    fun `a limit of zero or less returns nothing instead of throwing`() {
+        // `take` rejects a negative count, and there are TWO of them on this path: the one
+        // inside `rankMatches`, which the provider used to reach by passing `limit - 1`, and
+        // the provider's own after it appends the search row. Zero only exercises the first,
+        // which is why it passed while the second was still unguarded.
         assertEquals(emptyList(), UrlHistoryProvider.getSuggestions("git", limit = 0))
+        assertEquals(emptyList(), UrlHistoryProvider.getSuggestions("git", limit = -1))
+        assertEquals(emptyList(), UrlHistoryProvider.getSuggestions("git", limit = Int.MIN_VALUE))
+    }
+
+    @Test
+    fun `the encoder names what is safe rather than what is not`() {
+        // Asserted on the encoder rather than through a search row, because the row is only
+        // offered for text with no dot in it - which would have left the unreserved case
+        // below untestable, and it is the one that says the output stays readable.
+        //
+        // This was a chain of `replace` calls and every review round found another character
+        // missing from it. An allowlist ends that: RFC 3986 unreserved characters survive, a
+        // space is the `?q=` convention's `+`, everything else leaves as its UTF-8 bytes.
+        assertEquals("a-b_c.d~e", encodeUrlParameter("a-b_c.d~e"))
+        assertEquals("caf%C3%A9+r%C3%B6sti", encodeUrlParameter("café rösti"))
+        assertEquals("%E6%97%A5%E6%9C%AC", encodeUrlParameter("日本"))
+        assertEquals("%22exact+phrase%22", encodeUrlParameter("\"exact phrase\""))
+        assertEquals("a%3Cb%3Ec%7Cd%5Ce", encodeUrlParameter("a<b>c|d\\e"))
+        // The characters the denylist did cover still go out the same way, so the search row
+        // and the confirm path did not change what they search for.
+        assertEquals("foo+%26+bar", encodeUrlParameter("foo & bar"))
+        assertEquals("100%25+cotton", encodeUrlParameter("100% cotton"))
+        assertEquals("a+%2B+b", encodeUrlParameter("a + b"))
+        assertEquals("a%2Fb%3Fc%23d%3De", encodeUrlParameter("a/b?c#d=e"))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
@@ -69,7 +70,11 @@ class NewTabUrlFieldTest {
               {"url":"https://github.com/","title":"GitHub","domain":"github.com",
                "visitCount":13,"lastVisited":${System.currentTimeMillis()}},
               {"url":"https://github.com/risa-labs-inc/BossConsole/pulls","title":"Pull requests",
-               "domain":"github.com","visitCount":37,"lastVisited":${System.currentTimeMillis()}}
+               "domain":"github.com","visitCount":37,"lastVisited":${System.currentTimeMillis()}},
+              {"url":"https://news.example.com/first","title":"First","domain":"news.example.com",
+               "visitCount":9,"lastVisited":${System.currentTimeMillis()}},
+              {"url":"https://news.example.com/second","title":"Second","domain":"news.example.com",
+               "visitCount":2,"lastVisited":${System.currentTimeMillis()}}
             ]
             """.trimIndent(),
         )
@@ -280,6 +285,52 @@ class NewTabUrlFieldTest {
         // Arrowing into the list makes the highlighted row the proposal; the confirm button
         // relies on the completion having been cleared for that to hold.
         assertEquals(listOf("https://github.com/"), opened)
+    }
+
+    @Test
+    fun `Escape drops the highlighted row, not just the list and the ghost`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.DirectionDown) }
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Escape) }
+        settle()
+        confirm()
+
+        // The highlighted row outranks the ghost in `urlToOpen`, and Escape used to leave it
+        // behind: nothing suggestion-shaped was on screen any more, and the confirm button
+        // still opened a row the user could no longer see.
+        assertEquals(listOf("https://www.google.com/search?q=git"), opened)
+    }
+
+    @Test
+    fun `deleting a row drops the highlight it was addressed by`() {
+        openDialog()
+
+        // Two pages on one host, so the list still has a row under the deleted one. "git"
+        // cannot show this: its remaining row is on the same host as the ghost, so the two
+        // commit targets agree by accident.
+        rule.onNode(hasSetTextAction()).performTextInput("news")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.DirectionDown) }
+        settle()
+        rule.onAllNodesWithContentDescription("Delete")[0].performClick()
+        settle()
+        confirm()
+
+        // The list is filtered in place, so the row under the deleted one moves up into the
+        // index - and the highlight, which outranks the ghost, then names a page the user
+        // never pointed at. With the index dropped, the ghost's host is what commits.
+        assertEquals(listOf("https://news.example.com"), opened)
+    }
+
+    @Test
+    fun `a limit of zero returns nothing instead of throwing`() {
+        // The provider asks history for `limit - 1`, and `rankMatches` ends in `take`, which
+        // throws on a negative count.
+        assertEquals(emptyList(), UrlHistoryProvider.getSuggestions("git", limit = 0))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
@@ -242,11 +242,29 @@ class NewTabUrlFieldTest {
         settle()
         rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Escape) }
         settle()
+        rule.onNodeWithText(DEEP_ROW).assertDoesNotExist()
         confirm()
 
         // Escape rejected the proposal, so the typed text is what is left - and "git" is
         // not an address, so it is searched for.
         assertEquals(listOf("https://www.google.com/search?q=git"), opened)
+    }
+
+    @Test
+    fun `accepting a completion leaves the list closed`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNodeWithText(DEEP_ROW).assertExists()
+
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Tab) }
+        settle()
+
+        // Accepting rewrites the field, which re-keys the debounced lookup - so closing the
+        // list by clearing the flag alone left it to re-open one debounce later, under a
+        // comment claiming the opposite.
+        rule.onNodeWithText(DEEP_ROW).assertDoesNotExist()
     }
 
     @Test
@@ -286,5 +304,34 @@ class NewTabUrlFieldTest {
         val row = UrlHistoryProvider.getSuggestions("foo & bar", limit = 10).single { it.isSearchSuggestion }
 
         assertEquals("https://www.google.com/search?q=foo+%26+bar", row.url)
+    }
+
+    @Test
+    fun `a percent and a plus in the query survive encoding`() {
+        // Sharing the encoder fixed `&` and `#` but left these two: `100%` went out as a
+        // truncated escape, `a%26b` reached Google as `a&b` - the user's own text read back
+        // as a separator - and `a + b` became `a+++b`, which reads as `a   b`.
+        assertEquals(
+            "https://www.google.com/search?q=100%25+cotton",
+            searchRowFor("100% cotton"),
+        )
+        assertEquals("https://www.google.com/search?q=a+%2B+b", searchRowFor("a + b"))
+        // The `%` a replacement introduces must not itself be re-escaped, which is why `%`
+        // is replaced first.
+        assertEquals("https://www.google.com/search?q=a%2526b", searchRowFor("a%26b"))
+    }
+
+    private fun searchRowFor(query: String): String {
+        val rows = UrlHistoryProvider.getSuggestions(query, limit = 10)
+        return rows.single { it.isSearchSuggestion }.url
+    }
+
+    private companion object {
+        /**
+         * A dropdown row's title, and only a dropdown row's: the field itself renders the
+         * URL, so this is what tells "the list is on screen" apart from "the field holds a
+         * completion".
+         */
+        const val DEEP_ROW = "Pull requests"
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
@@ -201,6 +201,25 @@ class NewTabUrlFieldTest {
     }
 
     @Test
+    fun `Tab in the middle of the input does not accept either`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput {
+            pressKey(Key.MoveHome)
+            pressKey(Key.Tab)
+        }
+        settle()
+        confirm()
+
+        // The ghost is drawn AFTER the text, so with the caret at the front it describes an
+        // insertion point it does not belong to. Right already refused to accept there;
+        // Tab did not, because it never consulted the caret at all.
+        assertEquals(listOf("https://www.google.com/search?q=git"), opened)
+    }
+
+    @Test
     fun `Right in the middle of the input stays a cursor move`() {
         openDialog()
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
@@ -1,0 +1,290 @@
+package ai.rever.boss.components.dialogs
+
+import ai.rever.boss.components.overlays.OverlayConfig
+import ai.rever.boss.plugin.api.TabComponentWithUI
+import ai.rever.boss.plugin.api.TabInfo
+import ai.rever.boss.plugin.api.TabRegistry
+import ai.rever.boss.plugin.api.TabTypeInfo
+import ai.rever.boss.plugin.browser.UrlHistoryManager
+import ai.rever.boss.plugin.tab.fluck.FluckTabType
+import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.pressKey
+import com.arkivanov.decompose.ComponentContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What the new-tab dialog's URL field does as you type into it.
+ *
+ * Assertions are on the URL the dialog would actually OPEN, not on the field's rendered
+ * text: the completion is ghost text and deliberately not part of the field's value, so
+ * "where does this take me" is the only question worth pinning - and it is the one that was
+ * wrong.
+ */
+class NewTabUrlFieldTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private class Stub(
+        ctx: ComponentContext,
+        override val config: TabInfo,
+        override val tabTypeInfo: TabTypeInfo,
+    ) : TabComponentWithUI,
+        ComponentContext by ctx {
+        @Composable
+        override fun Content() = Unit
+    }
+
+    private val registry =
+        TabRegistry().apply {
+            registerTabType(FluckTabType) { config, ctx -> Stub(ctx, config, FluckTabType) }
+        }
+
+    private val opened = mutableListOf<String>()
+    private lateinit var temp: java.io.File
+    private var originalFile: java.io.File? = null
+    private val previousModal = OverlayConfig.heavyweightModal
+    private val previousUseHeavyweight = OverlayConfig.useHeavyweightPopups
+
+    @Before
+    fun setUp() {
+        temp = java.io.File.createTempFile("new-tab-history", ".json")
+        temp.writeText(
+            """
+            [
+              {"url":"https://github.com/","title":"GitHub","domain":"github.com",
+               "visitCount":13,"lastVisited":${System.currentTimeMillis()}},
+              {"url":"https://github.com/risa-labs-inc/BossConsole/pulls","title":"Pull requests",
+               "domain":"github.com","visitCount":37,"lastVisited":${System.currentTimeMillis()}}
+            ]
+            """.trimIndent(),
+        )
+        originalFile = UrlHistoryManager.historyFile
+        UrlHistoryManager.historyFile = temp
+        UrlHistoryManager.loadHistory()
+
+        // Render the modal in place instead of in a separate always-on-top window, so the
+        // dialog's own content belongs to this composition. The window itself is platform
+        // code with its own tests; what is under test here is the field inside it.
+        OverlayConfig.useHeavyweightPopups = true
+        OverlayConfig.heavyweightModal = { _, _, content -> content() }
+    }
+
+    @After
+    fun tearDown() {
+        OverlayConfig.heavyweightModal = previousModal
+        OverlayConfig.useHeavyweightPopups = previousUseHeavyweight
+        // UrlHistoryManager is a process-global store; a scratch file left in it would leak
+        // into any other test that reads history.
+        originalFile?.let { UrlHistoryManager.historyFile = it }
+        UrlHistoryManager.loadHistory()
+        temp.delete()
+    }
+
+    private fun openDialog() {
+        rule.setContent {
+            CompositionLocalProvider(LocalHeavyweightOverlays provides true) {
+                NewTabDialog(
+                    onDismiss = {},
+                    onCreateTab = { _, path -> opened += path },
+                    tabRegistry = registry,
+                )
+            }
+        }
+        rule.onNodeWithText("Enter URL or search term").assertExists()
+    }
+
+    /** Past the suggestion lookup's debounce, then let the completion effect run. */
+    private fun settle() {
+        rule.mainClock.advanceTimeBy(URL_SUGGESTION_DEBOUNCE_MS * 5)
+        rule.waitForIdle()
+    }
+
+    private fun confirm() {
+        rule.onNodeWithText("Fluck it").performClick()
+        rule.waitForIdle()
+    }
+
+    @Test
+    fun `confirming takes the completion the ghost text is offering`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        confirm()
+
+        assertEquals(listOf("https://github.com"), opened)
+    }
+
+    @Test
+    fun `Tab accepts the completion into the field`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Tab) }
+        settle()
+        confirm()
+
+        assertEquals(listOf("https://github.com"), opened)
+    }
+
+    @Test
+    fun `deleting suppresses the completion instead of filling it back in`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Backspace) }
+        settle()
+        confirm()
+
+        // "gi" is not an address and nothing re-completed it, so it is searched for. A
+        // completion that survived the delete would have opened github.com instead.
+        assertEquals(listOf("https://www.google.com/search?q=gi"), opened)
+    }
+
+    @Test
+    fun `the matching history entry is offered above the web search`() {
+        // Asserted on the returned order, not on rendered y-coordinates: the rows are what
+        // the reorder actually changed, and a layout comparison also relied on JVM
+        // assertions being enabled to fail at all.
+        val rows = UrlHistoryProvider.getSuggestions("git", limit = 10)
+
+        assertTrue(rows.isNotEmpty())
+        assertFalse(rows.first().isSearchSuggestion, "a history match must come first")
+        assertTrue(rows.last().isSearchSuggestion, "the web search row belongs at the bottom")
+    }
+
+    @Test
+    fun `Enter takes the completion the ghost text is offering`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Enter) }
+        rule.waitForIdle()
+
+        assertEquals(listOf("https://github.com"), opened)
+    }
+
+    @Test
+    fun `Right at the end of the input accepts the completion`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.DirectionRight) }
+        settle()
+        confirm()
+
+        assertEquals(listOf("https://github.com"), opened)
+    }
+
+    @Test
+    fun `Right in the middle of the input stays a cursor move`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput {
+            pressKey(Key.MoveHome)
+            pressKey(Key.DirectionRight)
+        }
+        // Probed by typing rather than by reading the field: the ghost is a visual
+        // transformation and Compose reports the TRANSFORMED text as the node's editable
+        // text, so neither a text matcher nor the semantics value can tell "git" with a
+        // ghost apart from an accepted "github.com". Where the next character lands can:
+        // after a cursor move it goes at index 1, after an accept it goes at the end.
+        rule.onNode(hasSetTextAction()).performTextInput("X")
+        settle()
+        confirm()
+
+        assertEquals(listOf("https://www.google.com/search?q=gXit"), opened)
+    }
+
+    @Test
+    fun `typing after a delete re-arms the completion`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Backspace) }
+        settle()
+        rule.onNode(hasSetTextAction()).performTextInput("t")
+        settle()
+        confirm()
+
+        // Suppression must be per-edit. Latched false, inline completion would be dead for
+        // the rest of the dialog's life and every other test here would still pass.
+        assertEquals(listOf("https://github.com"), opened)
+    }
+
+    @Test
+    fun `Escape cancels the completion, not just the list`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Escape) }
+        settle()
+        confirm()
+
+        // Escape rejected the proposal, so the typed text is what is left - and "git" is
+        // not an address, so it is searched for.
+        assertEquals(listOf("https://www.google.com/search?q=git"), opened)
+    }
+
+    @Test
+    fun `a highlighted row wins over the ghost completion`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("git")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.DirectionDown) }
+        settle()
+        confirm()
+
+        // Arrowing into the list makes the highlighted row the proposal; the confirm button
+        // relies on the completion having been cleared for that to hold.
+        assertEquals(listOf("https://github.com/"), opened)
+    }
+
+    @Test
+    fun `Tab with nothing to accept does not swallow the keystroke`() {
+        openDialog()
+
+        rule.onNode(hasSetTextAction()).performTextInput("zzqq")
+        settle()
+        rule.onNode(hasSetTextAction()).performKeyInput { pressKey(Key.Tab) }
+        settle()
+        confirm()
+
+        // Consuming Tab unconditionally trapped focus in the field, putting the dialog's
+        // own buttons out of keyboard reach.
+        assertEquals(listOf("https://www.google.com/search?q=zzqq"), opened)
+    }
+
+    @Test
+    fun `the search row is encoded the same way the confirm path encodes`() {
+        // Clicking the row and pressing Enter on the same text used to search for different
+        // things: the row only replaced spaces, so `&` arrived at Google as a separator.
+        val row = UrlHistoryProvider.getSuggestions("foo & bar", limit = 10).single { it.isSearchSuggestion }
+
+        assertEquals("https://www.google.com/search?q=foo+%26+bar", row.url)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabUrlFieldTest.kt
@@ -24,6 +24,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -59,6 +61,7 @@ class NewTabUrlFieldTest {
     private lateinit var temp: java.io.File
     private var originalFile: java.io.File? = null
     private val previousModal = OverlayConfig.heavyweightModal
+    private var previousSuggestionContext: CoroutineContext = EmptyCoroutineContext
     private val previousUseHeavyweight = OverlayConfig.useHeavyweightPopups
 
     @Before
@@ -87,10 +90,19 @@ class NewTabUrlFieldTest {
         // code with its own tests; what is under test here is the field inside it.
         OverlayConfig.useHeavyweightPopups = true
         OverlayConfig.heavyweightModal = { _, _, content -> content() }
+
+        // Run the suggestion lookup on the composition's own dispatcher. On
+        // `Dispatchers.Default` the work happens on a pool the test clock does not drive, so
+        // `advanceTimeBy` + `waitForIdle` proves the debounce elapsed but not that the result
+        // has landed - a race that a fast lookup wins almost every time, which is exactly the
+        // shape of a CI flake.
+        previousSuggestionContext = urlSuggestionContext
+        urlSuggestionContext = EmptyCoroutineContext
     }
 
     @After
     fun tearDown() {
+        urlSuggestionContext = previousSuggestionContext
         OverlayConfig.heavyweightModal = previousModal
         OverlayConfig.useHeavyweightPopups = previousUseHeavyweight
         // UrlHistoryManager is a process-global store; a scratch file left in it would leak

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryMatchingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryMatchingTest.kt
@@ -1,0 +1,171 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What the suggestion list matches, and in what order.
+ *
+ * Every case here is a real one from a 300-entry history file that the previous
+ * `contains`-anywhere match got wrong. Pinned against [rankMatches] rather than
+ * [UrlHistoryManager] so no test in this file can read the developer's own history.
+ */
+class HistoryMatchingTest {
+    private val now = 1_800_000_000_000L
+
+    private fun entry(
+        url: String,
+        title: String = "",
+        visits: Int = 1,
+        agoHours: Long = 1,
+    ) = UrlHistoryEntry(
+        url = url,
+        title = title,
+        domain = suggestableHost(url).orEmpty(),
+        visitCount = visits,
+        lastVisited = now - agoHours * 60 * 60 * 1000,
+    )
+
+    private fun rank(
+        query: String,
+        vararg entries: UrlHistoryEntry,
+    ) = rankMatches(entries.toList(), query, limit = 10, now = now).map { it.url }
+
+    @Test
+    fun `a term matches only at the start of a word`() {
+        assertTrue(startsWord("localhost:3000", "loc"))
+        assertTrue(startsWord("risa-labs-inc/BossConsole", "labs"))
+        // The rule that matters: not in the middle of one.
+        assertFalse(startsWord("screenshot: password gate, block quota", "loc"))
+    }
+
+    @Test
+    fun `a title match in the middle of a word ranks below a real one`() {
+        val unrelated =
+            entry("https://github.com/risa-labs-inc/BossConsole/pull/259", title = "block quota", visits = 6)
+        val real = entry("https://localhost:3000/", title = "Dev")
+
+        // "loc" is mid-word in "block", so the PR is answered - underneath, not on top of,
+        // the localhost the user was reaching for. Six visits used to be enough to win.
+        assertEquals(listOf(real.url, unrelated.url), rank("loc", unrelated, real))
+    }
+
+    @Test
+    fun `camel case counts as a word start`() {
+        // Otherwise typing the second half of a repository name finds nothing.
+        assertTrue(startsWord("risa-labs-inc/BossConsole", "console"))
+        // But an upper-to-lower step does not, or the OAuth case above comes back.
+        assertFalse(startsWord("%2FLocalhost", "localhost"))
+    }
+
+    @Test
+    fun `every term must match, in the address or the title`() {
+        val pulls = entry("https://github.com/risa-labs-inc/BossConsole/pulls", title = "Pull requests")
+        val issues = entry("https://github.com/risa-labs-inc/BossConsole/issues", title = "Issues")
+
+        // Two words the user remembers, in either order, matching across both fields.
+        assertEquals(listOf(pulls.url), rank("boss pulls", pulls, issues))
+        assertEquals(listOf(pulls.url), rank("pulls boss", pulls, issues))
+        assertEquals(emptyList(), rank("boss milestones", pulls, issues))
+    }
+
+    @Test
+    fun `the completable host prefix ranks first`() {
+        // Fewer visits, but it is the entry the field's ghost text completes to, so a list
+        // that ranked it second would disagree with what the field already shows.
+        val host = entry("https://github.com/", title = "GitHub", visits = 2)
+        val deep = entry("https://github.com/risa-labs-inc/BossConsole/pulls", title = "Pull requests", visits = 37)
+
+        assertEquals(listOf(host.url, deep.url), rank("github.com", deep, host))
+    }
+
+    @Test
+    fun `an address match beats a title-only match`() {
+        val titleOnly = entry("https://example.com/watch", title = "Youtube tips and tricks", visits = 50)
+        val address = entry("https://www.youtube.com/", title = "YouTube", visits = 1)
+
+        assertEquals(listOf(address.url, titleOnly.url), rank("youtube", titleOnly, address))
+    }
+
+    @Test
+    fun `frecency breaks ties inside a tier`() {
+        val daily = entry("https://daily.example/", title = "Daily", visits = 5)
+        val once = entry("https://once.example/", title = "Once", visits = 1)
+
+        assertEquals(listOf(daily.url, once.url), rank("example", once, daily))
+    }
+
+    @Test
+    fun `a blank query matches nothing`() {
+        val any = entry("https://github.com/")
+
+        assertEquals(emptyList(), rank("", any))
+        assertEquals(emptyList(), rank("   ", any))
+    }
+
+    @Test
+    fun `matching ignores the scheme and www the entry was stored with`() {
+        assertEquals(
+            listOf("https://www.youtube.com/"),
+            rank("youtube.com", entry("https://www.youtube.com/", title = "YouTube")),
+        )
+    }
+
+    @Test
+    fun `an address prefix match ignores the stored path's casing`() {
+        // `canonicalUrlKey` lowercases the authority and leaves the path alone, so a
+        // case-sensitive tier dropped every mixed-case path the moment the user typed into
+        // it - and the top row then disagreed with the ghost text, which is case-insensitive.
+        val deep = entry("https://github.com/risa-labs-inc/BossConsole/pulls", title = "Pull requests")
+        val titleOnly = entry("https://example.com/x", title = "boss console notes", visits = 99)
+
+        assertEquals(listOf(deep.url), rank("github.com/risa-labs-inc/boss", titleOnly, deep))
+    }
+
+    @Test
+    fun `word start boundaries`() {
+        assertFalse(startsWord("", "loc"))
+        assertFalse(startsWord("lo", "loc"))
+        assertTrue(startsWord("loc", "loc"))
+        // A digit-to-uppercase step is a word start, same as lower-to-uppercase.
+        assertTrue(startsWord("api/v2Beta", "beta"))
+    }
+
+    @Test
+    fun `pasting a full URL finds the entry`() {
+        // The entries are matched in canonical form, so a pasted address - scheme, `www.`
+        // and all - was one term longer than any address and matched nothing at all.
+        val page = entry("https://www.youtube.com/watch?v=abc", title = "A video")
+
+        assertEquals(listOf(page.url), rank("https://www.youtube.com/watch?v=abc", page))
+        assertEquals(listOf(page.url), rank("https://youtube.com/watch", page))
+    }
+
+    @Test
+    fun `a mid-word match is answered, but underneath every word-start match`() {
+        val midWordOnly = entry("https://cdn.example.com/youtubedl", title = "yt-dlp", visits = 99)
+        val wordStart = entry("https://tube.example.com/", title = "Tube", visits = 1)
+
+        // "tube" is buried inside "youtubedl" and starts a word in "tube.example.com". Word
+        // starts alone dropped the first entirely; ninety-nine visits do not lift it above
+        // the second.
+        assertEquals(listOf(wordStart.url, midWordOnly.url), rank("tube", midWordOnly, wordStart))
+    }
+
+    @Test
+    fun `the mid-word fallback does not resurrect query-string noise above a real hit`() {
+        val real = entry("https://localhost:3000/", title = "Dev")
+        val oauth =
+            entry(
+                "https://claude.ai/oauth/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A61673",
+                title = "Claude",
+                visits = 20,
+            )
+
+        // The OAuth URL only matches mid-word, so it sits below - which is the whole point
+        // of the tier rather than of dropping it.
+        assertEquals(listOf(real.url, oauth.url), rank("localhost", real, oauth))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryMatchingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryMatchingTest.kt
@@ -155,6 +155,17 @@ class HistoryMatchingTest {
     }
 
     @Test
+    fun `a row with no suggestable host is never answered`() {
+        // The gate `addUrl` applies to new visits, applied here to what gets SUGGESTED. It
+        // cannot be applied on load - `loadHistory` feeds the map `saveHistory` writes back -
+        // so a `javascript:` or `file://` row in a legacy or tampered file has to be dropped
+        // at match time instead. It is not something to offer as a completion the field fills
+        // in and Enter opens.
+        assertEquals(emptyList(), rank("alert", entry("javascript:alert(1)", title = "note", visits = 99)))
+        assertEquals(emptyList(), rank("notes", entry("file:///Users/me/notes.html", title = "notes", visits = 99)))
+    }
+
+    @Test
     fun `the mid-word fallback does not resurrect query-string noise above a real hit`() {
         val real = entry("https://localhost:3000/", title = "Dev")
         val oauth =

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryMatchingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryMatchingTest.kt
@@ -166,6 +166,30 @@ class HistoryMatchingTest {
     }
 
     @Test
+    fun `a term may match the title alone while another matches the address alone`() {
+        // The second clause of `wordStart` - per-term fallback to the title - is otherwise
+        // only reached in cases where the whole query already matched the address, so an
+        // implementation that ignored it entirely would still pass.
+        val page = entry("https://github.com/risa-labs-inc/BossConsole", title = "Pull requests")
+
+        assertEquals(listOf(page.url), rank("boss requests", page))
+        // And a term matching NEITHER field still rejects the entry.
+        assertEquals(emptyList(), rank("boss requests milestones", page))
+    }
+
+    @Test
+    fun `a term past the scanned address cap is not answered`() {
+        // The address is capped for the scan the same way the title is: a stored URL is at
+        // least as attacker-influenceable, and an OAuth URL runs to thousands of characters
+        // that `startsWord` walked per term per keystroke.
+        val padded = entry("https://example.com/" + "a/".repeat(300) + "needle", title = "")
+
+        assertEquals(emptyList(), rank("needle", padded))
+        // The entry still matches on the part that is scanned.
+        assertEquals(listOf(padded.url), rank("example.com", padded))
+    }
+
+    @Test
     fun `a userinfo URL is not suggested, the same way it is not completed`() {
         // `java.net.URL` reads the host as what follows the `@` while `canonicalUrlKey` keeps
         // the userinfo, so this passed the suggestable-host gate AND matched "git" at index

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryMatchingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryMatchingTest.kt
@@ -166,6 +166,18 @@ class HistoryMatchingTest {
     }
 
     @Test
+    fun `a userinfo URL is not suggested, the same way it is not completed`() {
+        // `java.net.URL` reads the host as what follows the `@` while `canonicalUrlKey` keeps
+        // the userinfo, so this passed the suggestable-host gate AND matched "git" at index
+        // 0. The field's ghost text already refused it; the list beside it did not, and its
+        // rows are clickable - so half the surface was hardened and half was not.
+        val spoof = entry("https://github.com@evil.example/", title = "GitHub", visits = 99)
+
+        assertEquals(emptyList(), rank("git", spoof))
+        assertEquals(emptyList(), rank("github", spoof))
+    }
+
+    @Test
     fun `the mid-word fallback does not resurrect query-string noise above a real hit`() {
         val real = entry("https://localhost:3000/", title = "Dev")
         val oauth =

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
@@ -198,7 +198,25 @@ class UrlHistoryManagerTest {
         repeat(1_400) { UrlHistoryManager.addUrl("https://site$it.example/", "Site $it") }
 
         val held = UrlHistoryManager.getSuggestions("example", limit = 10_000)
+        // Both bounds matter. `<= 1_200` alone passes if a prune only ever trims to the
+        // slack; `< 1_400` alone passes if it trims by a single entry. Together they say
+        // something actually cut back past the cap. `the prune waits for the slack` below
+        // pins the exact shape.
         assertTrue(held.size <= 1_200, "expected the store to be pruned, held ${held.size}")
+        assertTrue(held.size < 1_400, "expected a prune to have happened at all, held ${held.size}")
+    }
+
+    @Test
+    fun `a negative limit returns nothing instead of throwing`() {
+        // `rankMatches` ends in `take`, which rejects a negative count, and this function is
+        // what `DesktopUrlHistoryProvider` calls - so the limit arrives from plugin code
+        // through `PluginContext.urlHistoryProvider`. Floored at the function that throws
+        // rather than at any one call site.
+        UrlHistoryManager.addUrl("https://example.com/", "Example")
+
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("example", limit = -1))
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("example", limit = 0))
+        assertEquals(1, UrlHistoryManager.getSuggestions("example", limit = 1).size)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
@@ -207,6 +207,20 @@ class UrlHistoryManagerTest {
     }
 
     @Test
+    fun `matching still finds an entry after the store has pruned past the slack`() {
+        // The prune and the matcher are tested apart; this is the interaction that makes the
+        // cap load-bearing. It also drives the memoized fact table past its own bound, which
+        // now retains what the store holds rather than emptying itself.
+        UrlHistoryManager.addUrl("https://needle.example/page", "Needle")
+        repeat(1_400) { UrlHistoryManager.addUrl("https://filler$it.example/", "Filler $it") }
+        // Kept fresh so frecency does not evict the entry the assertion depends on.
+        UrlHistoryManager.addUrl("https://needle.example/page", "Needle")
+
+        val found = UrlHistoryManager.getSuggestions("needle.example")
+        assertEquals("https://needle.example/page", found.firstOrNull()?.url)
+    }
+
+    @Test
     fun `a negative limit returns nothing instead of throwing`() {
         // `rankMatches` ends in `take`, which rejects a negative count, and this function is
         // what `DesktopUrlHistoryProvider` calls - so the limit arrives from plugin code

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
@@ -178,4 +178,24 @@ class UrlHistoryManagerTest {
         assertEquals("Persisted", reloaded.title)
         assertNull(UrlHistoryManager.getSuggestions("nothing-here").firstOrNull())
     }
+
+    @Test
+    fun `a stored title is capped`() {
+        // A page controls its own `document.title`, and every stored title is word-scanned
+        // on every keystroke of every URL field.
+        UrlHistoryManager.addUrl("https://example.com/", "t".repeat(5_000))
+
+        val stored = UrlHistoryManager.getSuggestions("example.com").single()
+        assertEquals(256, stored.title.length)
+    }
+
+    @Test
+    fun `the in-memory store is capped, not just the file`() {
+        // The 1000 cap used to apply only on the way to disk, so the map grew for the whole
+        // life of the process - and the per-keystroke match cost grows with it.
+        repeat(1_400) { UrlHistoryManager.addUrl("https://site$it.example/", "Site $it") }
+
+        val held = UrlHistoryManager.getSuggestions("example", limit = 10_000)
+        assertTrue(held.size <= 1_200, "expected the store to be pruned, held ${held.size}")
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
@@ -218,9 +218,19 @@ class UrlHistoryManagerTest {
 
         // "needle" starts at index 301, past the 256-character cap, so it is not scanned.
         assertEquals(emptyList(), UrlHistoryManager.getSuggestions("needle"))
-        // And the entry itself is untouched: the cap bounds the scan, it does not rewrite
-        // the user's history.
-        assertEquals(title, UrlHistoryManager.getSuggestions("example.com").single().title)
+        // The suggestion is capped too, not just the scan: `maxLines = 1` truncates what a
+        // dropdown row draws, never what Compose measures.
+        assertEquals(
+            256,
+            UrlHistoryManager
+                .getSuggestions("example.com")
+                .single()
+                .title.length,
+        )
+        // And the store itself is untouched, which is why the cap is not applied on load:
+        // a save writes back what a load read.
+        runBlocking { UrlHistoryManager.saveHistory() }
+        assertTrue(tempFile.readText().contains(title), "a save must not rewrite the stored title")
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
@@ -14,6 +14,11 @@ import kotlin.test.assertTrue
  * recorded, how one page recorded under two spellings collapses, and the ordering the URL
  * bar actually sees.
  *
+ * The memoized URL fact table inside `UrlHistoryManager.kt` is process-global and is NOT
+ * reset between tests. That is safe because it is keyed by the URL string and derived from
+ * nothing else, so an entry left by another test can only be re-derived to the same value -
+ * do not read it as per-store state.
+ *
  * [UrlHistoryManager.historyFile] is pointed at a scratch file so no test here reads or
  * writes the developer's own history. The teardown does re-read it, deliberately:
  * [UrlHistoryManager] is a process-global store, and leaving it holding a deleted scratch

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
@@ -14,8 +14,10 @@ import kotlin.test.assertTrue
  * recorded, how one page recorded under two spellings collapses, and the ordering the URL
  * bar actually sees.
  *
- * [UrlHistoryManager.historyFile] is pointed at a scratch file so this exercises the real
- * read/write path without reading or writing the developer's own history.
+ * [UrlHistoryManager.historyFile] is pointed at a scratch file so no test here reads or
+ * writes the developer's own history. The teardown does re-read it, deliberately:
+ * [UrlHistoryManager] is a process-global store, and leaving it holding a deleted scratch
+ * file would strand every other test in the run.
  */
 class UrlHistoryManagerTest {
     private lateinit var tempFile: File
@@ -197,5 +199,63 @@ class UrlHistoryManagerTest {
 
         val held = UrlHistoryManager.getSuggestions("example", limit = 10_000)
         assertTrue(held.size <= 1_200, "expected the store to be pruned, held ${held.size}")
+    }
+
+    @Test
+    fun `a title from an older file is only scanned up to the cap`() {
+        // `addUrl` caps what it STORES, but a file written before that cap existed still
+        // holds whatever the page put in its `document.title` - and matching is the loop the
+        // cap exists to bound. Capping in `loadHistory` instead would be destructive: that
+        // map is what `saveHistory` writes back.
+        val title = "x".repeat(300) + " needle"
+        tempFile.writeText(
+            """
+            [{"url": "https://example.com/", "title": "$title",
+              "domain": "example.com", "visitCount": 1, "lastVisited": $NOW}]
+            """.trimIndent(),
+        )
+        UrlHistoryManager.loadHistory()
+
+        // "needle" starts at index 301, past the 256-character cap, so it is not scanned.
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("needle"))
+        // And the entry itself is untouched: the cap bounds the scan, it does not rewrite
+        // the user's history.
+        assertEquals(title, UrlHistoryManager.getSuggestions("example.com").single().title)
+    }
+
+    @Test
+    fun `the prune waits for the slack and then cuts back to the cap`() {
+        // The test above only shows that SOMETHING prunes. What makes it affordable is the
+        // shape: pruning is a sort, so it must not run on every visit past the cap, and when
+        // it does run it has to cut all the way back - otherwise the next visit sorts again.
+        fun store(size: Int) =
+            (1..size)
+                .associate { i ->
+                    // Keyed the way the store keys itself, or `retainAll` drops everything.
+                    distinctPageKey("https://site$i.example/") to
+                        UrlHistoryEntry(
+                            url = "https://site$i.example/",
+                            title = "Site $i",
+                            domain = "site$i.example",
+                            visitCount = i,
+                            lastVisited = NOW,
+                        )
+                }.toMutableMap()
+
+        val atSlack = store(1_200)
+        pruneIfOversized(atSlack, NOW)
+        assertEquals(1_200, atSlack.size, "the slack is what keeps pruning amortised")
+
+        val pastSlack = store(1_201)
+        pruneIfOversized(pastSlack, NOW)
+        assertEquals(1_000, pastSlack.size, "a prune has to cut to the cap, not to the slack")
+        // What survives is the best-ranked tail, not an arbitrary 1000.
+        assertTrue(distinctPageKey("https://site1201.example/") in pastSlack)
+        assertTrue(distinctPageKey("https://site1.example/") !in pastSlack)
+    }
+
+    private companion object {
+        /** A fixed clock, so ranking inside a prune does not depend on when the test runs. */
+        const val NOW = 1_800_000_000_000L
     }
 }


### PR DESCRIPTION
Typing in the new-tab dialog's URL field offered no inline completion, the "Search Google for …" row was pinned above every history match, and matching was `contains` anywhere in the domain, URL or title.

Reported symptom: *"if my text matches any tab from history, it should suggest like the address bar of chrome does"* — with the follow-up that the Google row sat on top and the gray autofill never appeared.

## Why it looked platform-specific

It isn't. There is no OS branch anywhere in this path — `composeApp` has three source sets, `UrlHistoryProvider` has one `actual`, and neither the dialog nor the history manager mentions `os.name`. What differed was the **widget**: the browser tab's address bar (`FluckBrowserTabComponent`, fluck-browser plugin) has had gray ghost-text autocomplete all along. The new-tab dialog never had it, on either platform.

Verified separately that history lookup was healthy the whole time — 309 `UrlHistoryEntry` objects live in the running app's heap, and the real 303-entry `~/.boss/browser-history.json` returned 10 hits for `git`.

## Inline completion

Same gray ghost text as the address bar, accepted with the same gestures: **Tab**, or **Right at the very end** of the input. Drawn with a `VisualTransformation` and never part of the field's value, so Backspace deletes a character the user typed rather than first clearing a completion they never asked for.

One derived `urlToOpen` is read by Enter, the Done action and the confirm button — ranked highlighted row > ghost completion > typed text — so no two commit paths can disagree about where the field goes. `UrlCompletion` keeps the displayed text and the navigation target apart, because they are not the same string: display is canonical so it lines up with what you type, target is what history recorded.

Completion rules, each one earned:

- a **host** completes before a path, so three characters do not fill in a deep PR URL
- once the typed text names a host at all (any `.` or `:`), a completion may only add a **path under that host, never change it**
- **paths match case-sensitively** — splicing typed casing onto a stored tail produced `…/bossConsole/pulls`, an address in neither history nor the field
- candidates with a query string or invisible characters are refused
- a deletion does not re-complete, an accepted completion is not extended, and Escape cancels the proposal as well as the list

## Matching

`rankMatches` works per term now: every whitespace-separated term must match, in the address or the title, and a **word-start** match outranks a **mid-word** one. Word starts alone fixed the noise but lost `tube` → youtube.com, so mid-word matches are answered in a tier underneath.

Against the real history file:

| you type | before | after |
|---|---|---|
| `loc` | a GitHub PR titled "…block…", then an OAuth `redirect_uri` | LocalFlow repo + searches |
| `localhost` | that OAuth URL again | nothing (there are no localhost visits in it) |
| `git` | deep PR page | `github.com`, then its pages by frecency |
| `boss pulls` | nothing | `github.com/risa-labs-inc/BossConsole/pulls` |
| `tube` | youtube.com | youtube.com (ranked under word-start hits) |

A pasted URL is canonicalised before matching — otherwise the whole paste was one term longer than any address and matched nothing.

This is the only query matcher in the tree, and the address bar calls it through `DesktopUrlHistoryProvider`, so **both** suggestion lists improve.

## Bounds

The 1000-entry cap applied only when writing to disk, so the in-memory map grew for the life of the process while per-keystroke cost went up roughly tenfold. Now pruned in memory too, titles capped at 256 chars (a page controls its own title), lookup moved off the composition thread, and the per-term address scan computed once instead of twice — about a third of the matching pass.

## Review

Ran `/review`: 5 specialists plus a red-team pass, 21 findings actioned. The ones worth naming:

- **Tab trapped keyboard focus** in the field, putting the dialog's own buttons out of reach
- **Autocomplete hijack** — a completion could extend a typed host into a different domain, so one drive-by visit to a lookalike was enough
- **Navigation target could diverge from the displayed text** across the debounce window
- **A selection-only edit** (a click, an arrow key, Cmd+C) silently disarmed the completion
- **A destructive `loadHistory`** that would have purged unparseable entries from the user's history file on the next save

## Second round

A further eight findings, all fixed in `4820dd51` rather than deferred:

- **Accepting re-opened the dropdown** one debounce later. The accept writes into `urlText`, which keys the suggestion effect. Both Escape and the accept now record the text the dismissal was made against, and the effect consults it after the delay - which also closes the case of a lookup already in flight landing under Escape.
- **Userinfo in a stored URL could reach the field as a host.** `github.com@evil.example` extended a typed `git` while the host was still open, and one Tab took it.
- **`encodeUrlParameter` let `%` and `+` through.** `100%` went out as a truncated escape, `a%26b` reached Google as `a&b`, `a + b` as `a+++b`.
- **A typed scheme turned the ghost off**, on the one input where the ghost and the dropdown are easiest to compare. The typed text is normalized the way a pasted query already was.
- **A query string disqualified the entry's host, not just its address.** Both reasons for the rule are about the address; its host is still offered.
- **The title cap was enforced on write but not on read**, so a file from an older build put an unbounded title in the per-keystroke scan.
- **Matching re-parsed every entry per keystroke.** `canonicalUrlKey` and `suggestableHost` depend on nothing but the URL string and are memoized on it.
- **Two definitions of "extends"**, one case-sensitive and one not, in the pair of functions that exist to keep the drawn text and the opened address together.

## Third round

Five more, all fixed in `86492498`:

- **A highlighted row survived everything that took its list away.** `urlToOpen` reads the row ahead of the ghost, and the only resets were inside the debounced effect. Arrow into the list and press Escape, and the confirm button still opened row 0 - a page no longer on screen. Arrow in and keep typing, and Enter inside the debounce window took a row from the previous list. The delete handler had the same root cause from the other side: the list is filtered in place, so rows shift under an index still pointing at one.
- **Userinfo URLs were refused by the completion and still offered by the list.** `java.net.URL` reads the host of `https://github.com@evil.example/` as `evil.example`, so it passed the host gate; `canonicalUrlKey` keeps the userinfo, so it matched a typed `git` at index 0. Clicking the row went straight there. Hardening the ghost alone hardened half a surface.
- **The typed side and the candidate side disagreed on "invisible".** The typed side used `Char.isWhitespace`, which counts U+00A0; the candidate side checked only controls and `FORMAT`. One predicate now, used by both.
- **The matcher bounded what it scanned but not what it returned.** `maxLines = 1` truncates what a row draws, never what Compose measures.
- **`limit - 1` could reach `take(-1)`**, which throws.

Also noted the accessibility cost of the ghost being a `VisualTransformation` in its KDoc.

15 further tests across both rounds. Every one was run against the unfixed code first and fails there.

Deliberately not addressed here: the search row can sit below the dropdown's fold with a busy history (a real query is long enough or has a space, both of which suppress completion, and the list scrolls); IDN/homoglyph lookalikes need a confusables policy, not a character-class filter; and this dropdown's rows still differ from the address bar's in icon and delete-button behaviour.

## Verification

- 342 test classes / **3484 tests**, 0 failures
- ktlint + detekt clean, **no baseline additions**
- 45 new tests covering completion rules, ranking tiers, the ghost's offset mapping, the accept/suppress/Escape/arrow interactions driven through a real composition, and every case named in the two review rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


