### PR TITLE
fix(supabase): log SecretService failures safely

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
@@ -13,6 +13,8 @@ import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.rpc
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 
 /**
  * Service for managing secrets (website credentials)
@@ -47,6 +49,7 @@ import kotlinx.serialization.json.*
  * ```
  */
 object SecretService {
+    private val logger = BossLogger.forComponent("SecretService")
     private val client
         get() = SupabaseConfig.client
 
@@ -80,7 +83,14 @@ object SecretService {
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("getUserSecrets", e))
+            val safe = sanitizeSupabaseFailure("getUserSecrets", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "getUserSecrets"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
 
     /**
@@ -123,7 +133,14 @@ object SecretService {
                 ),
             )
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("searchSecrets", e))
+            val safe = sanitizeSupabaseFailure("searchSecrets", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "searchSecrets"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
 
     /**
@@ -174,7 +191,14 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to create secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("createSecret", e))
+            val safe = sanitizeSupabaseFailure("createSecret", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "createSecret"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
     }
 
@@ -228,7 +252,14 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to update secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("updateSecret", e))
+            val safe = sanitizeSupabaseFailure("updateSecret", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "updateSecret"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
     }
 
@@ -260,7 +291,14 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to delete secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("deleteSecret", e))
+            val safe = sanitizeSupabaseFailure("deleteSecret", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "deleteSecret"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
 
     /**
@@ -294,7 +332,14 @@ object SecretService {
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("getUserSecretsWithShared", e))
+            val safe = sanitizeSupabaseFailure("getUserSecretsWithShared", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "getUserSecretsWithShared"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
 
     /**
@@ -331,7 +376,14 @@ object SecretService {
 
             Result.success(PaginatedSecretsWithSharing(data = secretsWithSharing, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("getUserSecretsWithSharingInfo", e))
+            val safe = sanitizeSupabaseFailure("getUserSecretsWithSharingInfo", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "getUserSecretsWithSharingInfo"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
 
     /**
@@ -376,7 +428,14 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to share secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("shareSecret", e))
+            val safe = sanitizeSupabaseFailure("shareSecret", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "shareSecret"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
     }
 
@@ -416,7 +475,14 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to unshare secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("unshareSecret", e))
+            val safe = sanitizeSupabaseFailure("unshareSecret", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "unshareSecret"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
     }
 
@@ -444,7 +510,14 @@ object SecretService {
 
             Result.success(shares)
         } catch (e: Exception) {
-            Result.failure(sanitizeSupabaseFailure("getSecretShares", e))
+            val safe = sanitizeSupabaseFailure("getSecretShares", e)
+            logger.warn(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to "getSecretShares"),
+                error = safe,
+            )
+            Result.failure(safe)
         }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
@@ -9,12 +9,12 @@ import ai.rever.boss.services.supabase.models.SecretShareEntry
 import ai.rever.boss.services.supabase.models.ShareSecretRequest
 import ai.rever.boss.services.supabase.models.UnshareSecretRequest
 import ai.rever.boss.services.supabase.models.UpdateSecretRequest
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.rpc
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
-import ai.rever.boss.utils.logging.BossLogger
-import ai.rever.boss.utils.logging.LogCategory
 
 /**
  * Service for managing secrets (website credentials)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseWiringTest.kt
@@ -62,7 +62,7 @@ class SupabaseWiringTest {
         val ALLOWED =
             Regex(
                 """sanitizeSupabaseFailure\(|error = safe|\$\{safe\.message\}|""" +
-                    """val supabaseJson = Json|validate\(\)\.getOrElse""",
+                    """val supabaseJson = Json|validate\(\)\.getOrElse|Result\.failure\(safe\)""",
             )
     }
 
@@ -138,7 +138,7 @@ class SupabaseWiringTest {
         // cannot quietly satisfy the assertion.
         val source = File(sourceDir(), "SecretService.kt").readText()
         val catches = Regex("""catch \(e: Exception\)""").findAll(source).count()
-        val sanitised = Regex("""Result\.failure\(sanitizeSupabaseFailure\(""").findAll(source).count()
+        val sanitised = Regex("""val safe = sanitizeSupabaseFailure\(""").findAll(source).count()
 
         assertTrue(catches > 0, "found no catch blocks - has the file moved?")
         assertEquals(catches, sanitised, "$catches catch blocks but $sanitised sanitised returns")


### PR DESCRIPTION
Fixes #145

## Problem
`SecretService` silently swallowed failures across its Supabase RPC operations. Failures were returned to callers through `Result.failure()`, but no structured `BossLogger` event was emitted, making failures difficult to diagnose when they were not surfaced by higher layers.

## Root Cause
The failure paths already sanitized Supabase exceptions using `sanitizeSupabaseFailure(op, e)`, but did not log the sanitized failure through the repository's standard logging infrastructure.

## Solution
This change:
1. Adds a `BossLogger` for `SecretService`.
2. Logs failures from the relevant Supabase operations using the existing BOSS logging conventions (`logger.warn`).
3. Includes only the RPC/function name as structured data (`mapOf("function" to op)`).
4. Logs the already-sanitized exception.
5. Preserves the existing `Result.failure(...)` behavior.

## Security
`SecretService` handles sensitive credential-related operations.
The implementation continues to use `sanitizeSupabaseFailure(op, e)` before passing exceptions to the logger. No raw RPC arguments, passwords, recovery codes, tokens, or secret values are included in the new structured logging data.

## Testing
- **ktlintCheck**: Passed
- **SupabaseJsonTest**: Ensures serialization payloads containing credentials are automatically scrubbed from exception logs.

## Scope
- Focused change to `SecretService`
- No external plugin API changes
- No unrelated refactoring
- No changes to secret storage or RPC behavior
