### PR TITLE
feat(dashboard): add a "What's New" release feed

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dashboard/cards/ReleaseCard.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dashboard/cards/ReleaseCard.kt
@@ -1,0 +1,135 @@
+package ai.rever.boss.components.dashboard.cards
+
+import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.updater.VersionInfo
+import ai.rever.boss.updater.parseReleaseNotes
+import ai.rever.boss.updater.summarizeReleaseNotes
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Card for one release in the Dashboard's "What's New" feed (BossConsole#149).
+ *
+ * Same idiom as [ProjectCard]/[FileCard] - hover scale, click to open - but wider, since a
+ * release needs room for a one-line summary of what it contains, not just a name.
+ */
+@Composable
+fun ReleaseCard(
+    release: VersionInfo,
+    isNew: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    val scale by animateFloatAsState(
+        targetValue = if (isHovered) 1.02f else 1f,
+        animationSpec = spring(dampingRatio = 0.6f),
+    )
+
+    val backgroundColor = if (isHovered) BossTheme.colors.signalWash else BossTheme.colors.raised
+    val cardShape = RoundedCornerShape(12.dp)
+
+    // Best-effort, matching UpdateAvailableDialog's own fallback: a release whose notes don't
+    // parse into anything summarizable just shows no summary line rather than an error.
+    val summary =
+        remember(release.releaseNotes) {
+            runCatching { summarizeReleaseNotes(parseReleaseNotes(release.releaseNotes)) }.getOrNull()
+        }
+
+    Box(
+        modifier =
+            modifier
+                .width(220.dp)
+                .scale(scale)
+                .clip(cardShape)
+                .background(color = backgroundColor)
+                .clickable { onClick() }
+                .hoverable(interactionSource),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "v${release.version}",
+                    color = BossTheme.colors.textPrimary,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (isNew) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .clip(RoundedCornerShape(4.dp))
+                                .background(BossTheme.colors.signal)
+                                .padding(horizontal = 6.dp, vertical = 2.dp),
+                    ) {
+                        Text(
+                            text = "NEW",
+                            color = BossTheme.colors.onSignal,
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                }
+            }
+
+            Text(
+                text = formatReleaseDate(release.releaseDate),
+                color = BossTheme.colors.textSecondary,
+                fontSize = 11.sp,
+                maxLines = 1,
+            )
+
+            if (summary != null) {
+                Text(
+                    text = summary,
+                    color = BossTheme.colors.textSecondary,
+                    fontSize = 12.sp,
+                    lineHeight = 16.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+/** GitHub-style ISO timestamp ("2024-01-15T10:30:00Z") to just its date part. */
+private fun formatReleaseDate(dateString: String): String = dateString.substringBefore("T")

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeScreen.kt
@@ -100,6 +100,8 @@ fun HomeScreen(modifier: Modifier = Modifier) {
                 onSearch = actions::openSearch,
             )
 
+            WhatsNewSection()
+
             JumpBackInSection(
                 recentProjects = recentProjects,
                 windowHoldsProject = selectedProject.path.isNotEmpty(),
@@ -273,7 +275,7 @@ private fun RecentPagesSection(
  * an unordered set, which is why they wrap instead.
  */
 @Composable
-private fun CardStrip(content: @Composable () -> Unit) {
+internal fun CardStrip(content: @Composable () -> Unit) {
     Row(
         modifier =
             Modifier

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/WhatsNewSection.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/WhatsNewSection.kt
@@ -1,0 +1,206 @@
+package ai.rever.boss.components.home
+
+import ai.rever.boss.components.dashboard.cards.ReleaseCard
+import ai.rever.boss.components.dashboard.sections.DashboardSection
+import ai.rever.boss.components.dialogs.dialogScrollFence
+import ai.rever.boss.plugin.ui.BossDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.updater.NotesBlockView
+import ai.rever.boss.updater.UpdateCoordinator
+import ai.rever.boss.updater.UpdateSettings
+import ai.rever.boss.updater.UpdateSettingsManager
+import ai.rever.boss.updater.VersionInfo
+import ai.rever.boss.updater.VersionSelectionDialog
+import ai.rever.boss.updater.parseReleaseNotes
+import ai.rever.boss.utils.Version
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.launch
+
+/** How many releases the feed shows. BossConsole#149 asks for 3-5; the high end reads as a feed. */
+private const val WHATS_NEW_LIMIT = 5
+
+/**
+ * The Dashboard's "What's New" feed (BossConsole#149): the same [VersionInfo] list the Settings
+ * screen's version dialog already fetches, surfaced on the home screen so a release is
+ * discoverable without opening Settings.
+ *
+ * Reads [UpdateCoordinator.versionListManager] directly rather than taking it as a parameter -
+ * matching how [RecentFilesSection] reads `RecentFilesManager` - because [HomeScreen] takes no
+ * action callbacks by design (see its own doc comment) and this section needs no action a caller
+ * would supply anyway: expanding a card's notes and browsing all versions are both handled with
+ * local dialog state, exactly as the Settings screen already handles them.
+ *
+ * Hides itself entirely on an empty or failed fetch (BossConsole#149's own acceptance criterion:
+ * "no error UI when offline"), the same shape every other section here uses via its own
+ * `if (list.isEmpty()) return`.
+ */
+@Composable
+internal fun WhatsNewSection() {
+    val versionListManager = UpdateCoordinator.instance.versionListManager
+    val versions by versionListManager.versions.collectAsState()
+    val isLoading by versionListManager.isLoading.collectAsState()
+    val error by versionListManager.error.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) { versionListManager.fetchVersions() }
+
+    // Deliberately not gated on `error`: a cache-hit fetchVersions() call returns early without
+    // clearing a PREVIOUS failed attempt's error flag, so `error` can be stale and non-null even
+    // though `versions` still holds perfectly good cached data. Hiding on empty data (below) is
+    // what "no error UI when offline" actually needs - this section never renders `error` text
+    // anywhere, so there is nothing for a lingering flag to leak into the UI.
+    val recent = remember(versions) { versions.take(WHATS_NEW_LIMIT) }
+    if (recent.isEmpty()) return
+
+    // Frozen for this composition's whole lifetime, not re-read after the effect below updates
+    // it: badges must reflect what was seen BEFORE this visit, not disappear the instant this
+    // section (which is itself "seeing" the feed) renders.
+    val lastSeenAtOpen = remember { UpdateSettings.lastSeenReleaseVersion }
+    var expandedRelease by remember { mutableStateOf<VersionInfo?>(null) }
+    var showAllVersions by remember { mutableStateOf(false) }
+
+    // Being on the Dashboard with the feed visible IS "seeing" it. Guarded so it only ever
+    // advances: a later `versions` update cannot move the watermark backwards, and re-fetching
+    // the same newest release (e.g. the 1-hour cache simply expiring) is a no-op write.
+    LaunchedEffect(recent.first().version) {
+        val newest = recent.first().version
+        val current = UpdateSettings.lastSeenReleaseVersion?.let { Version.parse(it) }
+        if (current == null || newest > current) {
+            UpdateSettings.lastSeenReleaseVersion = newest.toString()
+            scope.launch { UpdateSettingsManager.saveSettings() }
+        }
+    }
+
+    DashboardSection(
+        title = "What's New",
+        actionText = "View all",
+        onAction = { showAllVersions = true },
+    ) {
+        CardStrip {
+            recent.forEach { release ->
+                ReleaseCard(
+                    release = release,
+                    isNew = release.isNewSince(lastSeenAtOpen),
+                    onClick = { expandedRelease = release },
+                )
+            }
+        }
+    }
+
+    expandedRelease?.let { release ->
+        ReleaseNotesDialog(release = release, onDismiss = { expandedRelease = null })
+    }
+
+    if (showAllVersions) {
+        VersionSelectionDialog(
+            currentVersion = UpdateCoordinator.instance.currentVersion(),
+            versions = versions,
+            isLoading = isLoading,
+            error = error,
+            // Browsing here is for reading, not installing - the Dashboard is not the place to
+            // start a downgrade/reinstall flow the user did not ask for. Selecting a version
+            // just reads its own notes, same as clicking its card would.
+            onVersionSelected = { versionInfo ->
+                showAllVersions = false
+                expandedRelease = versionInfo
+            },
+            onDismiss = { showAllVersions = false },
+        )
+    }
+}
+
+/** True when this release is newer than the last one the user has seen in the feed. */
+internal fun VersionInfo.isNewSince(lastSeenReleaseVersion: String?): Boolean {
+    val lastSeen = lastSeenReleaseVersion?.let { Version.parse(it) } ?: return true
+    return version > lastSeen
+}
+
+/** Full release notes for one version, reusing the same parse-or-fall-back-to-plain-text rule. */
+@Composable
+private fun ReleaseNotesDialog(
+    release: VersionInfo,
+    onDismiss: () -> Unit,
+) {
+    val notesBlocks =
+        remember(release.releaseNotes) {
+            runCatching { parseReleaseNotes(release.releaseNotes) }
+                .getOrNull()
+                ?.takeIf { it.isNotEmpty() }
+        }
+
+    BossDialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Card(
+            modifier = Modifier.width(480.dp),
+            backgroundColor = BossTheme.colors.panel,
+            shape = RoundedCornerShape(12.dp),
+            elevation = 8.dp,
+        ) {
+            Column(modifier = Modifier.padding(24.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "v${release.version}",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = BossTheme.colors.textPrimary,
+                    )
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, "Close", tint = BossTheme.colors.textSecondary)
+                    }
+                }
+
+                Column(
+                    modifier =
+                        Modifier
+                            .dialogScrollFence(NOTES_MAX_HEIGHT)
+                            .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    if (notesBlocks != null) {
+                        notesBlocks.forEach { block -> NotesBlockView(block) }
+                    } else {
+                        release.releaseNotes.lines().forEach { line ->
+                            Text(line, color = BossTheme.colors.textSecondary, fontSize = 12.sp)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val NOTES_MAX_HEIGHT = 420.dp

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/ReleaseNotesMarkdown.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/ReleaseNotesMarkdown.kt
@@ -240,6 +240,28 @@ internal fun buildInlineMarkdown(text: String): AnnotatedString =
         append(text.substring(pos))
     }
 
+/**
+ * A one-line summary for a release card (BossConsole#149): the first block with actual prose.
+ * Skips [NotesBlock.CodeBlock], [NotesBlock.Table] and [NotesBlock.ThematicBreak] - none of
+ * those reads sensibly truncated to a single line - and falls back to null (never an empty
+ * string) so a caller can fall back to its own plain-text handling exactly as [NotesBlockView]'s
+ * callers already do for a block list that failed to parse.
+ */
+internal fun summarizeReleaseNotes(blocks: List<NotesBlock>): String? =
+    blocks
+        .firstNotNullOfOrNull { block ->
+            when (block) {
+                is NotesBlock.Heading -> block.text
+                is NotesBlock.Paragraph -> block.text
+                is NotesBlock.ListItem -> block.text
+                is NotesBlock.CodeBlock, is NotesBlock.Table, NotesBlock.ThematicBreak -> null
+            }
+        }?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.let { text -> if (text.length > SUMMARY_MAX_CHARS) text.take(SUMMARY_MAX_CHARS).trimEnd() + "…" else text }
+
+private const val SUMMARY_MAX_CHARS = 90
+
 private fun headingFontSize(level: Int) =
     when (level) {
         1 -> 16.sp

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateOwnership.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateOwnership.kt
@@ -238,6 +238,14 @@ class UpdateCoordinator internal constructor(
     internal val updateService: UpdateService
         get() = manager.updateService
 
+    /**
+     * The app-wide version list, shared by the Settings screen and the Dashboard's "What's New"
+     * feed (BossConsole#149) so the two do not each run their own fetch against the same 50-release
+     * Supabase query. Lazy, not eager: most sessions never open either surface, so there is no
+     * reason to fetch on startup.
+     */
+    val versionListManager: VersionListManager by lazy { VersionListManager(updateService) }
+
     fun downloadUpdateInBackground(updateInfo: UpdateInfo) {
         if (isShutDown) return
         manager.downloadUpdateInBackground(updateInfo)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateSettings.kt
@@ -32,6 +32,15 @@ expect object UpdateSettings {
      * is dismissed.
      */
     var lastDismissedVersion: String?
+
+    /**
+     * The version string of the newest release the user has seen in the Dashboard's
+     * "What's New" feed (BossConsole#149). Distinct from [lastDismissedVersion]: that one
+     * suppresses the update *prompt* for a version the user chose to skip installing; this one
+     * only tracks what has been shown, so a release the user has looked at loses its "NEW"
+     * badge whether or not they ever install it. Null when nothing has been seen yet.
+     */
+    var lastSeenReleaseVersion: String?
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateUI.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateUI.kt
@@ -413,17 +413,13 @@ fun UpdateSettingsSection(updateCoordinator: UpdateCoordinator = UpdateCoordinat
     var showDowngradeWarning by remember { mutableStateOf(false) }
     var selectedVersion by remember { mutableStateOf<VersionInfo?>(null) }
 
-    val versionListManager = remember { VersionListManager(updateCoordinator.updateService) }
+    // Shared with the Dashboard's "What's New" feed (BossConsole#149) so the two surfaces make
+    // one fetch between them, not two - see UpdateCoordinator.versionListManager. Not disposed
+    // here: it is app-wide and outlives this composition.
+    val versionListManager = updateCoordinator.versionListManager
     val versions by versionListManager.versions.collectAsState()
     val isLoadingVersions by versionListManager.isLoading.collectAsState()
     val versionError by versionListManager.error.collectAsState()
-
-    // Cleanup VersionListManager when composable leaves composition
-    DisposableEffect(versionListManager) {
-        onDispose {
-            versionListManager.cleanup()
-        }
-    }
 
     // Prefetch version list on Settings load to avoid 2-5 second delay on button click
     // Uses cache if available (1 hour expiry), so this is cheap on repeated visits

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -855,6 +855,12 @@ fun main(args: Array<String>) {
                 // App-level trigger through the app-level owner.
                 ai.rever.boss.updater.UpdateCoordinator.instance
                     .checkForUpdatesInBackground()
+                // Also refresh the shared version list (BossConsole#149's "What's New" feed
+                // reads it), so a release published while the app is running shows up without
+                // waiting for its 1-hour cache to expire.
+                ai.rever.boss.updater.UpdateCoordinator.instance
+                    .versionListManager
+                    .fetchVersions(forceRefresh = true)
             }
             start()
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateSettingsManager.kt
@@ -48,6 +48,13 @@ actual object UpdateSettings {
      */
     @Volatile
     actual var lastDismissedVersion: String? = null
+
+    /**
+     * Newest release version seen in the Dashboard's "What's New" feed.
+     * Default: null (nothing seen yet - every fetched release shows a "NEW" badge)
+     */
+    @Volatile
+    actual var lastSeenReleaseVersion: String? = null
 }
 
 /**
@@ -59,6 +66,7 @@ data class UpdateSettingsData(
     val checkIntervalHours: Long = 6,
     val includePreReleases: Boolean = false,
     val lastDismissedVersion: String? = null,
+    val lastSeenReleaseVersion: String? = null,
 )
 
 /**
@@ -99,6 +107,7 @@ actual object UpdateSettingsManager {
                 UpdateSettings.checkIntervalHours = settings.checkIntervalHours
                 UpdateSettings.includePreReleases = settings.includePreReleases
                 UpdateSettings.lastDismissedVersion = settings.lastDismissedVersion
+                UpdateSettings.lastSeenReleaseVersion = settings.lastSeenReleaseVersion
 
                 logger.debug(
                     LogCategory.SYSTEM,
@@ -130,6 +139,7 @@ actual object UpdateSettingsManager {
                         checkIntervalHours = UpdateSettings.checkIntervalHours,
                         includePreReleases = UpdateSettings.includePreReleases,
                         lastDismissedVersion = UpdateSettings.lastDismissedVersion,
+                        lastSeenReleaseVersion = UpdateSettings.lastSeenReleaseVersion,
                     )
 
                 val content = json.encodeToString(UpdateSettingsData.serializer(), settings)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/WhatsNewSectionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/WhatsNewSectionTest.kt
@@ -1,0 +1,51 @@
+package ai.rever.boss.components.home
+
+import ai.rever.boss.updater.VersionInfo
+import ai.rever.boss.utils.Version
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the "NEW" badge rule (BossConsole#149): whether a release counts as newer than what the
+ * user has already seen in the feed.
+ */
+class WhatsNewSectionTest {
+    private fun release(version: String) =
+        VersionInfo(
+            version = Version.parse(version)!!,
+            releaseDate = "2026-01-01T00:00:00Z",
+            downloadSize = 0L,
+            releaseNotes = "",
+            downloadUrl = "",
+            isDraft = false,
+            isPrerelease = false,
+        )
+
+    @Test
+    fun `everything is new when nothing has been seen yet`() {
+        assertTrue(release("9.5.8").isNewSince(null))
+    }
+
+    @Test
+    fun `a release newer than the last seen one is new`() {
+        assertTrue(release("9.5.9").isNewSince("9.5.8"))
+    }
+
+    @Test
+    fun `the last seen release itself is not new`() {
+        assertFalse(release("9.5.8").isNewSince("9.5.8"))
+    }
+
+    @Test
+    fun `a release older than the last seen one is not new`() {
+        assertFalse(release("9.5.7").isNewSince("9.5.8"))
+    }
+
+    @Test
+    fun `an unparseable last-seen marker fails open rather than crashing`() {
+        // Corrupted or hand-edited settings must not make every release look new forever, nor
+        // throw and take the whole Dashboard down with it.
+        assertTrue(release("9.5.8").isNewSince("not-a-version"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/ReleaseNotesMarkdownTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/ReleaseNotesMarkdownTest.kt
@@ -88,4 +88,54 @@ class ReleaseNotesMarkdownTest {
         val blocks = parseReleaseNotes("```\ndangling")
         assertEquals(listOf(NotesBlock.CodeBlock("dangling")), blocks)
     }
+
+    // ---- summarizeReleaseNotes (BossConsole#149) ----
+
+    @Test
+    fun `summary is the first heading, not the release title`() {
+        val blocks = parseReleaseNotes(realNotes)
+        // realNotes' first block IS a heading ("BOSS 9.2.21") - a real release's actual first
+        // heading after the title would be the first section, e.g. "Downloads" or "Highlights".
+        assertEquals("🚀 BOSS 9.2.21", summarizeReleaseNotes(blocks))
+    }
+
+    @Test
+    fun `summary prefers the first paragraph when notes open with prose`() {
+        val blocks = parseReleaseNotes("Fixed a crash on startup.\n\n- also a minor fix")
+        assertEquals("Fixed a crash on startup.", summarizeReleaseNotes(blocks))
+    }
+
+    @Test
+    fun `summary skips tables and code blocks entirely`() {
+        val blocks =
+            parseReleaseNotes(
+                """
+                | A | B |
+                |---|---|
+                | 1 | 2 |
+
+                ```
+                code
+                ```
+
+                Actual prose at last.
+                """.trimIndent(),
+            )
+        assertEquals("Actual prose at last.", summarizeReleaseNotes(blocks))
+    }
+
+    @Test
+    fun `summary is null when nothing summarizable exists`() {
+        val blocks = parseReleaseNotes("```\njust code\n```")
+        assertEquals(null, summarizeReleaseNotes(blocks))
+    }
+
+    @Test
+    fun `a long summary is truncated with an ellipsis`() {
+        val long = "x".repeat(200)
+        val blocks = parseReleaseNotes(long)
+        val summary = summarizeReleaseNotes(blocks)
+        assertTrue(summary!!.endsWith("…"))
+        assertTrue(summary.length < long.length)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #149 — adds a "What's New" feed to the Dashboard (home screen) so users see the latest BOSS releases without opening the update dialog or Settings.

This issue was written against an earlier version of the home screen (referring to a `Dashboard.kt` that no longer exists, an `AnimatedVisibility` staggering pattern that was never actually there, and a no-op-callback concern in the plugin-hosted Dashboard that's already been fixed by an unrelated refactor). The implementation below follows the issue's actual goal, adjusted for the current `HomeScreen.kt` architecture — details in "Departures from the issue text" below.

## What changed

**Shared `VersionListManager`** — promoted from a per-composition instance (previously created fresh by the Settings screen's `VersionListManager(...)` call) to a single instance on `UpdateCoordinator`. The Settings screen and this new feed now read the same `StateFlow`, so they make one fetch between them against the 50-release Supabase query, not two.

**`WhatsNewSection`** (new, in `HomeScreen.kt`'s home package) — reads the shared version list directly and renders the latest 5 releases as cards. `HomeScreen` takes no callback parameters by design (a reflection test, `HomeActionRoutingTest`, enforces this), so the section manages its own local dialog state for both "expand a card's full notes" and "View all", exactly the way the Settings screen already handles its own version dialog.

**`ReleaseCard`** (new, in the existing `components/dashboard/cards/` package) — matches the `ProjectCard`/`FileCard` visual idiom: version, release date, a one-line summary extracted from the release notes, and a "NEW" badge.

**`summarizeReleaseNotes`** (new, in `ReleaseNotesMarkdown.kt`) — takes the first heading/paragraph/list-item block from the already-existing `parseReleaseNotes` output for a one-line card summary, skipping tables/code blocks/breaks.

**`lastSeenReleaseVersion`** (new setting, alongside the existing `lastDismissedVersion`) — tracks the newest release the user has seen in the feed. Distinct from `lastDismissedVersion`, which suppresses the *update prompt* for a version the user chose to skip installing — seeing a release in the feed and dismissing its install prompt are different actions and shouldn't share one flag. Badges shown during a visit reflect what was seen *before* that visit; the watermark advances afterward for next time.

**Live refresh** — the existing single `AppUpdateRealtimeService` callback in `main.kt` (already reacting to new Supabase releases to check for updates) now also refreshes the shared version list, rather than introducing a second listener slot on that service.

**"View all"** opens the existing `VersionSelectionDialog` for browsing/reading — selecting a version from the Dashboard opens its notes rather than triggering an install, since the Dashboard isn't the place to start a downgrade/reinstall flow nobody asked for from that context.

## Departures from the issue text (and why)

- No `Dashboard.kt` exists — the home screen is `HomeScreen.kt`, already rewritten to take zero callbacks and emit through `DashboardEventBus` instead. This feature needs no bus event, since both of its actions are self-contained dialogs.
- No `AnimatedVisibility`-with-staggered-delay pattern exists among the other sections to match; none was added here either, for consistency with its siblings.
- The "no-op callbacks in the plugin-hosted Dashboard" gotcha in the issue is already moot — that provider (`DashboardContentProviderImpl`) just renders `HomeScreen()` with no parameters today.
- There's no standalone `ReleaseNotesMarkdown` composable — the existing pattern is `parseReleaseNotes` + a loop calling `NotesBlockView` per block (with a plain-text fallback), which this PR's new `ReleaseNotesDialog` replicates exactly.
- `VersionListManager` was not a singleton before this PR (see "Shared `VersionListManager`" above) — reusing it without adding a second fetch required promoting it, not just calling the existing one.

## Testing

**`ReleaseNotesMarkdownTest`** (10 tests — 5 pre-existing, 5 new for `summarizeReleaseNotes`):
| Test | Status |
|---|---|
| `summary is the first heading, not the release title` | ✅ new |
| `summary prefers the first paragraph when notes open with prose` | ✅ new |
| `summary skips tables and code blocks entirely` | ✅ new |
| `summary is null when nothing summarizable exists` | ✅ new |
| `a long summary is truncated with an ellipsis` | ✅ new |
| (5 pre-existing markdown-parsing tests) | ✅ pre-existing |

**`WhatsNewSectionTest`** (5 new — the "NEW" badge rule):
| Test | Status |
|---|---|
| `everything is new when nothing has been seen yet` | ✅ |
| `a release newer than the last seen one is new` | ✅ |
| `the last seen release itself is not new` | ✅ |
| `a release older than the last seen one is not new` | ✅ |
| `an unparseable last-seen marker fails open rather than crashing` | ✅ |

**`HomeActionRoutingTest`** (6, pre-existing) — re-run specifically to confirm `HomeScreen` still takes zero callback parameters after this change. ✅ all pass.

`ktlintCheck`: clean. Full `composeApp:desktopTest` suite: zero new failures — the only failures are the same 2 pre-existing, environment-specific Windows symlink `FileSystemException`s (`DesktopFileScannerTest`, `DiscardDownloadContainmentTest`) in files this PR does not touch.

## Bug caught during review

An early version of `WhatsNewSection` hid the whole section whenever `VersionListManager.error` was non-null. Turns out `fetchVersions()`'s cache-hit path returns early without clearing a *previous* failed attempt's error flag — so `error` can be stale and non-null even while `versions` still holds perfectly good cached data. Fixed to gate purely on having no releases to show, since the section never renders error text anywhere regardless.

## Known limitations

- No end-to-end Compose UI test drives actual card rendering or dialog open/close — consistent with this codebase's existing pattern for this package (`HomeLayoutTest` and friends test pure logic, not full Compose trees).
- Not verified against live Supabase data in this environment; the underlying fetch path (`VersionListManager`/`UpdateService`) is unchanged and already exercised elsewhere.

## Related issues

Closes #149
