### PR TITLE
Fix: Implement proper ISO timestamp parsing in PluginStoreClient

### DIFF
--- a/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreClient.kt
+++ b/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreClient.kt
@@ -673,10 +673,9 @@ data class PluginDetailResponse(
         }
 
     private fun parseTimestamp(timestamp: String): Long {
-        // Simple ISO timestamp parsing - return 0 if parsing fails
         return try {
-            // Remove timezone info and parse
-            0L // TODO: Implement proper timestamp parsing if needed
+            if (timestamp.isBlank()) return 0L
+            kotlinx.datetime.Instant.parse(timestamp).toEpochMilliseconds()
         } catch (_: Exception) {
             0L
         }


### PR DESCRIPTION
# 📋 Pull Request

## Description
This PR fixes issue #337 by replacing the unimplemented `parseTimestamp` method in `PluginStoreClient.kt` with a working implementation using `kotlinx.datetime.Instant`. Previously, all plugin timestamps defaulted to `0L` (the Unix epoch) when fetched from the remote store. 

## 🔄 Type of Change
- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (non-breaking change that adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 **Configuration change** (changes to build scripts, CI/CD, or project configuration)
- [ ] 📚 **Documentation** (documentation only changes)
- [ ] 🧹 **Refactoring** (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ **Performance improvement** (code change that improves performance)
- [ ] 🧪 **Tests** (adding missing tests or correcting existing tests)

## 📦 Version Impact
- [ ] **No version change needed**
- [x] **Patch version** (bug fixes, small improvements) - `x.x.+1`
- [ ] **Minor version** (new features, enhancements) - `x.+1.0`  
- [ ] **Major version** (breaking changes) - `+1.0.0`

## ✅ Testing Checklist

### 🧪 **Local Testing**
- [x] I have tested this change locally on my development machine
- [x] All existing tests pass with my changes
- [ ] I have added new tests for new functionality (if applicable)
- [x] I have verified the fix/feature works as intended

### 🖥️ **Platform Testing** 
- [x] 🍎 **macOS** - Tested and working
- [x] 🪟 **Windows** - Tested and working
- [x] 🐧 **Linux** - Tested and working
- [ ] 📱 **Mobile** (iOS/Android) - Tested if applicable
- [ ] 🌐 **Web** (WASM) - Tested if applicable

### 🏗️ **Build Verification**
- [x] Project builds successfully with my changes
- [x] No new build warnings introduced
- [x] Distribution packages (DMG/MSI/JAR) can be created successfully
- [ ] Version system integration tested (if version-related changes)

## 🔍 Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation (if needed)
- [x] My changes generate no new warnings or errors

## 🚀 CI/CD Integration
- [x] This PR will trigger appropriate CI/CD workflows
- [x] I understand that all status checks must pass before merging
- [x] I have considered the impact on our centralized version management system

## 📸 Screenshots/Media
### Before
Plugins retrieved from the Plugin Store showed an "Updated At" date reflecting `Jan 1, 1970` due to the hardcoded `0L` return.

### After  
Plugins in the Toolbox UI correctly show their most recent timestamp as provided by the remote backend API.

## 🔗 Related Issues
Fixes #337

## 📝 Additional Context

### 🎯 **Motivation and Context**
The `parseTimestamp` method had a `TODO` and simply bypassed parsing by returning `0L`. This broke the accuracy of plugin metadata displayed across the UI.

### 🧠 **Implementation Details**
Replaced the `0L` return with standard KMP `kotlinx.datetime.Instant.parse(timestamp).toEpochMilliseconds()`. Handled blank strings to avoid exceptions.

### ⚠️ **Breaking Changes**
None.

### 🔮 **Future Considerations**
We may want to add Unit Tests for this particular `PluginStoreClient` method to ensure invalid backend dates continue to be caught by the standard exception handler.

## 👀 Review Focus Areas
- [x] **Logic and Algorithm**: Core functionality and business logic
- [ ] **Performance**: Potential performance implications
- [ ] **Security**: Security considerations and best practices  
- [ ] **Platform Compatibility**: Cross-platform compatibility
- [x] **User Experience**: UI/UX improvements or changes
- [ ] **Documentation**: Accuracy and completeness of documentation

## 🚨 Pre-merge Checklist
- [x] All conversations have been resolved
- [x] Code has been rebased on latest main branch
- [x] Commit messages are clear and descriptive
- [x] PR title accurately describes the change
- [x] Ready for production deployment
