### PR TITLE
fix(plugins): make class loading parallel-safe

### DIFF
--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
@@ -61,6 +61,11 @@ class PluginClassLoader(
     companion object {
         private val logger = BossLogger.forComponent("PluginClassLoader")
 
+        // Use one lock per class name instead of serialising unrelated plugin class loads.
+        init {
+            registerAsParallelCapable()
+        }
+
         /**
          * Weak process-wide registry of every constructed plugin classloader,
          * across all windows' managers (managers are per-window; crash
@@ -309,24 +314,35 @@ class PluginClassLoader(
         name: String,
         resolve: Boolean,
     ): Class<*> {
-        // Try to find in plugin JAR first
-        try {
-            val clazz = findClass(name)
-            if (resolve) {
-                resolveClass(clazz)
+        // ClassLoader.loadClass normally owns this lock, but the child-first path cannot delegate
+        // to it without losing its loading order. Re-check after acquiring the same JVM lock so
+        // two plugin threads cannot both miss findLoadedClass and call defineClass for one name.
+        synchronized(getClassLoadingLock(name)) {
+            val loadedClass = findLoadedClass(name)
+            if (loadedClass != null) {
+                if (resolve) {
+                    resolveClass(loadedClass)
+                }
+                return loadedClass
             }
-            return clazz
-        } catch (notInPluginJar: ClassNotFoundException) {
-            // One read: _state can move UNLOAD_IN_PROGRESS -> UNLOADED under us,
-            // and the message must not disagree with the structured field.
-            val stateAtRefusal = state
-            if (stateAtRefusal == ClassLoaderState.ACTIVE) {
-                // Fall back to parent. Deliberately unlogged: this is the
-                // expected delegation path for every host-provided class a
-                // plugin touches, so logging here would flood at class-load
-                // time on a hot path.
-                return parent.loadClass(name)
-            }
+            // Try to find in plugin JAR first
+            try {
+                val clazz = findClass(name)
+                if (resolve) {
+                    resolveClass(clazz)
+                }
+                return clazz
+            } catch (notInPluginJar: ClassNotFoundException) {
+                // One read: _state can move UNLOAD_IN_PROGRESS -> UNLOADED under us,
+                // and the message must not disagree with the structured field.
+                val stateAtRefusal = state
+                if (stateAtRefusal == ClassLoaderState.ACTIVE) {
+                    // Fall back to parent. Deliberately unlogged: this is the
+                    // expected delegation path for every host-provided class a
+                    // plugin touches, so logging here would flood at class-load
+                    // time on a hot path.
+                    return parent.loadClass(name)
+                }
 
             // A closed URLClassLoader answers findClass() with
             // ClassNotFoundException for EVERY name, including the ones its own
@@ -348,25 +364,21 @@ class PluginClassLoader(
             // straggler thread made the late request (a Ktor worker, a
             // coroutine dispatcher, an AWT handler) and can tear that thread
             // down mid-teardown.
-            val refusal =
-                ClassNotFoundException(
-                    "Plugin classloader for '$pluginId' is $stateAtRefusal; refusing to resolve " +
-                        "'$name' against the host classloader. Something still referenced the " +
-                        "plugin after it was unloaded - that reference is the bug.",
-                    notInPluginJar,
-                )
-            // WARN, not ERROR: refusing is the correct outcome and teardown
-            // continues. The throwable is attached so the first entry for a name
-            // carries the straggler's stack; repeats drop to DEBUG so a retry
-            // loop cannot bury the shutdown log. Best effort — logging must
-            // never replace the refusal, which is the thing that has to
-            // propagate.
-            try {
-                logRefusal(refusedClassNames.add(name), pluginId, name, stateAtRefusal, refusal)
-            } catch (_: Throwable) {
-                // Logging can itself fail during shutdown; the refusal stands.
+                val refusal =
+                    ClassNotFoundException(
+                        "Plugin classloader for '$pluginId' is $stateAtRefusal; refusing to resolve " +
+                            "'$name' against the host classloader. Something still referenced the " +
+                            "plugin after it was unloaded - that reference is the bug.",
+                        notInPluginJar,
+                    )
+                // WARN, not ERROR: refusing is the correct outcome and teardown continues.
+                try {
+                    logRefusal(refusedClassNames.add(name), pluginId, name, stateAtRefusal, refusal)
+                } catch (_: Throwable) {
+                    // Logging can itself fail during shutdown; the refusal stands.
+                }
+                throw refusal
             }
-            throw refusal
         }
     }
 

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderConcurrencyTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderConcurrencyTest.kt
@@ -1,0 +1,67 @@
+package ai.rever.boss.plugin.loader
+
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/** Regression coverage for duplicate class definitions during concurrent plugin startup. */
+class PluginClassLoaderConcurrencyTest {
+    private val tempJars = mutableListOf<File>()
+
+    @AfterTest
+    fun cleanup() {
+        tempJars.forEach { it.delete() }
+    }
+
+    @Test
+    fun `concurrent loads of one plugin class return one definition`() {
+        val hostLoader = PluginClassLoaderConcurrencyTest::class.java.classLoader
+        val className = OwnedByPluginA::class.java.name
+        val resource = className.replace('.', '/') + ".class"
+        val jar = File.createTempFile("plugin-cl-concurrency-test", ".jar")
+        tempJars += jar
+        JarOutputStream(jar.outputStream()).use { out ->
+            out.putNextEntry(JarEntry(resource))
+            hostLoader.getResourceAsStream(resource)!!.use { it.copyTo(out) }
+            out.closeEntry()
+        }
+
+        val loader =
+            PluginClassLoader(
+                pluginId = "concurrency-test",
+                urls = arrayOf(jar.toURI().toURL()),
+                parent = hostLoader,
+            )
+        val workers = 16
+        val ready = CountDownLatch(workers)
+        val start = CountDownLatch(1)
+        val pool = Executors.newFixedThreadPool(workers)
+        try {
+            val futures = (0 until workers).map {
+                pool.submit<Class<*>> {
+                    ready.countDown()
+                    assertTrue(start.await(5, TimeUnit.SECONDS))
+                    loader.loadClass(className)
+                }
+            }
+            assertTrue(ready.await(5, TimeUnit.SECONDS))
+            start.countDown()
+
+            val loaded = futures.map { it.get(10, TimeUnit.SECONDS) }
+            val distinctClasses = loaded.distinct()
+            assertEquals(1, distinctClasses.size)
+            assertSame(loader, distinctClasses.single().classLoader)
+        } finally {
+            pool.shutdownNow()
+            loader.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This change makes `PluginClassLoader` safe under concurrent class loading.

The child-first loading path previously called `findClass(name)` without using the JVM class-loading lock. If multiple plugin threads requested the same class simultaneously, they could race into class definition and produce a duplicate-definition `LinkageError`.

The loader now:

- Registers as parallel-capable.
- Uses `getClassLoadingLock(name)` for per-class synchronization.
- Rechecks `findLoadedClass(name)` inside the lock.
- Preserves child-first loading.
- Preserves active-loader parent fallback.
- Preserves post-unload refusal behavior.
- Preserves class resolution semantics.

## Regression coverage

Added `PluginClassLoaderConcurrencyTest`, which releases 16 worker threads simultaneously against the same synthetic plugin class and verifies that all callers receive the same class definition from the plugin classloader.

## Validation

The complete plugin-loader desktop test suite passes:

```text
./gradlew :plugin-platform:plugin-loader:desktopTest --no-daemon --no-configuration-cache --console=plain
BUILD SUCCESSFUL
