### PR TITLE
Store a folded key name on capture, and repair the keymaps that hold a keyCode (#329)

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -83,7 +83,7 @@
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$fun install()</ID>
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun chordMatchesEvent( modifiers: Collection&lt;String&gt;, event: KeyEvent, ): Boolean</ID>
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun dispatchAction( actionId: String, windowId: String, ): Boolean</ID>
-    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun getKeyName(keyCode: Int): String</ID>
+    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun getKeyName(keyCode: Int): String</ID>
     <ID>CyclomaticComplexMethod:AuthScreenContainer.kt$@Composable fun AuthScreenContainer(onLoginSuccess: () -&gt; Unit)</ID>
     <ID>CyclomaticComplexMethod:BossActionButton.kt$@Composable fun BossActionButton( imageVector: ImageVector? = null, leftLogo: (@Composable () -&gt; Unit)? = null, leftIcon: ImageVector? = null, text: String, fontSize: TextUnit = 13.sp, color: Color = BossTheme.colors.textPrimary, iconColor: Color? = null, // Optional separate icon color (defaults to color if null) iconSize: Dp = 20.dp, // Icon size for imageVector mode maxTextWidth: Dp? = null, // Optional max width for text (truncates with ellipsis) modifier: Modifier = Modifier, contentPadding: PaddingValues = PaddingValues(2.dp), isSelected: Boolean = false, contextMenuItems: List&lt;ContextMenuItem&gt;? = null, contextDirection: Panel = bottom, hintText: String? = null, showHintWithDelay: Boolean = true, hintDirection: Panel = bottom, /** * Sized for a narrow column rather than the top bar. * * The vertical tab bar is 200dp wide and its own rows are 24dp of 10sp text; a control built * for a 40dp horizontal bar sits in it like furniture in the wrong room. Opt-in, so the top * bar - where every one of these numbers was chosen - is untouched. */ compact: Boolean = false, onClick: () -&gt; Unit = {}, )</ID>
     <ID>CyclomaticComplexMethod:BossAppDialogs.kt$@Composable internal fun BossAppDialogs(state: BossAppState)</ID>
@@ -239,7 +239,7 @@
     <ID>LargeClass:UpdateScriptGenerator.kt$UpdateScriptGenerator</ID>
     <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$fun install()</ID>
     <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun dispatchAction( actionId: String, windowId: String, ): Boolean</ID>
-    <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun getKeyName(keyCode: Int): String</ID>
+    <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun getKeyName(keyCode: Int): String</ID>
     <ID>LongMethod:ActionCard.kt$@Composable fun ActionCard( icon: ImageVector, title: String, shortcut: String? = null, onClick: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:AdvancedSettings.kt$@Composable fun AdvancedSettings()</ID>
     <ID>LongMethod:ApplicationRestarter.kt$ApplicationRestarter$private fun buildRelaunchCommand(): List&lt;String&gt;</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/KeyCaptureDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/KeyCaptureDialog.kt
@@ -1,7 +1,9 @@
 package ai.rever.boss.components.settings.keymap
 
 import ai.rever.boss.keymap.model.KeyBinding
+import ai.rever.boss.keymap.model.KeyStroke
 import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.keymap.model.storedKeyName
 import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.SystemUtils
@@ -170,7 +172,10 @@ fun KeyCaptureDialog(
                     contentAlignment = Alignment.Center,
                 ) {
                     if (hasCapture && capturedKey != null) {
-                        val displayStr = buildDisplayString(capturedKey!!, capturedModifiers)
+                        // The preview renders the keystroke that Apply will persist, rather than
+                        // formatting the captured Key on its own. It used to have a private copy
+                        // of the formatter, which is how it came to display a raw keyCode.
+                        val displayStr = KeyStroke(storedKeyName(capturedKey!!), capturedModifiers).displayString()
                         KeyDisplay(displayStr, large = true)
                     } else {
                         Column(
@@ -209,7 +214,11 @@ fun KeyCaptureDialog(
                                 val binding =
                                     KeyBinding(
                                         actionId = actionId,
-                                        key = capturedKey!!.keyCode.toString(),
+                                        // #329: this was `capturedKey!!.keyCode.toString()`, a
+                                        // packed Long ("4294967333"). Both matchers compare
+                                        // key NAMES, so every rebind made here saved, displayed
+                                        // and then fired on neither path.
+                                        key = storedKeyName(capturedKey!!),
                                         modifiers = capturedModifiers,
                                         context = context,
                                         category = category,
@@ -257,46 +266,3 @@ private fun KeyDisplay(
         )
     }
 }
-
-/**
- * Builds a display string for captured keys.
- */
-private fun buildDisplayString(
-    key: Key,
-    modifiers: List<String>,
-): String {
-    val isMac = System.getProperty("os.name").contains("Mac", ignoreCase = true)
-
-    val modifierStrings =
-        modifiers.map { modifier ->
-            when (modifier.lowercase()) {
-                "cmd", "meta" -> if (isMac) "⌘" else "Ctrl"
-                "ctrl", "control" -> if (isMac) "⌃" else "Ctrl"
-                "shift" -> if (isMac) "⇧" else "Shift"
-                "alt", "option" -> if (isMac) "⌥" else "Alt"
-                else -> modifier
-            }
-        }
-
-    val keyString = formatKeyDisplay(key.keyCode.toString())
-
-    return (modifierStrings + keyString).joinToString(if (isMac) "" else "+")
-}
-
-/**
- * Formats the key name for display.
- */
-private fun formatKeyDisplay(keyName: String): String =
-    when (keyName.lowercase()) {
-        "space", "spacebar" -> "Space"
-        "arrowleft", "directionleft" -> "←"
-        "arrowright", "directionright" -> "→"
-        "arrowup", "directionup" -> "↑"
-        "arrowdown", "directiondown" -> "↓"
-        "enter", "return" -> "↩"
-        "backspace" -> "⌫"
-        "delete" -> "⌦"
-        "escape", "esc" -> "Esc"
-        "tab" -> "Tab"
-        else -> keyName.uppercase()
-    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapMatcher.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapMatcher.kt
@@ -6,6 +6,7 @@ import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.model.ShortcutContext
 import ai.rever.boss.keymap.model.canonicalKeyName
 import ai.rever.boss.keymap.model.canonicalModifiers
+import ai.rever.boss.keymap.model.composeKeyName
 import ai.rever.boss.utils.SystemUtils
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -233,17 +234,10 @@ class KeymapMatcher(
         eventKey: Key,
         bindingKeyName: String,
     ): Boolean {
-        // Extract key name from the Key object
-        // Key.toString() format is "Key: X" where X is the key name
-        val eventKeyString = eventKey.toString()
-        val eventKeyName =
-            if (eventKeyString.startsWith("Key: ")) {
-                eventKeyString.substring(5).trim()
-            } else {
-                eventKey.keyCode.toString()
-            }
-
-        val eventKeyNormalized = normalizeKeyName(eventKeyName)
+        // The name comes from `composeKeyName` rather than a copy of the "Key: " parse that used
+        // to live here. It is the same three lines, and having two of them is how this path came
+        // to be the one that knew about a spelling the other did not.
+        val eventKeyNormalized = normalizeKeyName(composeKeyName(eventKey))
         val bindingKeyNormalized = normalizeKeyName(bindingKeyName)
 
         return eventKeyNormalized.equals(bindingKeyNormalized, ignoreCase = true)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/model/KeyBinding.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/model/KeyBinding.kt
@@ -26,6 +26,40 @@ internal fun canonicalModifiers(modifiers: List<String>): Set<String> =
         }
 
 /**
+ * The prefix `Key.toString()` renders in front of a key's name.
+ *
+ * Compose exposes no accessor for the name itself, so anything that needs one reads it back out
+ * of the rendered string. Two places did that with their own copy of the offset; naming it once
+ * means they cannot disagree about where the name starts.
+ */
+private const val KEY_RENDER_PREFIX = "Key: "
+
+/**
+ * The name Compose renders for a [Key], which is one of the two key vocabularies in the app.
+ *
+ * The other is `AWTKeyboardInterceptor.getKeyName`. Neither is derived from the other, and where
+ * they disagree a chord fires on one path and silently does nothing on the other;
+ * [canonicalKeyName] is the fold that reconciles them and `KeyVocabularyAgreementTest` walks both.
+ *
+ * Two things about this rendering are worth knowing before depending on it. It is not the
+ * presets' vocabulary - the left arrow renders "Left" against their "DirectionLeft". And it is
+ * not stable: `Key.toString()` falls through to AWT's `getKeyText`, which answers with a word
+ * while the toolkit is cold and with the macOS glyph once it is up, so `Key.Tab` is "Tab" in a
+ * headless test and "⇥" in a running app. Anything PERSISTING a name wants the fold, not this.
+ *
+ * `Key.keyCode` is a packed Long rather than a name, so it is a last resort here and only for a
+ * key Compose itself cannot name, where `toString()` already renders the bare number.
+ */
+internal fun composeKeyName(key: Key): String {
+    val rendered = key.toString()
+    return if (rendered.startsWith(KEY_RENDER_PREFIX)) {
+        rendered.substring(KEY_RENDER_PREFIX.length).trim()
+    } else {
+        key.keyCode.toString()
+    }
+}
+
+/**
  * The one name a key answers to, with every spelling the codebase can produce folded together.
  *
  * Three vocabularies reach this: Compose's `Key` property names, which the presets store
@@ -61,8 +95,27 @@ private val KEY_ALIASES: Map<String, String> =
         alias("directionup", "up", "arrowup", "↑")
         alias("directiondown", "down", "arrowdown", "↓")
         alias("space", "spacebar", "␣", " ")
-        alias("escape", "esc")
-        alias("enter", "return")
+        // Compose renders these two ways on one machine. `Key.toString()` falls through to AWT's
+        // `getKeyText`, which answers with a word while the toolkit is cold and with the macOS
+        // glyph once it is up - so "Tab" and "⇥" are both real spellings of one key, and which
+        // one you get depends on nothing the user did.
+        //
+        // The GLYPH is what a running app produces, so these were live on the Compose matcher
+        // path before any of this: `KeymapMatcher` derives the event's name from `Key.toString()`
+        // and compares it against the preset's, so Ctrl+Tab and Ctrl+Shift+Tab - TAB_NEXT and
+        // TAB_PREVIOUS, shipped in all four presets - asked whether "⇥" was "Tab" and were told
+        // no. They survive on the AWT interceptor, which says "Tab" on both sides. Measured warm
+        // and cold; `KeyVocabularyAgreementTest` covers whichever one an environment renders and
+        // `CanonicalKeyNameTest` enumerates both.
+        //
+        // The arrow and space glyphs above are here for the same reason; these are the rest.
+        alias("escape", "esc", "⎋")
+        alias("enter", "return", "⏎")
+        alias("tab", "⇥")
+        alias("backspace", "⌫")
+        alias("delete", "⌦")
+        alias("home", "↖")
+        alias("end", "↘")
         // A dedicated + key and Shift+= are the same chord to every preset: zoom in is stored as
         // Equals with a Cmd+Shift+Equals alternate.
         alias("equals", "plus", "+", "=")
@@ -76,12 +129,24 @@ private val KEY_ALIASES: Map<String, String> =
         alias("closebracket", "close bracket", "right bracket", "rightbracket", "]")
         // Shift+/ reports "?" on a US layout.
         alias("slash", "/", "?")
-        alias("backslash", "\\")
+        // "Back Slash" is Compose's cold spelling for `Key.Backslash`, the same spaced shape as
+        // the bracket keys above. Unlike the glyphs below this one is not reachable in a running
+        // app, which renders "\" - already folded here. It is kept because the cold spelling is
+        // what a headless or pre-toolkit path sees, and a fold that covers one of a key's two
+        // real spellings is the state every entry in this table was added to leave.
+        alias("backslash", "back slash", "\\")
         alias("semicolon", ";")
-        alias("apostrophe", "'")
         alias("comma", ",")
         alias("period", ".")
-        alias("grave", "`")
+        // Cold spellings again, in the same shape: Compose renders "Quote", "Back Quote",
+        // "Page Up" and "Page Down" where the interceptor says "Apostrophe", "Grave", "PageUp"
+        // and "PageDown". A running app renders "'" and "`" for the first two (already folded)
+        // and the glyphs above for the page keys. `KeyVocabularyAgreementTest` walks both tables
+        // so the next divergence fails a build rather than a keystroke.
+        alias("apostrophe", "quote", "'")
+        alias("grave", "back quote", "`")
+        alias("pageup", "page up", "⇞")
+        alias("pagedown", "page down", "⇟")
         // Digit characters against the word forms the presets store ("One" for Cmd+1).
         listOf("zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine")
             .forEachIndexed { digit, word -> put(digit.toString(), word) }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/model/KeyBinding.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/model/KeyBinding.kt
@@ -60,6 +60,52 @@ internal fun composeKeyName(key: Key): String {
 }
 
 /**
+ * The name a captured [Key] should be STORED under, as opposed to merely compared by.
+ *
+ * [composeKeyName] gives whatever Compose renders, which is not the vocabulary the presets use:
+ * the left arrow renders "Left" against the presets' "DirectionLeft", the right bracket renders
+ * "Close Bracket" against "CloseBracket", and the 1 key renders "1" against "One". Every one of
+ * those MATCHES, because [canonicalKeyName] folds them - but none of them DISPLAYS the same,
+ * because `KeyStroke.formatKeyDisplay` knows "directionleft" and not "left". Stored raw, a
+ * rebound arrow would sit in the Shortcuts list as "⌘LEFT" beside a preset's "⌘←".
+ *
+ * Folding first makes a rebind indistinguishable from a preset binding everywhere: same match,
+ * same signature, same rendering. It also makes the stored value STABLE, which the raw rendering
+ * is not: `Key.toString()` falls through to AWT's `getKeyText`, so the same user rebinding Tab
+ * gets "Tab" or "⇥" in their file depending on whether the toolkit was up when they did it.
+ *
+ * Case is the one thing the fold does not carry, so the file
+ * gains "directionleft" where a preset has "DirectionLeft" - every comparison in the keymap is
+ * case-insensitive, and a lowercase name a reader can recognise beats a correctly-cased one
+ * nobody can.
+ */
+internal fun storedKeyName(key: Key): String = canonicalKeyName(composeKeyName(key))
+
+/**
+ * The key name a stored packed `Key.keyCode` stands for, or null when [stored] is not one.
+ *
+ * Every keymap ever saved through the Shortcuts screen carries these, so two callers need the
+ * answer: [canonicalKeyName], so an unmigrated file still MATCHES, and the settings migration,
+ * so the file stops holding a fifteen-digit key and the Shortcuts list stops rendering one.
+ * Both want the folded name, for the reason [storedKeyName] gives.
+ *
+ * Guarded to strings no key name can be - two or more characters, all digits. The single-digit
+ * spellings are claimed by [KEY_ALIASES] before this is reached, and Compose names no key in
+ * digits alone, so this cannot shadow a real name.
+ */
+internal fun keyNameForStoredKeyCode(stored: String): String? {
+    if (stored.length < 2 || !stored.all { it.isDigit() }) return null
+    // `takeIf { it != stored }` is checked BEFORE folding: an unnamed keyCode renders as the bare
+    // number, there is nothing to repair, and handing it back to `canonicalKeyName` would spin it
+    // straight through here again.
+    return stored
+        .toLongOrNull()
+        ?.let { composeKeyName(Key(it)) }
+        ?.takeIf { it != stored }
+        ?.let { canonicalKeyName(it) }
+}
+
+/**
  * The one name a key answers to, with every spelling the codebase can produce folded together.
  *
  * Three vocabularies reach this: Compose's `Key` property names, which the presets store
@@ -73,7 +119,12 @@ internal fun composeKeyName(key: Key): String {
  */
 internal fun canonicalKeyName(keyName: String): String {
     val lower = keyName.lowercase()
-    return KEY_ALIASES[lower] ?: lower
+    // The keyCode branch is for a packed `Key.keyCode`, written by every pre-#329 rebind. It is
+    // folded here rather than only migrated because the migration rewrites ONE file: a keymap
+    // restored from a backup, copied off another machine, or exported and re-imported reaches the
+    // matchers before it reaches the migration, and the whole failure is a rebind that silently
+    // does nothing.
+    return KEY_ALIASES[lower] ?: keyNameForStoredKeyCode(lower) ?: lower
 }
 
 /**
@@ -396,7 +447,10 @@ data class KeyBinding(
 
             return KeyBinding(
                 actionId = actionId,
-                key = key.keyCode.toString(),
+                // The name, not `key.keyCode` - see [composeKeyName]. Same defect as the capture
+                // dialog's (#329); this copy has no caller today, which is exactly why it would
+                // have been the one to survive.
+                key = storedKeyName(key),
                 modifiers = modifiers,
                 context = context,
                 enabled = true,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/keymap/KeymapSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/keymap/KeymapSettingsManager.kt
@@ -3,11 +3,13 @@ package ai.rever.boss.keymap
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.KeyStroke
 import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.keymap.model.keyNameForStoredKeyCode
 import ai.rever.boss.keymap.presets.KeymapPresets
 import ai.rever.boss.keymap.presets.KeymapPresets.claimsChord
 import ai.rever.boss.keymap.presets.KeymapPresets.withoutChordsTakenBy
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.ComponentLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -103,9 +105,18 @@ actual object KeymapSettingsManager {
      * @return Migrated settings with any missing actions added from the preset
      */
     internal fun migrateSettings(loaded: KeymapSettings): KeymapSettings {
+        // Before anything reads a chord off this keymap. Every rebind made in the Shortcuts
+        // screen up to #329 stored a packed `Key.keyCode`, and the chord arithmetic below is
+        // exactly what that breaks: `chordHolders` signs a numeric key into a signature no
+        // preset chord can equal, so a keymap whose owner rebound panel.navigate_right through
+        // the UI reads as NOT claiming that chord, and the drop-on-conflict guard added for
+        // that user hands them a second action on it. Repairing first is what makes the guard
+        // see the chords its motivating example is about.
+        val repaired = repairStoredKeyCodes(loaded, logger)
+
         // Get the preset that matches user's presetName
         val presetShortcuts =
-            when (loaded.presetName) {
+            when (repaired.presetName) {
                 "VS Code" -> KeymapPresets.getVSCodePreset().shortcuts
                 "IntelliJ IDEA" -> KeymapPresets.getIntelliJPreset().shortcuts
                 "Emacs" -> KeymapPresets.getEmacsPreset().shortcuts
@@ -115,10 +126,10 @@ actual object KeymapSettingsManager {
         // Find actions in preset that are missing from user settings
         val missingActions =
             presetShortcuts.filterKeys { actionId ->
-                !loaded.shortcuts.containsKey(actionId)
+                !repaired.shortcuts.containsKey(actionId)
             }
 
-        val alternateTopUps = alternateTopUps(loaded, presetShortcuts)
+        val alternateTopUps = alternateTopUps(repaired, presetShortcuts)
 
         // Chord-checked against the keymap as it will stand, exactly as withStandardBrowserBindings
         // checks additions against the preset. Adding a preset's new actions verbatim would ship
@@ -128,8 +139,8 @@ actual object KeymapSettingsManager {
         // tab.next_positional on it. The stored binding wins the match, so the new chord would
         // do nothing while the conflict badge lit up - and this PR lands twenty chords in one
         // migration, not one. An action whose every chord is taken is dropped, as in the merge.
-        val toppedUp = loaded.shortcuts + alternateTopUps
-        val holders = chordHolders(loaded.copy(shortcuts = toppedUp))
+        val toppedUp = repaired.shortcuts + alternateTopUps
+        val holders = chordHolders(repaired.copy(shortcuts = toppedUp))
         val newActions =
             missingActions.values
                 .mapNotNull { it.withoutChordsTakenBy(holders) }
@@ -149,7 +160,7 @@ actual object KeymapSettingsManager {
         }
 
         if (newActions.isEmpty() && alternateTopUps.isEmpty()) {
-            return loaded // No migration needed
+            return repaired // Nothing beyond the key-name repair, if any
         }
 
         logger.info(
@@ -166,7 +177,7 @@ actual object KeymapSettingsManager {
         // Merge: user settings, alternates topped up on untouched bindings, then new actions
         val mergedShortcuts = toppedUp + newActions
 
-        return loaded.copy(shortcuts = mergedShortcuts)
+        return repaired.copy(shortcuts = mergedShortcuts)
     }
 
     /**
@@ -352,3 +363,46 @@ private fun chordHolders(settings: KeymapSettings): List<KeyBinding> = settings.
  * object is at its TooManyFunctions threshold.
  */
 private fun KeyStroke.sameChordAs(other: KeyStroke): Boolean = signature() == other.signature()
+
+/**
+ * Rewrite any key stored as a packed `Key.keyCode` back to the name it stands for.
+ *
+ * The Shortcuts screen wrote `Key.keyCode.toString()` for every rebind up to #329, so a
+ * keymap that has been touched through the UI carries entries like
+ * `"key": "4294967333"`. `canonicalKeyName` resolves those at match time, so this is not what
+ * makes them fire again - it is what stops the Shortcuts list rendering a ten-digit key, what lets
+ * `migrateSettings`' chord arithmetic see the chord, and what keeps the file legible for the hand
+ * editing its own docs invite.
+ *
+ * Alternates are rewritten too: nothing writes one today, but `keymap-settings.json` is a
+ * documented hand-edited file and a repair that covers only half of a binding is a worse
+ * answer than one that covers none.
+ *
+ * Top-level rather than a member of the object, for the reason [sameChordAs] gives; the logger is
+ * passed in because that makes the object's private one unreachable.
+ */
+private fun repairStoredKeyCodes(
+    loaded: KeymapSettings,
+    logger: ComponentLogger,
+): KeymapSettings {
+    var repairs = 0
+
+    fun repair(key: String): String = keyNameForStoredKeyCode(key)?.also { repairs++ } ?: key
+
+    val shortcuts =
+        loaded.shortcuts.mapValues { (_, binding) ->
+            binding.copy(
+                key = repair(binding.key),
+                alternateKeystrokes = binding.alternateKeystrokes.map { it.copy(key = repair(it.key)) },
+            )
+        }
+
+    if (repairs == 0) return loaded
+
+    logger.info(
+        LogCategory.SYSTEM,
+        "Repaired keymap entries that stored a packed Key.keyCode instead of a key name",
+        mapOf("count" to repairs),
+    )
+    return loaded.copy(shortcuts = shortcuts)
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -549,8 +549,13 @@ object AWTKeyboardInterceptor {
      * worked only because the native menu carries its own accelerator, and fell dead the moment
      * a terminal or browser held focus. [keyNameMatches] accepts both spellings so an older or
      * hand-edited keymap file still resolves.
+     *
+     * `internal` so `KeyVocabularyAgreementTest` can hold this table against the names Compose
+     * renders for the same physical keys. The two are separate hand-maintained vocabularies over
+     * one keyboard, and every time they have drifted the symptom has been a chord that works on
+     * one path and silently does nothing on the other.
      */
-    private fun getKeyName(keyCode: Int): String =
+    internal fun getKeyName(keyCode: Int): String =
         when (keyCode) {
             KeyEvent.VK_A -> "A"
             KeyEvent.VK_B -> "B"

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/CanonicalKeyNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/CanonicalKeyNameTest.kt
@@ -66,6 +66,41 @@ class CanonicalKeyNameTest {
     }
 
     @Test
+    fun `the glyphs Compose renders once the AWT toolkit is up`() {
+        // `Key.toString()` falls through to AWT's `getKeyText`, which answers with a word while
+        // the toolkit is cold and with the macOS glyph once it is up - so one machine produces
+        // both spellings and which one a keymap holds depends on nothing the user did. Enumerated
+        // here rather than left to `KeyVocabularyAgreementTest`, whose input is whatever the
+        // environment happened to render: a cold run there cannot see a missing glyph.
+        assertAllSame("Escape", "Esc", "\u238B")
+        assertAllSame("Enter", "Return", "\u23CE")
+        assertAllSame("Tab", "\u21E5")
+        assertAllSame("Backspace", "\u232B")
+        assertAllSame("Delete", "\u2326")
+        assertAllSame("Home", "\u2196")
+        assertAllSame("End", "\u2198")
+        assertAllSame("PageUp", "Page Up", "\u21DE")
+        assertAllSame("PageDown", "Page Down", "\u21DF")
+        assertAllSame("Space", "Spacebar", "\u2423")
+        assertNotEquals(canonicalKeyName("\u21DE"), canonicalKeyName("\u21DF"))
+        assertNotEquals(canonicalKeyName("\u232B"), canonicalKeyName("\u2326"))
+        assertNotEquals(canonicalKeyName("\u2196"), canonicalKeyName("\u2198"))
+    }
+
+    @Test
+    fun `the spaced spellings Compose renders`() {
+        // `Key.toString()` is where the capture dialog and the Compose matcher both get a name,
+        // and it spaces words the AWT interceptor and the presets run together. Every one of
+        // these was a chord that resolved on one path and silently did nothing on the other;
+        // `KeyVocabularyAgreementTest` is what walks the whole keyboard for the next one.
+        assertAllSame("Backslash", "Back Slash", "\\")
+        assertAllSame("Apostrophe", "Quote", "'")
+        assertAllSame("Grave", "Back Quote", "`")
+        assertNotEquals(canonicalKeyName("PageUp"), canonicalKeyName("PageDown"))
+        assertNotEquals(canonicalKeyName("Grave"), canonicalKeyName("Apostrophe"))
+    }
+
+    @Test
     fun `an unknown name canonicalises to itself, case-folded`() {
         // What makes the presets' own vocabulary the default answer rather than a special case.
         assertEquals(canonicalKeyName("F7"), canonicalKeyName("f7"))

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/CanonicalKeyNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/CanonicalKeyNameTest.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.keymap
 
 import ai.rever.boss.keymap.model.canonicalKeyName
+import ai.rever.boss.keymap.model.composeKeyName
+import androidx.compose.ui.input.key.Key
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -98,6 +100,20 @@ class CanonicalKeyNameTest {
         assertAllSame("Grave", "Back Quote", "`")
         assertNotEquals(canonicalKeyName("PageUp"), canonicalKeyName("PageDown"))
         assertNotEquals(canonicalKeyName("Grave"), canonicalKeyName("Apostrophe"))
+    }
+
+    @Test
+    fun `a packed Key keyCode folds onto the key it stands for`() {
+        // What every rebind made in the Shortcuts screen wrote before #329. An unmigrated keymap
+        // has to keep matching, so the fold answers for these rather than only the migration.
+        listOf(Key.DirectionLeft, Key.Spacebar, Key.Enter, Key.Escape, Key.A, Key.One, Key.Backslash)
+            .forEach { key ->
+                assertEquals(
+                    canonicalKeyName(composeKeyName(key)),
+                    canonicalKeyName(key.keyCode.toString()),
+                    "a stored keyCode should be the same key as its name: $key",
+                )
+            }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeyCaptureNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeyCaptureNameTest.kt
@@ -1,0 +1,203 @@
+package ai.rever.boss.keymap
+
+import ai.rever.boss.keymap.model.KeyStroke
+import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.keymap.model.canonicalKeyName
+import ai.rever.boss.keymap.model.storedKeyName
+import ai.rever.boss.keymap.presets.KeymapPresets
+import ai.rever.boss.window.AWTKeyboardInterceptor
+import androidx.compose.ui.input.key.Key
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What the Shortcuts screen writes when a user rebinds an action, against what the two matchers
+ * will accept when that user presses the key.
+ *
+ * `KeyCaptureDialog` stored `Key.keyCode.toString()` - Compose's PACKED code, "4294967333"
+ * for the left arrow - while both matchers compare key NAMES. So a rebind saved, listed and then
+ * fired on neither path, with no conflict badge and no error to explain it (#329). These are the
+ * assertions that would have caught it: the name the dialog produces has to be the same key as
+ * the one the presets spell, on both paths, for every key a preset uses.
+ */
+class KeyCaptureNameTest {
+    /**
+     * The Compose [Key] a user presses, against the spelling the presets store for it.
+     *
+     * Hand-written rather than derived, because deriving it from `storedKeyName` is what is
+     * under test. [`every key the presets use is covered here`] keeps it honest: a preset that
+     * starts using a key absent from this table fails the build rather than shipping a chord
+     * nobody can rebind.
+     */
+    private val presetSpellingByKey: Map<Key, String> =
+        mapOf(
+            Key.B to "B",
+            Key.E to "E",
+            Key.F to "F",
+            Key.G to "G",
+            Key.H to "H",
+            Key.I to "I",
+            Key.K to "K",
+            Key.L to "L",
+            Key.N to "N",
+            Key.O to "O",
+            Key.P to "P",
+            Key.R to "R",
+            Key.S to "S",
+            Key.T to "T",
+            Key.W to "W",
+            Key.X to "X",
+            Key.Zero to "Zero",
+            Key.One to "One",
+            Key.Two to "Two",
+            Key.Three to "Three",
+            Key.Four to "Four",
+            Key.Five to "Five",
+            Key.Six to "Six",
+            Key.Seven to "Seven",
+            Key.Eight to "Eight",
+            Key.Nine to "Nine",
+            Key.Minus to "Minus",
+            Key.Equals to "Equals",
+            Key.Slash to "Slash",
+            Key.Backslash to "Backslash",
+            Key.Comma to "Comma",
+            Key.Tab to "Tab",
+            Key.Spacebar to "Spacebar",
+            Key.DirectionLeft to "DirectionLeft",
+            Key.DirectionRight to "DirectionRight",
+            Key.DirectionUp to "DirectionUp",
+            Key.DirectionDown to "DirectionDown",
+            Key.LeftBracket to "OpenBracket",
+            Key.RightBracket to "CloseBracket",
+        )
+
+    /**
+     * Run [check] over every key in the table and fail once with all of its complaints.
+     *
+     * A gap in the name fold is rarely one key - the bracket pair was two, `Back Slash` and
+     * `Close Bracket` are the same shape - and failing on the first turns one build into
+     * several to learn the shape of the problem.
+     */
+    private fun assertNoMismatches(
+        what: String,
+        check: (Key, String) -> String?,
+    ) {
+        val complaints =
+            presetSpellingByKey.mapNotNull { (key, spelling) ->
+                check(key, spelling)?.let { "  $key: $it" }
+            }
+        assertTrue(complaints.isEmpty(), "$what:\n" + complaints.joinToString("\n"))
+    }
+
+    private fun shippedPresets(): List<KeymapSettings> =
+        listOf(
+            KeymapPresets.getBOSSDefault(),
+            KeymapPresets.getVSCodePreset(),
+            KeymapPresets.getIntelliJPreset(),
+            KeymapPresets.getEmacsPreset(),
+        )
+
+    @Test
+    fun `every key the presets use is covered here`() {
+        val spellings =
+            shippedPresets()
+                .flatMap { it.shortcuts.values }
+                .flatMap { it.allKeystrokes }
+                .map { it.key }
+                .toSet()
+
+        val uncovered = spellings - presetSpellingByKey.values.toSet()
+        assertTrue(
+            uncovered.isEmpty(),
+            "a preset uses a key this test cannot capture, so nothing here proves it is rebindable: $uncovered",
+        )
+    }
+
+    @Test
+    fun `a captured key is stored as a name, never as a packed keyCode`() {
+        presetSpellingByKey.keys.forEach { key ->
+            val stored = storedKeyName(key)
+            assertTrue(
+                stored.any { !it.isDigit() },
+                "the capture dialog would store a packed keyCode for $key: '$stored'",
+            )
+        }
+    }
+
+    @Test
+    fun `a captured key is the same key the presets spell`() {
+        assertNoMismatches("a rebind claims a different key than the preset it replaces") { key, presetSpelling ->
+            val stored = canonicalKeyName(storedKeyName(key))
+            val preset = canonicalKeyName(presetSpelling)
+            "stored '${storedKeyName(key)}' folds to '$stored', preset '$presetSpelling' folds to '$preset'"
+                .takeIf { stored != preset }
+        }
+    }
+
+    @Test
+    fun `a captured key resolves on the AWT path too`() {
+        // The two paths are separate implementations over separate vocabularies - AWT key codes
+        // on one side, Compose Key names on the other - so a name that satisfies the Compose
+        // matcher proves nothing about the interceptor. Both, or the rebind is still half dead.
+        assertNoMismatches("the AWT interceptor does not accept what the dialog stores") { key, presetSpelling ->
+            "stored '${storedKeyName(key)}' is not '$presetSpelling' to the interceptor"
+                .takeIf { !AWTKeyboardInterceptor.keyNameMatches(storedKeyName(key), presetSpelling) }
+        }
+    }
+
+    @Test
+    fun `a rebind renders exactly like the preset binding it replaces`() {
+        // Why the capture folds the name before storing it rather than keeping what Compose
+        // renders. `Key.DirectionLeft` renders "Left", `Key.RightBracket` renders "Close
+        // Bracket", `Key.One` renders "1" - all three MATCH through the alias table, and all
+        // three would have listed as "⌘LEFT", "⌘CLOSE BRACKET" and "⌘1" beside a preset's "⌘←",
+        // "⌘]" and "⌘1", because the display formatter knows only the presets' spellings.
+        assertNoMismatches("a rebind does not render like the preset binding it replaces") { key, presetSpelling ->
+            val rebound = KeyStroke(storedKeyName(key), listOf("Cmd")).displayString()
+            val preset = KeyStroke(presetSpelling, listOf("Cmd")).displayString()
+            "lists as '$rebound', preset lists as '$preset'".takeIf { rebound != preset }
+        }
+    }
+
+    @Test
+    fun `a keymap still holding a packed keyCode keeps matching`() {
+        // The migration rewrites the file, but it rewrites ONE file. A keymap restored from a
+        // backup, copied off another machine, or exported and re-imported reaches the matchers
+        // first, and the failure being fixed is a rebind that silently does nothing.
+        assertNoMismatches("a pre-#329 keymap entry no longer fires") { key, presetSpelling ->
+            val stored = canonicalKeyName(key.keyCode.toString())
+            "stored keyCode ${key.keyCode} folds to '$stored', not '$presetSpelling'"
+                .takeIf { stored != canonicalKeyName(presetSpelling) }
+        }
+    }
+
+    @Test
+    fun `a packed keyCode and its name are one chord, not two`() {
+        // Signatures are what KeymapValidator groups conflicts by, what `claimsChord` asks, and
+        // what the migration's drop-on-conflict guard reads. While a UI rebind signed as a
+        // fifteen-digit key it collided with nothing, so the guard added for "someone who
+        // rebound panel.navigate_right" could not see the very rebinds it was written for.
+        assertNoMismatches("a stored keyCode signs as a different chord than its name") { key, presetSpelling ->
+            val stored = KeyStroke(key.keyCode.toString(), listOf("Cmd", "Alt")).signature()
+            val named = KeyStroke(presetSpelling, listOf("Cmd", "Alt")).signature()
+            "signs as '$stored', '$presetSpelling' signs as '$named'".takeIf { stored != named }
+        }
+    }
+
+    @Test
+    fun `single digits are still their word forms, not keyCodes`() {
+        // The keyCode fold is guarded to two-or-more all-digit strings precisely so the digit
+        // spellings the alias table already claims keep reaching their word forms. Losing this
+        // would take Cmd+1 out, which no test above would notice.
+        listOf("Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine")
+            .forEachIndexed { digit, word ->
+                assertEquals(
+                    canonicalKeyName(word),
+                    canonicalKeyName(digit.toString()),
+                    "'$digit' should still be '$word'",
+                )
+            }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeyVocabularyAgreementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeyVocabularyAgreementTest.kt
@@ -1,0 +1,157 @@
+package ai.rever.boss.keymap
+
+import ai.rever.boss.keymap.model.canonicalKeyName
+import ai.rever.boss.keymap.model.composeKeyName
+import ai.rever.boss.window.AWTKeyboardInterceptor
+import androidx.compose.ui.input.key.Key
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import java.awt.event.KeyEvent as AwtKeyEvent
+
+/**
+ * The two key-name vocabularies BOSS maintains, held against each other key by key.
+ *
+ * `AWTKeyboardInterceptor.getKeyName` names a physical key one way; Compose's `Key.toString()`,
+ * which is where the Shortcuts screen and `KeymapMatcher` both get their name, names it another.
+ * Neither list is derived from the other, and where they disagree the result is always the same
+ * shape: a chord that fires on one path and silently does nothing on the other, with no conflict
+ * badge and no error to explain it.
+ *
+ * Its input is whatever this environment renders, which is deliberate - CI runs it on three
+ * platforms and `Key.toString()` answers differently on each, and differently again depending on
+ * whether the AWT toolkit has been initialised yet (a word while cold, a macOS glyph once up).
+ * So it is a canary over the real vocabulary rather than a fixed list, and `CanonicalKeyNameTest`
+ * carries the enumerated spellings that a single run cannot be trusted to reach.
+ *
+ * They had drifted on fourteen keys when this was written - the nine macOS glyphs a running app
+ * renders (Enter, Escape, Tab, Backspace, Delete, Home, End, PageUp, PageDown) and five cold
+ * spellings (`Back Slash`, `Quote`, `Back Quote`, `Page Up`, `Page Down`) - on top of the
+ * "Left"/"DirectionLeft" and bracket-pair gaps found before it. The glyphs were the reachable
+ * half: Ctrl+Tab and Ctrl+Shift+Tab are shipped in all four presets and asked this matcher
+ * whether "⇥" was "Tab".
+ *
+ * `canonicalKeyName` is the fold that reconciles them, so what this asserts is that the fold
+ * covers the keyboard rather than the handful of keys someone happened to notice.
+ */
+class KeyVocabularyAgreementTest {
+    /**
+     * One physical key, named from both sides.
+     *
+     * The pairing is the only thing that has to be hand-written - it is the identity of the key
+     * itself, not either vocabulary - and everything else is read out of the two tables under
+     * test. Modifier-only keys are left out: the interceptor gates on them rather than binding
+     * them, so they never reach a keymap entry.
+     */
+    private val keyboard: List<Pair<Key, Int>> =
+        listOf(
+            Key.A to AwtKeyEvent.VK_A,
+            Key.B to AwtKeyEvent.VK_B,
+            Key.C to AwtKeyEvent.VK_C,
+            Key.D to AwtKeyEvent.VK_D,
+            Key.E to AwtKeyEvent.VK_E,
+            Key.F to AwtKeyEvent.VK_F,
+            Key.G to AwtKeyEvent.VK_G,
+            Key.H to AwtKeyEvent.VK_H,
+            Key.I to AwtKeyEvent.VK_I,
+            Key.J to AwtKeyEvent.VK_J,
+            Key.K to AwtKeyEvent.VK_K,
+            Key.L to AwtKeyEvent.VK_L,
+            Key.M to AwtKeyEvent.VK_M,
+            Key.N to AwtKeyEvent.VK_N,
+            Key.O to AwtKeyEvent.VK_O,
+            Key.P to AwtKeyEvent.VK_P,
+            Key.Q to AwtKeyEvent.VK_Q,
+            Key.R to AwtKeyEvent.VK_R,
+            Key.S to AwtKeyEvent.VK_S,
+            Key.T to AwtKeyEvent.VK_T,
+            Key.U to AwtKeyEvent.VK_U,
+            Key.V to AwtKeyEvent.VK_V,
+            Key.W to AwtKeyEvent.VK_W,
+            Key.X to AwtKeyEvent.VK_X,
+            Key.Y to AwtKeyEvent.VK_Y,
+            Key.Z to AwtKeyEvent.VK_Z,
+            Key.Zero to AwtKeyEvent.VK_0,
+            Key.One to AwtKeyEvent.VK_1,
+            Key.Two to AwtKeyEvent.VK_2,
+            Key.Three to AwtKeyEvent.VK_3,
+            Key.Four to AwtKeyEvent.VK_4,
+            Key.Five to AwtKeyEvent.VK_5,
+            Key.Six to AwtKeyEvent.VK_6,
+            Key.Seven to AwtKeyEvent.VK_7,
+            Key.Eight to AwtKeyEvent.VK_8,
+            Key.Nine to AwtKeyEvent.VK_9,
+            Key.F1 to AwtKeyEvent.VK_F1,
+            Key.F2 to AwtKeyEvent.VK_F2,
+            Key.F3 to AwtKeyEvent.VK_F3,
+            Key.F4 to AwtKeyEvent.VK_F4,
+            Key.F5 to AwtKeyEvent.VK_F5,
+            Key.F6 to AwtKeyEvent.VK_F6,
+            Key.F7 to AwtKeyEvent.VK_F7,
+            Key.F8 to AwtKeyEvent.VK_F8,
+            Key.F9 to AwtKeyEvent.VK_F9,
+            Key.F10 to AwtKeyEvent.VK_F10,
+            Key.F11 to AwtKeyEvent.VK_F11,
+            Key.F12 to AwtKeyEvent.VK_F12,
+            Key.Enter to AwtKeyEvent.VK_ENTER,
+            Key.Escape to AwtKeyEvent.VK_ESCAPE,
+            Key.Spacebar to AwtKeyEvent.VK_SPACE,
+            Key.Tab to AwtKeyEvent.VK_TAB,
+            Key.Backspace to AwtKeyEvent.VK_BACK_SPACE,
+            Key.Delete to AwtKeyEvent.VK_DELETE,
+            Key.DirectionLeft to AwtKeyEvent.VK_LEFT,
+            Key.DirectionRight to AwtKeyEvent.VK_RIGHT,
+            Key.DirectionUp to AwtKeyEvent.VK_UP,
+            Key.DirectionDown to AwtKeyEvent.VK_DOWN,
+            Key.MoveHome to AwtKeyEvent.VK_HOME,
+            Key.MoveEnd to AwtKeyEvent.VK_END,
+            Key.PageUp to AwtKeyEvent.VK_PAGE_UP,
+            Key.PageDown to AwtKeyEvent.VK_PAGE_DOWN,
+            Key.Minus to AwtKeyEvent.VK_MINUS,
+            Key.Equals to AwtKeyEvent.VK_EQUALS,
+            Key.LeftBracket to AwtKeyEvent.VK_OPEN_BRACKET,
+            Key.RightBracket to AwtKeyEvent.VK_CLOSE_BRACKET,
+            Key.Slash to AwtKeyEvent.VK_SLASH,
+            Key.Backslash to AwtKeyEvent.VK_BACK_SLASH,
+            Key.Semicolon to AwtKeyEvent.VK_SEMICOLON,
+            Key.Apostrophe to AwtKeyEvent.VK_QUOTE,
+            Key.Comma to AwtKeyEvent.VK_COMMA,
+            Key.Period to AwtKeyEvent.VK_PERIOD,
+            Key.Grave to AwtKeyEvent.VK_BACK_QUOTE,
+        )
+
+    @Test
+    fun `both paths name the same physical key the same key`() {
+        val disagreements =
+            keyboard.mapNotNull { (key, awtKeyCode) ->
+                val fromCompose = composeKeyName(key)
+                val fromAwt = AWTKeyboardInterceptor.getKeyName(awtKeyCode)
+                "  $key: Compose says '$fromCompose', AWT says '$fromAwt'"
+                    .takeIf { canonicalKeyName(fromCompose) != canonicalKeyName(fromAwt) }
+            }
+
+        assertTrue(
+            disagreements.isEmpty(),
+            "these keys resolve on one path and not the other, which is a chord that silently " +
+                "does nothing wherever the other path is the one listening:\n" +
+                disagreements.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun `distinct keys stay distinct through the fold`() {
+        // The other half of the same contract, and the cheaper mistake to make: an alias table
+        // reconciles spellings by collapsing them, and one entry in the wrong row would silently
+        // make two keys the same chord. Asserting only agreement above would pass on a fold that
+        // answered the same thing for everything.
+        val collisions =
+            keyboard
+                .groupBy { (key, _) -> canonicalKeyName(composeKeyName(key)) }
+                .filterValues { it.size > 1 }
+
+        assertTrue(
+            collisions.isEmpty(),
+            "the fold collapsed keys that are not the same key: " +
+                collisions.map { (canonical, keys) -> "$canonical <- ${keys.map { it.first }}" },
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapMigrationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapMigrationTest.kt
@@ -6,7 +6,9 @@ import ai.rever.boss.keymap.model.KeyStroke
 import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.keymap.model.canonicalKeyName
 import ai.rever.boss.keymap.presets.KeymapPresets
+import androidx.compose.ui.input.key.Key
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -230,6 +232,86 @@ class KeymapMigrationTest {
 
         assertNotNull(migrated.getBinding(KeymapActions.TAB_REOPEN_CLOSED), "Cmd+Shift+T should be added")
         assertNotNull(migrated.getBinding(KeymapActions.TAB_SELECT_1))
+    }
+
+    @Test
+    fun `a keycode written by the Shortcuts screen is repaired to a key name`() {
+        // Everything the capture dialog saved before #329: a packed `Key.keyCode`, which the
+        // Shortcuts list then renders as a fifteen-digit "key".
+        val legacy = legacySettings()
+        val uiRebound =
+            assertNotNull(legacy.getBinding(KeymapActions.PANEL_NAVIGATE_RIGHT))
+                .copy(key = Key.DirectionRight.keyCode.toString(), modifiers = listOf("Cmd", "Alt"))
+        val settings = legacy.copy(shortcuts = legacy.shortcuts + (uiRebound.actionId to uiRebound))
+
+        val migrated = KeymapSettingsManager.migrateSettings(settings)
+
+        val repaired = assertNotNull(migrated.getBinding(KeymapActions.PANEL_NAVIGATE_RIGHT))
+        assertEquals(
+            canonicalKeyName("DirectionRight"),
+            canonicalKeyName(repaired.key),
+            "the stored keyCode should have been rewritten to the key it stands for",
+        )
+        assertTrue(
+            repaired.key.any { !it.isDigit() },
+            "the file should no longer hold a raw keyCode: '${repaired.key}'",
+        )
+        assertEquals(listOf("Cmd", "Alt"), repaired.modifiers, "the user's chord is otherwise untouched")
+    }
+
+    @Test
+    fun `a chord rebound through the UI is seen by the drop-on-conflict guard`() {
+        // The same scenario as `a new action is dropped when the stored keymap already claims its
+        // chord`, with the rebind made in the Shortcuts screen rather than by hand - which is the
+        // only way most people make one. It is also the reason the repair runs BEFORE the chord
+        // arithmetic instead of after it: `chordHolders` signs a numeric key into a signature no
+        // preset chord can equal, so this keymap read as NOT holding Cmd+3 and the guard handed
+        // tab.select_3 straight onto it. Hand-edited files were protected and the ones made in
+        // the app were not, which is the opposite of who needs it.
+        val legacy = legacySettings()
+        val uiRebound =
+            assertNotNull(legacy.getBinding(KeymapActions.PANEL_NAVIGATE_RIGHT))
+                .copy(key = Key.Three.keyCode.toString(), modifiers = listOf("Cmd"))
+        val customised =
+            legacy.copy(shortcuts = legacy.shortcuts + (KeymapActions.PANEL_NAVIGATE_RIGHT to uiRebound))
+
+        val migrated = KeymapSettingsManager.migrateSettings(customised)
+
+        assertEquals(
+            canonicalKeyName("Three"),
+            canonicalKeyName(assertNotNull(migrated.getBinding(KeymapActions.PANEL_NAVIGATE_RIGHT)).key),
+            "the user's own binding is untouched apart from the repair",
+        )
+        assertNull(
+            migrated.getBinding(KeymapActions.TAB_SELECT_BY_INDEX[2]),
+            "Cmd+3 was taken by a UI rebind, so the new action is dropped rather than shipped as a conflict",
+        )
+        // The rest of the batch still lands: dropping is per action, not all-or-nothing.
+        assertNotNull(migrated.getBinding(KeymapActions.TAB_SELECT_BY_INDEX[0]))
+        assertNotNull(migrated.getBinding(KeymapActions.TAB_REOPEN_CLOSED))
+    }
+
+    @Test
+    fun `a repaired alternate keeps its chord`() {
+        // keymap-settings.json is documented as hand-editable, so an alternate can carry a
+        // keyCode too. Repairing only the primary would leave the binding half readable.
+        val legacy = legacySettings()
+        val withAlternate =
+            assertNotNull(legacy.getBinding(KeymapActions.BROWSER_ZOOM_IN))
+                .copy(alternateKeystrokes = listOf(KeyStroke(Key.Equals.keyCode.toString(), listOf("Cmd", "Shift"))))
+        val settings = legacy.copy(shortcuts = legacy.shortcuts + (withAlternate.actionId to withAlternate))
+
+        val migrated = KeymapSettingsManager.migrateSettings(settings)
+
+        val zoomIn = assertNotNull(migrated.getBinding(KeymapActions.BROWSER_ZOOM_IN))
+        assertTrue(
+            zoomIn.alternateKeystrokes.any { canonicalKeyName(it.key) == canonicalKeyName("Equals") },
+            "the alternate should have been repaired too: ${zoomIn.alternateKeystrokes}",
+        )
+        assertTrue(
+            zoomIn.alternateKeystrokes.none { stroke -> stroke.key.all { it.isDigit() } },
+            "no alternate should still hold a raw keyCode",
+        )
     }
 
     @Test


### PR DESCRIPTION
Completes #329, on top of the one-line capture fix in #335.

> **Stacked on #373.** This branch contains #373's commit as its base, so the diff below shows both. The commit to review here is the second one, `Store a folded key name on capture, and repair the keymaps that hold a keyCode`. If #373 lands first this rebases to nothing; if you would rather have them as one PR, say so and I will squash them.

## What #335 already does, and what it leaves

#335 changes the capture to store `capturedKey.toString().removePrefix("Key: ").trim()`. That is the right shape and it stops new rebinds being dead. Its own description records the rest as future work:

> Existing user keymap entries that were previously persisted using numeric key codes may require separate migration or compatibility handling if such entries are encountered.

That is every keymap that has ever been touched through the Shortcuts screen. This PR is that handling, plus the three places the same defect survives, plus tests. I have no interest in duplicating #335 and am happy for it to land first.

## Fold the name before storing it

The raw rendering is neither the presets' vocabulary nor stable.

It is not the vocabulary: the left arrow renders `Left` against the presets' `DirectionLeft`, the right bracket `Close Bracket` against `CloseBracket`, the 1 key `1` against `One`. All three **match**, through the alias table. None of them **display** the same, because `formatKeyDisplay` knows `directionleft` and not `left`. Stored raw, a rebound arrow lists in the Shortcuts screen as `⌘LEFT` beside a preset's `⌘←`.

It is not stable: `Key.toString()` falls through to AWT's `getKeyText`, which answers with a word while the toolkit is cold and with the macOS glyph once it is up. The same user rebinding Tab gets `Tab` or `⇥` in their file depending on nothing they did. (That instability is the subject of #372 / #373, which this is stacked on.)

`storedKeyName` folds through `canonicalKeyName` first. A rebind is then indistinguishable from a preset binding: same match, same signature, same rendering, and deterministic. The cost is that the file gains `directionleft` where a preset has `DirectionLeft`; every comparison in the keymap is case-insensitive, and I would rather a lowercase name a reader recognises than a correctly-cased one nobody does. Happy to be overruled on that.

## Existing keymaps are handled twice, deliberately

`canonicalKeyName` resolves a stored keyCode so an unmigrated file keeps matching, **and** the settings migration rewrites it so the file stops holding a ten-digit key.

Either alone is not enough. The migration cleans one file, and a keymap restored from a backup, copied off another machine, or exported and re-imported reaches the matchers before it reaches the migration. The fold is guarded to strings no key name can be (two or more characters, all digits), so it cannot shadow a real name; the single-digit spellings are claimed by `KEY_ALIASES` before it is reached.

## The repair runs before the chord arithmetic

This is the ordering that matters, and it is what lets #322's drop-on-conflict guard see a UI rebind at all.

While a rebind signed as a numeric key, `chordHolders` produced a signature no preset chord could equal. So a keymap whose owner had rebound an action through the UI read as *not* claiming that chord, and migration handed a new action straight onto it. #322's motivating example is "someone who rebound `panel.navigate_right` to Cmd+Opt+Right", which is a UI rebind: the guard was protecting hand-edited files and not the ones made in the app, which is the opposite of who needs it. `a chord rebound through the UI is seen by the drop-on-conflict guard` is that scenario, mirroring the existing hand-edited test beside it.

## Two smaller things

- **The dialog's preview was rendering the raw keyCode too.** It had a private copy of the display formatter (`buildDisplayString` plus a third `formatKeyDisplay`). It now renders the exact `KeyStroke` that Apply persists, so the preview cannot disagree with what is saved, and the duplicated formatter goes.
- **`KeyBinding.fromComposeKey` had the same `key.keyCode.toString()` line.** It has no caller today, which is exactly why it would have outlived the fix.

## Answering the question the issue leaves open

> Worth checking whether the Shortcuts screen's own tester reports these as unmatched today; if so it is a usable repro without a build change.

It does. `ShortcutTestRunner.testShortcut` step 4 calls `validateKeyName`, a numeric key reaches its final branch, and the row fails with `Unknown key name '4294967333' - won't match user input`.

## Tests

- `KeyCaptureNameTest` covers the round trip over every key the presets use: stored as a name, same key as the preset spells, resolves on the AWT path too, renders identically to the preset binding, an unmigrated keyCode still matches, and a keyCode signs as the same chord as its name. `every key the presets use is covered here` fails if a preset starts using a key the test cannot capture, so the coverage cannot quietly fall behind the presets.
- `KeymapMigrationTest` gains three: the repair itself, the alternate-keystroke case, and the #322 guard seeing a UI rebind.
- `CanonicalKeyNameTest` gains the packed-keyCode fold.

`:composeApp:desktopTest` (3705 tests), `:composeApp:ktlintCheck` and `:composeApp:detekt` all pass.

## Noted, not fixed

Two more copies of the key vocabulary, left alone to keep this reviewable. Both would be their own issue if wanted:

- `ShortcutTestRunner.validateKeyName` keeps a fourth hardcoded list of valid key names. It rejects `F7` and the bracket spellings, so the tester reports valid bindings as failures.
- `KeyStroke.matches` compares key names raw with no fold. It has no production caller today (only tests), which makes it a trap rather than a live bug.
