### PR TITLE
feat(dashboard): add a "What's new" feed of recent releases (#149)

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dashboard/cards/ReleaseCard.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dashboard/cards/ReleaseCard.kt
@@ -1,0 +1,122 @@
+package ai.rever.boss.components.dashboard.cards
+
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Card for one release in the Dashboard "What's new" feed: version, date, a one-line summary, and a
+ * NEW badge when the release is newer than what the user has already seen.
+ *
+ * Takes primitives rather than a `VersionInfo` / feed model on purpose - this `cards` package is
+ * imported by the home screen, and taking the domain type would make the dependency point back the
+ * other way. The caller maps its model to these strings.
+ */
+@Composable
+fun ReleaseCard(
+    versionLabel: String,
+    date: String,
+    summary: String,
+    isNew: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    val scale by animateFloatAsState(
+        targetValue = if (isHovered) 1.02f else 1f,
+        animationSpec = spring(dampingRatio = 0.6f),
+    )
+    val backgroundColor = if (isHovered) BossTheme.colors.signalWash else BossTheme.colors.raised
+    val cardShape = RoundedCornerShape(12.dp)
+
+    Column(
+        modifier =
+            modifier
+                .width(240.dp)
+                .scale(scale)
+                .clip(cardShape)
+                .background(color = backgroundColor)
+                .clickable { onClick() }
+                .hoverable(interactionSource)
+                .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = versionLabel,
+                color = BossTheme.colors.textPrimary,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (isNew) {
+                NewBadge()
+            }
+        }
+
+        if (date.isNotBlank()) {
+            Text(
+                text = date,
+                color = BossTheme.colors.textSecondary,
+                fontSize = 11.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        // Fixed height so cards in the strip line up whether or not a summary is present.
+        Text(
+            text = summary,
+            color = BossTheme.colors.textSecondary,
+            fontSize = 12.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth().height(34.dp),
+        )
+    }
+}
+
+@Composable
+private fun NewBadge() {
+    Text(
+        text = "NEW",
+        color = BossTheme.colors.onSignal,
+        fontSize = 9.sp,
+        fontWeight = FontWeight.Bold,
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .background(BossTheme.colors.signal)
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+    )
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeScreen.kt
@@ -100,6 +100,8 @@ fun HomeScreen(modifier: Modifier = Modifier) {
                 onSearch = actions::openSearch,
             )
 
+            WhatsNewSection()
+
             JumpBackInSection(
                 recentProjects = recentProjects,
                 windowHoldsProject = selectedProject.path.isNotEmpty(),

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/WhatsNew.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/WhatsNew.kt
@@ -1,0 +1,77 @@
+package ai.rever.boss.components.home
+
+import ai.rever.boss.updater.UpdateCoordinator
+import ai.rever.boss.updater.VersionInfo
+import ai.rever.boss.updater.VersionListManager
+import ai.rever.boss.utils.Version
+
+/**
+ * How many recent releases the Dashboard "What's new" feed shows before "View all". Kept small: the
+ * strip is a teaser that sits above the fold, not the version history the "View all" dialog is for.
+ */
+internal const val WHATS_NEW_LIMIT = 5
+
+/**
+ * One release in the feed, paired with whether it should carry a NEW badge.
+ *
+ * A plain view model rather than a `VersionInfo` extension so the badge rule is decided once, in
+ * [whatsNewEntries], and pinned by a test rather than recomputed at each render.
+ */
+internal data class WhatsNewEntry(
+    val info: VersionInfo,
+    val isNew: Boolean,
+)
+
+/**
+ * The releases to show, newest first, each flagged NEW when it is newer than [lastSeen].
+ *
+ * [versions] arrives from [VersionListManager] already filtered (no drafts or pre-releases) and
+ * sorted descending, so this only takes the head and decides the badge. Two rules the test pins:
+ *
+ *  - A null [lastSeen] badges NOTHING. It is the first-run / never-seen state, and painting every
+ *    release NEW there is the noise this feature is meant to avoid - the feed advances the marker to
+ *    the latest release the first time it is shown, so genuine future releases badge after that.
+ *  - Only STRICTLY newer releases badge. The release the user is already on, and older ones, are not
+ *    new to them.
+ */
+internal fun whatsNewEntries(
+    versions: List<VersionInfo>,
+    lastSeen: Version?,
+    limit: Int = WHATS_NEW_LIMIT,
+): List<WhatsNewEntry> =
+    versions.take(limit).map { info ->
+        WhatsNewEntry(info, isNew = lastSeen != null && info.version.isNewerThan(lastSeen))
+    }
+
+/**
+ * A one-line summary of release notes for a card: the first non-empty line with any leading
+ * markdown heading, bullet or quote punctuation stripped, or "" when there is nothing usable.
+ *
+ * Best-effort and deliberately dumb - the full, correctly rendered notes are one click away through
+ * `parseReleaseNotes`; this only needs to give the card a readable teaser without pulling the
+ * markdown parser into the strip.
+ */
+internal fun releaseSummary(notes: String): String {
+    val line =
+        notes
+            .lineSequence()
+            .map { it.trim() }
+            .firstOrNull { it.isNotEmpty() }
+            ?: return ""
+    return line.trimStart('#', '-', '*', '>', ' ').trim()
+}
+
+/**
+ * One shared [VersionListManager] for the feed, so opening the Dashboard repeatedly reuses the
+ * manager's 1-hour cache instead of fetching every time.
+ *
+ * `by lazy` rather than eager: constructing it reads [UpdateCoordinator.instance], and nothing
+ * should force that graph up until a window actually shows the feed. `VersionListManager` fetches
+ * through the caller's coroutine scope and holds no scope of its own, so a process-wide holder is
+ * safe - there is nothing here to leak when a window closes.
+ */
+internal object WhatsNewVersions {
+    val manager: VersionListManager by lazy {
+        VersionListManager(UpdateCoordinator.instance.updateService)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/WhatsNewSection.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/WhatsNewSection.kt
@@ -1,0 +1,190 @@
+package ai.rever.boss.components.home
+
+import ai.rever.boss.components.dashboard.cards.ReleaseCard
+import ai.rever.boss.components.dashboard.sections.DashboardSection
+import ai.rever.boss.plugin.ui.BossAlertDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.updater.NotesBlockView
+import ai.rever.boss.updater.UpdateSettings
+import ai.rever.boss.updater.UpdateSettingsManager
+import ai.rever.boss.updater.VersionInfo
+import ai.rever.boss.updater.VersionSelectionDialog
+import ai.rever.boss.updater.parseReleaseNotes
+import ai.rever.boss.utils.AppVersion
+import ai.rever.boss.utils.Version
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Dashboard "What's new" feed: recent releases and what changed in them, so features ship visibly
+ * rather than only through the update dialog at update time.
+ *
+ * Hides itself whenever there is nothing to show - not yet fetched, offline, or a fetch error - so
+ * the Dashboard never carries an error state for this. The version list, the markdown renderer and
+ * the "View all" dialog are all reused from the updater; the only new persisted state is
+ * [UpdateSettings.lastSeenReleaseVersion], which drives the NEW badge. Lives in its own file rather
+ * than beside the other home sections only to keep `HomeScreen` under detekt's per-file function cap.
+ */
+@Composable
+internal fun WhatsNewSection() {
+    val manager = WhatsNewVersions.manager
+    val versions by manager.versions.collectAsState()
+    val isLoading by manager.isLoading.collectAsState()
+    val error by manager.error.collectAsState()
+
+    // Best-effort refresh on mount; the manager's own 1-hour cache means repeated opens do not
+    // re-fetch. On failure `versions` stays empty and the section hides - never an error state.
+    LaunchedEffect(Unit) { manager.fetchVersions() }
+
+    if (versions.isEmpty()) return
+
+    // Read the marker ONCE, before advancing it below, so this session's badges reflect what the
+    // user had not seen on entry rather than clearing the instant the section mounts.
+    val lastSeen =
+        remember {
+            UpdateSettings.lastSeenReleaseVersion?.let { runCatching { Version.parse(it) }.getOrNull() }
+        }
+    val entries = remember(versions, lastSeen) { whatsNewEntries(versions, lastSeen) }
+
+    // Advance the marker to the latest release so these stop being NEW on the next launch.
+    AdvanceSeenMarker(versions.first().version)
+
+    var notesFor by remember { mutableStateOf<VersionInfo?>(null) }
+    var showAll by remember { mutableStateOf(false) }
+
+    DashboardSection(
+        title = "What's new",
+        actionText = "View all",
+        onAction = { showAll = true },
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(BossTheme.space.md),
+        ) {
+            entries.forEach { entry ->
+                ReleaseCard(
+                    versionLabel = "v${entry.info.version}",
+                    // Trim an ISO datetime to its date; a plain date passes through unchanged.
+                    date = entry.info.releaseDate.substringBefore('T'),
+                    summary = releaseSummary(entry.info.releaseNotes),
+                    isNew = entry.isNew,
+                    onClick = { notesFor = entry.info },
+                )
+            }
+        }
+    }
+
+    notesFor?.let { info ->
+        ReleaseNotesDialog(info = info, onDismiss = { notesFor = null })
+    }
+
+    if (showAll) {
+        VersionSelectionDialog(
+            currentVersion = AppVersion.CURRENT,
+            versions = versions,
+            isLoading = isLoading,
+            error = error,
+            // Read-only here: selecting a version opens its notes rather than starting a download.
+            onVersionSelected = { info ->
+                showAll = false
+                notesFor = info
+            },
+            onDismiss = { showAll = false },
+        )
+    }
+}
+
+/**
+ * Records [newest] as the last release the user has seen, so it and everything older stop carrying a
+ * NEW badge on the next launch. A no-op when the marker is already current, to avoid a disk write on
+ * every Dashboard open.
+ */
+@Composable
+private fun AdvanceSeenMarker(newest: Version) {
+    LaunchedEffect(newest) {
+        if (UpdateSettings.lastSeenReleaseVersion != newest.toString()) {
+            UpdateSettings.lastSeenReleaseVersion = newest.toString()
+            UpdateSettingsManager.saveSettings()
+        }
+    }
+}
+
+/**
+ * The full release notes for one version, rendered the same way the update dialog's "What's new"
+ * does - through [parseReleaseNotes]/[NotesBlockView], falling back to plain lines when the markdown
+ * cannot be parsed.
+ */
+@Composable
+private fun ReleaseNotesDialog(
+    info: VersionInfo,
+    onDismiss: () -> Unit,
+) {
+    val notesBlocks =
+        remember(info.releaseNotes) {
+            runCatching { parseReleaseNotes(info.releaseNotes) }
+                .getOrNull()
+                ?.takeIf { it.isNotEmpty() }
+        }
+    BossAlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Close", color = BossTheme.colors.textSecondary, fontSize = 13.sp)
+            }
+        },
+        modifier = Modifier.widthIn(min = 360.dp, max = 480.dp),
+        title = {
+            Text(
+                "BossConsole v${info.version}",
+                color = BossTheme.colors.textPrimary,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier.heightIn(max = 320.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                when {
+                    notesBlocks != null -> {
+                        notesBlocks.forEach { NotesBlockView(it) }
+                    }
+
+                    info.releaseNotes.isNotBlank() -> {
+                        info.releaseNotes.lines().forEach { line ->
+                            Text(line, color = BossTheme.colors.textSecondary, fontSize = 12.sp)
+                        }
+                    }
+
+                    else -> {
+                        Text("No release notes.", color = BossTheme.colors.textSecondary, fontSize = 12.sp)
+                    }
+                }
+            }
+        },
+    )
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateSettings.kt
@@ -32,6 +32,16 @@ expect object UpdateSettings {
      * is dismissed.
      */
     var lastDismissedVersion: String?
+
+    /**
+     * The newest release version the user has seen in the Dashboard "What's new"
+     * feed. Releases newer than this are badged NEW there; viewing the feed
+     * advances it to the latest release. Null until the feed has been shown
+     * once, which the feed treats as "badge nothing" so a first run is not a
+     * wall of NEW badges. Distinct from [lastDismissedVersion], which governs the
+     * update PROMPT rather than the feed.
+     */
+    var lastSeenReleaseVersion: String?
 }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateSettingsManager.kt
@@ -48,6 +48,13 @@ actual object UpdateSettings {
      */
     @Volatile
     actual var lastDismissedVersion: String? = null
+
+    /**
+     * Newest release version the user has seen in the Dashboard "What's new" feed
+     * Default: null (feed never shown; treated as "badge nothing")
+     */
+    @Volatile
+    actual var lastSeenReleaseVersion: String? = null
 }
 
 /**
@@ -59,6 +66,7 @@ data class UpdateSettingsData(
     val checkIntervalHours: Long = 6,
     val includePreReleases: Boolean = false,
     val lastDismissedVersion: String? = null,
+    val lastSeenReleaseVersion: String? = null,
 )
 
 /**
@@ -99,6 +107,7 @@ actual object UpdateSettingsManager {
                 UpdateSettings.checkIntervalHours = settings.checkIntervalHours
                 UpdateSettings.includePreReleases = settings.includePreReleases
                 UpdateSettings.lastDismissedVersion = settings.lastDismissedVersion
+                UpdateSettings.lastSeenReleaseVersion = settings.lastSeenReleaseVersion
 
                 logger.debug(
                     LogCategory.SYSTEM,
@@ -130,6 +139,7 @@ actual object UpdateSettingsManager {
                         checkIntervalHours = UpdateSettings.checkIntervalHours,
                         includePreReleases = UpdateSettings.includePreReleases,
                         lastDismissedVersion = UpdateSettings.lastDismissedVersion,
+                        lastSeenReleaseVersion = UpdateSettings.lastSeenReleaseVersion,
                     )
 
                 val content = json.encodeToString(UpdateSettingsData.serializer(), settings)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/WhatsNewTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/WhatsNewTest.kt
@@ -1,0 +1,85 @@
+package ai.rever.boss.components.home
+
+import ai.rever.boss.updater.VersionInfo
+import ai.rever.boss.utils.Version
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the two pure decisions behind the Dashboard "What's new" feed: which releases carry a NEW
+ * badge, and how a release-notes teaser is reduced to one line. Both are consumed inside a composable
+ * whose failure is only visible on screen, so they are extracted and tested here.
+ */
+class WhatsNewTest {
+    private fun release(
+        major: Int,
+        minor: Int,
+        patch: Int,
+        notes: String = "notes",
+    ): VersionInfo =
+        VersionInfo(
+            version = Version(major, minor, patch),
+            releaseDate = "2026-09-06",
+            downloadSize = 0L,
+            releaseNotes = notes,
+            downloadUrl = "",
+            isDraft = false,
+            isPrerelease = false,
+        )
+
+    // VersionListManager hands these over already sorted descending, so the feed relies on that order.
+    private val versions =
+        listOf(
+            release(9, 5, 8),
+            release(9, 5, 7),
+            release(9, 5, 6),
+            release(9, 5, 5),
+        )
+
+    @Test
+    fun `nothing is badged when no release has been seen yet`() {
+        // First run / never-seen: a null lastSeen must badge nothing, or every release lights up NEW
+        // the first time the feed is shown - the noise this marker exists to prevent.
+        val entries = whatsNewEntries(versions, lastSeen = null)
+        assertEquals(versions.size, entries.size)
+        assertTrue(entries.none { it.isNew }, "a null lastSeen must not badge anything")
+    }
+
+    @Test
+    fun `only releases strictly newer than the last seen version are badged`() {
+        val entries = whatsNewEntries(versions, lastSeen = Version(9, 5, 6))
+
+        // 9.5.8 and 9.5.7 are newer than 9.5.6; 9.5.6 itself (already seen) and 9.5.5 are not.
+        assertEquals(listOf(true, true, false, false), entries.map { it.isNew })
+    }
+
+    @Test
+    fun `the feed is capped at the limit, newest first`() {
+        val many = (20 downTo 1).map { release(9, 5, it) }
+        val entries = whatsNewEntries(many, lastSeen = null, limit = 5)
+
+        assertEquals(5, entries.size)
+        assertEquals(Version(9, 5, 20), entries.first().info.version)
+        assertEquals(Version(9, 5, 16), entries.last().info.version)
+    }
+
+    @Test
+    fun `a summary is the first non-empty line with leading markdown punctuation stripped`() {
+        val notes =
+            """
+
+            # BossConsole 9.5.8
+
+            - Fixed the toast overlay
+            """.trimIndent()
+        assertEquals("BossConsole 9.5.8", releaseSummary(notes))
+    }
+
+    @Test
+    fun `a summary of blank notes is empty rather than punctuation`() {
+        assertEquals("", releaseSummary("   \n\n  "))
+        assertEquals("", releaseSummary(""))
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **"What's new"** feed to the Dashboard (home screen) so users see recent BOSS releases and feature enhancements when they open the app, instead of only at update time. Fixes #149.

## What it does

- A "What's new" section under the home header shows the latest releases as cards - version, date, and a one-line summary.
- Clicking a card opens the **full release notes**, rendered through the updater's own `parseReleaseNotes`/`NotesBlockView` (the renderer the update dialog uses), with a plain-text fallback.
- **View all** opens the existing `VersionSelectionDialog` (read-only here - selecting a version opens its notes rather than starting a download).
- Releases newer than the last one the user has seen carry a **NEW** badge; viewing advances the marker, persisted as `UpdateSettings.lastSeenReleaseVersion`. A first run badges nothing.

## Reuse / no new backend

- `VersionListManager` supplies the list (already filtered, sorted, 1-hour cached) through one shared holder - no new networking.
- Hides itself when there is nothing to show (not fetched, offline, or fetch error) - the Dashboard never shows an error state for this.
- `HomeScreen` takes no callbacks, so the section renders identically in the browser plugin's `about:blank` Dashboard copy.

## Tests

- `WhatsNewTest` pins the NEW-badge rule (`whatsNewEntries`) and the notes summary (`releaseSummary`).
- `./gradlew :composeApp:desktopTest --tests "ai.rever.boss.components.home.WhatsNewTest"` - 5 pass; full `components.home.*` and `updater.*` suites pass.
- `./gradlew :composeApp:ktlintCheck :composeApp:detekt` - green.

## Scope

Live Realtime refresh (`AppUpdateRealtimeService`) is deliberately deferred: it is desktop-only and refreshes update *state* rather than the version list, so wiring it from commonMain needs an expect/actual seam. The feed refreshes on mount via the 1-hour cache. Product announcements independent of releases (the issue's phase 2) are out of scope.
