### PR TITLE
Cap plugin MCP tool results at the host, so no single result can flood the context

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
@@ -279,6 +279,78 @@ internal fun mcpToolPermitted(
     }
 
 /**
+ * Hard ceiling, in characters, on what [McpToolRegistryCore.invoke] hands back for one
+ * plugin tool call.
+ *
+ * **A backstop against catastrophe, not a substitute for per-tool limits.** An MCP result
+ * is re-sent as cached prefix on every later request for the rest of the session, so one
+ * oversized answer is a recurring cost, not a one-off: a single `console_search` was
+ * measured at 234,000 tokens on a real host. Tools are still expected to bound their own
+ * output - page it, summarise it, say what they left out. Returning 149,000 characters
+ * because the cap permits it is a bug in the tool, not compliance with this.
+ *
+ * The number mirrors BossTerm's `mcpMaxAnswerChars` (TerminalSettings, default 150_000),
+ * which is what its private `shorten()` enforces over its own built-in handlers. It is
+ * duplicated rather than read because the host cannot reach that setting: bossterm-compose
+ * is bundled privately inside the terminal-tab plugin's JAR and resolved by that plugin's
+ * classloader, so BossConsole has no compile- or run-time handle on it. Change one and
+ * change the other; two ceilings for one product is worse than either number alone.
+ */
+internal const val MAX_MCP_RESULT_CHARS: Int = 150_000
+
+/**
+ * Cut [text] to at most [cap] characters and append a marker saying so.
+ *
+ * A free function next to [mcpToolPermitted], for the same reason: the rule is testable
+ * without constructing the singleton.
+ *
+ * Three things a bare `take(cap)` gets wrong here:
+ * - **Silence.** A cut prefix reads as a complete answer and the agent acts on it, so the
+ *   marker is appended *after* the cut: a truncated result always ends with its own
+ *   explanation.
+ * - **The tool's own trailing note.** Several tools close with something like
+ *   `[504 older matching lines omitted...]`, which is precisely what cutting the tail
+ *   destroys. The marker names that loss rather than leaving a reader to assume the tool
+ *   reported everything it had.
+ * - **Surrogate pairs.** Cutting between a high and a low surrogate leaves a lone
+ *   surrogate, so the boundary backs off one character when the last kept char is a high
+ *   surrogate.
+ *
+ * The return is `<= cap` characters, marker included: the marker is first sized against
+ * its worst case (nothing kept, so the largest digit count its numbers can carry) and that
+ * length reserved out of the budget. The one exception is a [cap] smaller than the marker
+ * itself, which only a test would set - a slightly over-cap explanation still beats an
+ * unexplained blob. A [cap] of zero or less disables the cap, matching `shorten()`.
+ */
+internal fun capMcpResultText(
+    text: String,
+    cap: Int = MAX_MCP_RESULT_CHARS,
+): String {
+    if (cap <= 0 || text.length <= cap) return text
+    // Worst case is "nothing kept", the most digits `dropped` can carry; the real marker is
+    // therefore never longer than this, so reserving its length cannot overflow the cap.
+    val reserved = truncationMarker(total = text.length, dropped = text.length, cap = cap).length
+    val budget = (cap - reserved).coerceAtLeast(0)
+    // Never end on a high surrogate: its low partner is in the part being dropped.
+    val keep = if (budget > 0 && text[budget - 1].isHighSurrogate()) budget - 1 else budget
+    return text.take(keep) + truncationMarker(total = text.length, dropped = text.length - keep, cap = cap)
+}
+
+/**
+ * The note [capMcpResultText] leaves in place of the cut tail. Worded to stand on its own,
+ * because it may be the only thing left where the tool had written its own "omitted" line.
+ */
+private fun truncationMarker(
+    total: Int,
+    dropped: Int,
+    cap: Int,
+): String =
+    "\n\n[BOSS host cap: this tool result was $total characters, over the $cap-character " +
+        "limit, so the last $dropped characters were cut. Whatever the tool put at the end is " +
+        "gone, including any note it appended about content it had already left out. Re-run " +
+        "with a narrower query, a filter, or a smaller range to get the rest.]"
+
+/**
  * Testable core behind [McpToolRegistryImpl]. Extracted so unit tests can
  * exercise the registration/permission/persistence/dispatch logic against a
  * throwaway instance and a temp file, instead of the process-wide singleton
@@ -289,12 +361,21 @@ internal fun mcpToolPermitted(
  * in-memory), which is convenient for tests that don't care about it.
  * [invokeTimeoutMs] defaults to production's 60s but is overridable so tests
  * can exercise the timeout path in milliseconds instead of actually waiting.
+ * [maxResultChars] is the same story for the result-size backstop: production
+ * gets [MAX_MCP_RESULT_CHARS], tests get a number they can overshoot in a line.
  * [onFault] is how a kill-switch persistence failure reaches the operator (the
  * façade turns it into a status-bar message); it is also mirrored into [fault].
  */
