### PR TITLE
Let an unpublished plugin be published again

### DIFF
--- a/supabase/functions/plugin-store/routes/publish.ts
+++ b/supabase/functions/plugin-store/routes/publish.ts
@@ -13,7 +13,7 @@ import {
   PublishFromGitHubMetadataResponseSchema,
   ErrorResponseSchema
 } from "../types/schemas.ts"
-import { getPlugin, createPlugin, setPluginTags, getPluginById, getPluginOrgId, updatePlugin } from "../services/plugins.ts"
+import { getPluginForPublish, createPlugin, setPluginTags, getPluginById, getPluginOrgId, updatePlugin } from "../services/plugins.ts"
 import {
   authorizeExistingPluginPublish,
   authorizeNewPluginPublish,
@@ -138,8 +138,9 @@ publish.openapi(publishPluginRoute, async (ctx) => {
       return ctx.json({ success: false, error: permCheck.error }, 400)
     }
 
-    // Check if plugin ID already exists
-    const existing = await getPlugin(supabase, body.pluginId)
+    // Check if plugin ID already exists. Must see unpublished rows too: they still hold the
+    // unique plugin_id index, so missing one here turns a clean 400 into a 23505 on insert.
+    const existing = await getPluginForPublish(supabase, body.pluginId)
     if (existing) {
       return ctx.json({ success: false, error: 'Plugin ID already exists' }, 400)
     }
@@ -293,8 +294,9 @@ publish.openapi(publishVersionRoute, async (ctx) => {
     }
     const user = auth.user
 
-    // Get plugin
-    const plugin = await getPlugin(supabase, pluginId)
+    // Get plugin, unpublished rows included: gating on the storefront's published filter here
+    // made an unpublished plugin look absent and 404 its owner's version publishes.
+    const plugin = await getPluginForPublish(supabase, pluginId)
     if (!plugin) {
       return ctx.json({ success: false, error: 'Plugin not found' }, 404)
     }
@@ -706,8 +708,8 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
       return ctx.json({ success: false, error: permCheck.error }, 400)
     }
 
-    // Check if plugin already exists
-    const existingPlugin = await getPlugin(supabase, manifest.pluginId)
+    // Check if plugin already exists, unpublished rows included - see getPluginForPublish.
+    const existingPlugin = await getPluginForPublish(supabase, manifest.pluginId)
     let pluginUuid: string
     let isNewPlugin = false
 
@@ -733,6 +735,16 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
 
       pluginUuid = existingPlugin.id
 
+      // Publishing a version is an explicit request to be in the store, so an unpublished row is
+      // restored here. Without this the lookup fix alone would return 200 while leaving the
+      // plugin invisible, which is a worse failure than the 500 it replaced. Nothing in this
+      // function ever sets published = false (admin delete is a hard delete), so this cannot be
+      // undoing a moderation action taken through the product; it is logged so an out-of-band
+      // unpublish is not silently reversed.
+      if (!existingPlugin.published) {
+        console.log(`Re-publishing previously unpublished plugin ${manifest.pluginId}`)
+      }
+
       // Update plugin metadata from manifest
       await updatePlugin(supabase, pluginUuid, {
         displayName: manifest.displayName,
@@ -741,7 +753,8 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
         iconUrl: manifest.iconUrl,
         type: (manifest.type as string || 'panel').toLowerCase(),
         apiVersion: manifest.apiVersion,
-        requiredPermissions: manifest.requiredPermissions || []
+        requiredPermissions: manifest.requiredPermissions || [],
+        published: true
       })
     } else {
       // Create new plugin
@@ -1023,8 +1036,8 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
       return ctx.json({ success: false, error: permCheck.error }, 400)
     }
 
-    // Check if plugin already exists
-    const existingPlugin = await getPlugin(supabase, manifest.pluginId)
+    // Check if plugin already exists, unpublished rows included - see getPluginForPublish.
+    const existingPlugin = await getPluginForPublish(supabase, manifest.pluginId)
     let pluginUuid: string
     let isNewPlugin = false
 
@@ -1049,13 +1062,19 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
 
       pluginUuid = existingPlugin.id
 
+      // Same republish rule as the /github path above.
+      if (!existingPlugin.published) {
+        console.log(`Re-publishing previously unpublished plugin ${manifest.pluginId}`)
+      }
+
       await updatePlugin(supabase, pluginUuid, {
         displayName: manifest.displayName,
         description: manifest.description,
         homepageUrl: body.githubUrl,
         type: ((manifest.type as string) || 'panel').toLowerCase(),
         apiVersion: manifest.apiVersion,
-        requiredPermissions: manifest.requiredPermissions || []
+        requiredPermissions: manifest.requiredPermissions || [],
+        published: true
       })
     } else {
       isNewPlugin = true

--- a/supabase/functions/plugin-store/services/plugins.ts
+++ b/supabase/functions/plugin-store/services/plugins.ts
@@ -100,6 +100,42 @@ export async function searchPlugins(
 }
 
 /**
+ * Look up a plugin by manifest id for the PUBLISH paths, including unpublished rows.
+ *
+ * getPlugin() goes through the get_plugin_with_stats RPC, whose body ends in
+ * `WHERE p.published = true`. That is right for the storefront and wrong for deciding
+ * create-vs-update on publish: an unpublished row is invisible to that lookup while still
+ * occupying the unique plugin_id index, so the caller took the create branch and the INSERT
+ * failed with 23505, surfaced to publishers as "Plugin ID already exists" on an HTTP 500.
+ * The effect was that an unpublished plugin could never be published again by any route.
+ *
+ * Deliberately a direct table read rather than a widened RPC: get_plugin_with_stats backs the
+ * public storefront, and dropping its published filter there would list unpublished plugins to
+ * everyone.
+ */
+export async function getPluginForPublish(
+  supabase: SupabaseClient,
+  pluginId: string
+): Promise<{ id: string; authorId: string; published: boolean } | null> {
+  const { data, error } = await supabase
+    .from('plugins')
+    .select('id, author_id, published')
+    .eq('plugin_id', pluginId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('Error getting plugin for publish:', error)
+    throw new Error(`Failed to get plugin: ${error.message}`)
+  }
+
+  if (!data) {
+    return null
+  }
+
+  return { id: data.id, authorId: data.author_id, published: data.published }
+}
+
+/**
  * Get plugin details by plugin ID string
  */
 export async function getPlugin(
@@ -337,6 +373,7 @@ export async function updatePlugin(
     type?: string
     apiVersion?: string
     requiredPermissions?: string[]
+    published?: boolean
   }
 ): Promise<void> {
   const updateData: Record<string, unknown> = {}
@@ -348,6 +385,7 @@ export async function updatePlugin(
   if (updates.type !== undefined) updateData.type = updates.type
   if (updates.apiVersion !== undefined) updateData.api_version = updates.apiVersion
   if (updates.requiredPermissions !== undefined) updateData.required_permissions = updates.requiredPermissions
+  if (updates.published !== undefined) updateData.published = updates.published
 
   if (Object.keys(updateData).length === 0) {
     return // Nothing to update


### PR DESCRIPTION
## The bug

`getPlugin()` goes through the `get_plugin_with_stats` RPC, whose body ends in `WHERE p.published = true` (`supabase/migrations/20260630000000_plugin_install_permissions.sql:152`). That filter is right for the storefront and wrong for the publish paths, which used the same lookup to decide between creating and updating a plugin.

An unpublished row is invisible to that lookup but still occupies the unique `plugin_id` index. So publish took the create branch, the INSERT failed with Postgres `23505`, and `services/plugins.ts` turned it into `throw new Error('Plugin ID already exists')`, which the route surfaced as **HTTP 500**.

The net effect: **once a plugin is unpublished, no route can ever publish it again.**

## How it showed up

`boss-plugin-rparecorder` failed on every release attempt with:

```
Response: {"success":false,"error":"Plugin ID already exists"}
##[error]Failed to publish to BOSS Store (HTTP 500)
```

It looked like a flaky server, which is partly why a unique violation reported as a 500 is worth noting separately. It is deterministic, and retrying can never clear it.

## The fix

Add `getPluginForPublish`, a direct table read on `plugins` with no `published` filter, and use it at **all four** publish decision sites:

| site | route |
|---|---|
| `publish.ts:143` | create-plugin route |
| `publish.ts:299` | version publish (was 404ing its own owner) |
| `publish.ts:711` | `POST /github` |
| `publish.ts:1040` | `POST /github/metadata` (>50 MB path) |

`get_plugin_with_stats` is deliberately left alone. Dropping its `published` filter would have been the smaller diff, but that RPC backs the public storefront and it would have listed unpublished plugins to everyone.

## Why the lookup fix alone was not enough

`updatePlugin` never touched `published`. Fixing only the lookup would have made publish take the update branch and return **200 while leaving the plugin invisible** - a silent no-op, which is a worse failure than the 500 it replaced.

So the two GitHub publish paths now also set `published: true`, and log when they restore a previously unpublished row. Publishing a version is an explicit request to be in the store, and nothing in this function ever sets `published = false` (admin delete is a hard delete, and the column defaults to `TRUE`), so this cannot be reversing a moderation action taken through the product. The log line means an out-of-band unpublish is not silently undone.

If you would rather an unpublished plugin required an explicit admin action to restore, say so and I will swap the republish for a 409 that names the state.

## Verification

- `deno check` error set is **byte-identical to `origin/main`** (10 TS2307, 7 TS7006, all pre-existing import-map and implicit-any noise). Compared against a clean `git archive` of `origin/main`, and I confirmed the two trees actually differ before trusting the comparison.
- `deno lint` clean on both changed files.
- The now-unused `getPlugin` import was dropped from `publish.ts`.

Not verified end to end against the live store, since that needs a deploy. `rparecorder`'s row still has `published = false`, so it stays broken until this ships.