### PR TITLE
Pin boss-plugin-api 1.0.88 for the terminal-tab surface

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,7 +143,18 @@ intellij-platform = "243.21565.199"
 # The host implements the new members in this branch: UnifiedDiffParser + git diff
 # plumbing, the diff/composer tab types, the editor buffer API, and
 # ContentSearchService. Same forced order as above: api first, then this.
-boss-plugin-api = "1.0.87"
+#
+# 1.0.88 adds the terminal-tab surface, as ONE release (boss-plugin-api#50, which
+# consolidated #47/#48/#49 so this pin moves once rather than three times):
+# initialCommand overloads on splitVertical/splitHorizontal, renameTab, and
+# tabActivity/tabActivityFlow/sendCommand/sendInterrupt on TerminalTabPluginAPI.
+#
+# Superset of 1.0.87, and nothing here is for the host to implement. The host only
+# CONSUMES this interface, through TerminalAPIAccess.getProvider(); terminal-tab is the
+# implementor. Every addition also carries a default body, so no existing implementor
+# gains an abstract member. The host needs the bump only so a plugin calling these
+# resolves them against the api the host loads, rather than finding them absent.
+boss-plugin-api = "1.0.88"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
Moves the pin from `1.0.87` to `1.0.88`.

**1.0.88 is already published**, so this does not 404 CI the way the file's own guidance warns about.

## What is in 1.0.88

[boss-plugin-api#50](https://github.com/risa-labs-inc/boss-plugin-api/pull/50), which consolidated #47, #48 and #49 into a single release so this pin moves once rather than three times:

- `initialCommand` overloads on `splitVertical` / `splitHorizontal`
- `renameTab`
- `tabActivity`, `tabActivityFlow`, `sendCommand`, `sendInterrupt`

All on `TerminalTabPluginAPI`.

## Why this is a safe bump

Checked rather than assumed, since the surrounding comments warn that some api releases need host-side implementation:

- **The host does not implement this interface.** It only consumes it, through `TerminalAPIAccess.getProvider()`. `terminal-tab` is the implementor. The only other host references are crash-blame test fixtures naming `TerminalTabPluginAPIImpl` in strings.
- **Every addition has a default body.** `TerminalTabPluginAPI$DefaultImpls` is present in the published 1.0.88 jar, so no existing implementor gains an abstract member.
- **Superset of 1.0.87.** Nothing withdrawn.
- Verified against the real artifact: pulled `boss-plugin-api-1.0.88.jar` from the release and confirmed `renameTab`, `tabActivity`, `tabActivityFlow`, `sendCommand` and `sendInterrupt` are all present in the compiled `TerminalTabPluginAPI`.

So the host needs the bump only so that a plugin calling these methods resolves them against the api the host loads, rather than finding them absent at runtime.

## Order

`api#50` merged and cut v1.0.88. This is step 2. Step 3 is terminal-tab #85/#86/#87, which need no pin edit of their own since terminal-tab's `build.yml` tracks `latest`.