+// 7 of these arrived with the governance work (policy engine, approval bus, ledger); this
+// change adds the 8th, `maxResultChars`, purely as a test seam alongside `invokeTimeoutMs`.
+// Suppressed rather than hidden behind mutable state: the count is a real signal that this
+// class wants its collaborators grouped into a config object, and that should stay visible
+// to whoever adds the ninth.
+@Suppress("LongParameterList")
 internal class McpToolRegistryCore(
     private val disabledFile: File?,
     private val invokeTimeoutMs: Long = 60_000L,
+    private val maxResultChars: Int = MAX_MCP_RESULT_CHARS,
     private val onFault: (McpKillSwitchFault) -> Unit = {},
     val policyEngine: McpPolicyEngine = McpPolicyEngine(),
     val approvalBus: McpApprovalBus = McpApprovalBus(),
@@ -772,8 +853,41 @@ internal class McpToolRegistryCore(
             }
         }
 
+    private suspend fun executeAuthorized(
+        tool: RegisteredMcpTool,
+        args: McpToolArgs,
+    ): McpToolResult = capResult(tool.definition.name, executeUncapped(tool, args))
+
+    /**
+     * Bound the text a plugin answers with, whatever it asked to say.
+     *
+     * This sits on the execution path rather than on [invoke] so that every caller is
+     * covered - the MCP server bridge (terminal-tab's `McpDynamicTools`, which hands
+     * `result.text` straight to `TextContent` with no length check of its own), the in-app
+     * voice agent (`BossVoiceToolSource`), and flow-tab's `BossRegistryToolSource`, all of
+     * which are LLM contexts. Placing it here rather than around [invoke] also keeps the
+     * host's own short strings - a policy denial, a revoked-access message - off the path,
+     * and means the ledger records the capped text rather than a megabyte it will never use.
+     *
+     * Errors are capped on the same terms as successes, deliberately: the bridge does not
+     * distinguish them (both become one `TextContent`), and a plugin is perfectly able to
+     * return a megabyte of stack trace or echo back a failed payload.
+     */
+    private fun capResult(
+        toolName: String,
+        result: McpToolResult,
+    ): McpToolResult {
+        if (result.text.length <= maxResultChars) return result
+        logger.warn(
+            LogCategory.SYSTEM,
+            "MCP tool result exceeded the host cap and was truncated",
+            mapOf("tool" to toolName, "chars" to result.text.length, "cap" to maxResultChars),
+        )
+        return result.copy(text = capMcpResultText(result.text, maxResultChars))
+    }
+
     @Suppress("TooGenericExceptionCaught") // Plugin handlers may throw any implementation-specific exception.
-    private suspend fun executeAuthorized(tool: RegisteredMcpTool, args: McpToolArgs): McpToolResult =
+    private suspend fun executeUncapped(tool: RegisteredMcpTool, args: McpToolArgs): McpToolResult =
         try {
             withTimeout(invokeTimeoutMs) { tool.definition.handler.call(args) }
         } catch (_: TimeoutCancellationException) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpToolRegistryCoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpToolRegistryCoreTest.kt
@@ -637,4 +637,123 @@ class McpToolRegistryCoreTest {
     // ---------------------------------------------------------------------
     // Governed Autonomy - Policy, Approval Gate, and Operation Ledger
     // ---------------------------------------------------------------------
+    // invoke(): the result-size backstop.
+    //
+    // An MCP result is re-read as cached prefix on every later request in the
+    // session, so one oversized answer keeps costing. Until [MAX_MCP_RESULT_CHARS]
+    // every plugin tool was unbounded here: the bridge hands `result.text` to
+    // TextContent without looking at its length.
+    // ---------------------------------------------------------------------
+
+    /** A core whose single tool answers with [text]. */
+    private fun payloadCore(
+        text: String,
+        cap: Int,
+        isError: Boolean = false,
+    ): McpToolRegistryCore =
+        McpToolRegistryCore(disabledFile = null, maxResultChars = cap).also {
+            it.registerProvider(
+                provider("p1", echoTool("big", handler = McpToolHandler { McpToolResult(text, isError) })),
+            )
+        }
+
+    @Test
+    fun `a result under the cap comes back byte-identical`() =
+        runBlocking {
+            val payload = "y".repeat(999) + "\n[504 older matching lines omitted...]"
+
+            val result = payloadCore(payload, cap = 100_000).invoke("big", "{}")
+
+            assertEquals(payload, result.text)
+            assertFalse(result.isError)
+        }
+
+    @Test
+    fun `a result of exactly the cap is untouched`() =
+        runBlocking {
+            // The boundary is `<=`, not `<`. A character of slack here would cut a result
+            // that fits and pay the marker's cost for nothing.
+            val cap = 1_000
+            val payload = "z".repeat(cap)
+
+            val result = payloadCore(payload, cap = cap).invoke("big", "{}")
+
+            assertEquals(payload, result.text)
+            assertEquals(cap, result.text.length)
+        }
+
+    @Test
+    fun `a result over the cap is cut and carries a marker saying so`() =
+        runBlocking {
+            val cap = 1_000
+            // Ends with a tool's own trailing note, which is exactly what cutting the tail
+            // destroys - so the marker has to say the tail is gone, not just that it cut.
+            val payload = "x".repeat(5_000) + "\n[504 older matching lines omitted...]"
+
+            val result = payloadCore(payload, cap = cap).invoke("big", "{}")
+
+            assertTrue(result.text.length <= cap, "cap holds marker included, got ${result.text.length}")
+            assertTrue(result.text.startsWith("x".repeat(100)), "the head of the answer survives")
+            assertTrue(
+                result.text.contains("BOSS host cap"),
+                "a silent cut reads as a complete answer; tail was: ${result.text.takeLast(60)}",
+            )
+            assertTrue(result.text.contains("was ${payload.length} characters"), "the marker says how big it was")
+            assertTrue(result.text.trimEnd().endsWith("]"), "the marker is the last thing in the result")
+            assertFalse(
+                result.text.contains("504 older matching lines omitted"),
+                "the tool's own trailing note is what got cut - the marker has to cover for it",
+            )
+        }
+
+    @Test
+    fun `an oversized error result is capped too and stays an error`() =
+        runBlocking {
+            // The bridge turns both into one TextContent, so an error costs the same context
+            // as a success; a plugin can return a megabyte of stack trace.
+            val cap = 1_000
+
+            val result = payloadCore("e".repeat(20_000), cap = cap, isError = true).invoke("big", "{}")
+
+            assertTrue(result.isError, "capping must not change the error flag")
+            assertTrue(result.text.length <= cap)
+            assertTrue(result.text.contains("BOSS host cap"))
+        }
+
+    @Test
+    fun `the production default is BossTerm's 150000 and invoke applies it with no override`() =
+        runBlocking {
+            assertEquals(150_000, MAX_MCP_RESULT_CHARS, "one number per product: BossTerm's mcpMaxAnswerChars")
+
+            // No maxResultChars argument: this is the production wiring.
+            val core = McpToolRegistryCore(disabledFile = null)
+            core.registerProvider(
+                provider("p1", echoTool("big", handler = McpToolHandler { McpToolResult("q".repeat(200_000)) })),
+            )
+
+            val result = core.invoke("big", "{}")
+
+            assertTrue(result.text.length <= MAX_MCP_RESULT_CHARS, "got ${result.text.length}")
+            assertTrue(result.text.contains("BOSS host cap"))
+        }
+
+    @Test
+    fun `cutting never leaves a lone surrogate, at either boundary parity`() {
+        // Every char is half of a surrogate pair, so the cut lands mid-pair at every other
+        // offset. Sweeping 21 consecutive caps walks the boundary through both parities: a
+        // cut that only backs off on even offsets fails about half of them.
+        val text = "\uD83D\uDE00".repeat(1_000)
+
+        for (cap in 600..620) {
+            val out = capMcpResultText(text, cap)
+            val kept = out.substringBefore("\n\n[BOSS host cap")
+
+            assertTrue(kept.isNotEmpty(), "cap=$cap left no payload; the sweep would prove nothing")
+            assertFalse(kept.last().isHighSurrogate(), "cap=$cap ends on a lone high surrogate")
+            // The concrete harm: a lone surrogate has no UTF-8 encoding, so the wire form
+            // substitutes '?' and the round trip stops matching.
+            val roundTripped = String(out.toByteArray(Charsets.UTF_8), Charsets.UTF_8)
+            assertEquals(out, roundTripped, "cap=$cap does not survive a UTF-8 round trip")
+        }
+    }
 }


### PR DESCRIPTION
## The problem

An MCP tool result is re-read as cached prefix on **every subsequent request** for the rest of a session, so an oversized result is a recurring cost rather than a one-off. Measured on a real host, one `console_search` call returned **234,000 tokens** in a single result.

BossTerm already caps its own answers - `shorten()`, default `mcpMaxAnswerChars = 150_000`. But it is `private` and wraps only BossTerm's 13 built-in handlers. **Every plugin-contributed tool bypasses it**: plugin tools register on the raw SDK `Server` via `McpDynamicTools.registerOne`, which does `TextContent(text = result.text)` with no length inspection. So `codebase_read`, `git_diff`, `k8s_logs`, `console_*` and the rest are unbounded today.

## The layer

`McpToolRegistryCore.invoke` - the single BOSS-owned dispatcher for every plugin tool. It already bounds handlers in *time* (`withTimeout(invokeTimeoutMs)`); this adds the missing *size* bound in the same place.

Every consumer of `invoke` was checked before choosing it:

| consumer | LLM context? | needs untruncated text? |
|---|---|---|
| MCP server bridge (`McpDynamicTools`) | yes | no |
| In-app voice agent (`BossVoiceToolSource`) | yes (OpenAI Realtime) | no |
| flow-tab tool nodes (`BossRegistryToolSource`) | yes (feeds AgentNode) | no |
| Host panel menu (`PanelMenuActions`, `evolver_open`) | no | no - reads only `isError`, discards the success text |

No consumer needs the raw text, so nothing is truncated out from under a caller that wanted it.

## The change

`invoke`'s old body is unchanged, renamed `invokeUncapped`; `invoke` now calls it, caps, and logs a `warn` only when the cap actually fires. Timeout handling, cancellation rethrow, error classification and tool exposure are untouched. `maxResultChars` is a constructor parameter defaulting to the constant, mirroring the existing `invokeTimeoutMs` test seam.

Truncation always announces itself:

> `[BOSS host cap: this tool result was N characters, over the C-character limit, so the last D characters were cut. Whatever the tool put at the end is gone, including any note it appended about content it had already left out. Re-run with a narrower query, a filter, or a smaller range to get the rest.]`

That second sentence exists for a specific interaction: several plugin tools append their own trailing note (console emits `[504 older matching lines omitted...]`). Cutting the tail destroys exactly that note, so the marker names the loss rather than letting the reader assume the tool reported everything.

**Total output stays within the cap, marker included** - the marker is sized against its own worst case and that length reserved out of the budget before cutting. Cutting never splits a surrogate pair, which would leave a lone surrogate that encodes to `?`.

Error results are capped too, and stay errors: the bridge does not distinguish them (both become one `TextContent` at the same context cost), and a plugin can return a megabyte of stack trace. The host's own error strings are short, so in practice this only bites a plugin's.

## On the number

150,000 characters, matching BossTerm's existing `mcpMaxAnswerChars` so the product has one number rather than two. The host **cannot** read that setting - `bossterm-compose` is not a host dependency (the terminal-tab plugin bundles it privately), so it is a constant whose KDoc names the setting it mirrors and says to change both together.

Two honest caveats, both recorded in the KDoc:

- **This is a backstop against catastrophe, not a budget.** It turns one 900k-character result into one still-large 150k-character result. It does not make `console_search` cheap - per-tool paging does that, and returning 149,000 characters because the cap permits it is a bug in the tool, not compliance with this.
- **It counts characters, not tokens.** Roughly 4:1 for ASCII, but dense JSON or CJK at 150k characters is a very different token bill. Characters are what BossTerm already counts, so this matches rather than introducing a second unit.

Two constants that must move together is a smell; the clean fix is putting the number on the plugin API surface where both sides can read it, which is a `boss-plugin-api` release and a three-repo chain.

## Verification

- `:composeApp:desktopTest` filtered to `ai.rever.boss.mcp.*`: **54 tests, 0 failures** (from JUnit XML). Full `:composeApp:desktopTest`: **3,695 tests across 367 classes, 0 failures, 0 skipped**.
- `./gradlew detekt ktlintCheck`: exit 0, tasks executed rather than FROM-CACHE, no baseline edited.
- Five mutations, **no survivors**: cap removed; marker dropped; surrogate back-off removed; boundary `<=` → `<`; under-cap guard removed. Each applied by a harness that aborts unless the anchor is unique, re-reads the file to prove the edit landed, and asserts byte-identical restoration.

The under-cap-guard mutation was added deliberately: the "under the cap is byte-identical" test asserts that nothing changes, so it necessarily survives the cap-removed and marker-dropped mutations and would otherwise have been unproven. The surrogate test sweeps 21 consecutive cap values rather than one, because a single cap has fixed boundary parity and a back-off-only-on-even bug would pass half the time.