### PR TITLE
Do not skip a declared minApiVersion when the API layer is unresolved

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -235,7 +235,10 @@ object PluginStoreSetup {
                     hostBossVersion = AppVersion.currentVersionString(),
                     // Gate by minApiVersion: lambda because the api layer resolves
                     // later in startup (initializeApiLayer publishes the property).
-                    hostApiVersion = { System.getProperty("boss.api.version") ?: "" },
+                    // No `?: ""`: null means the api layer has not published its version yet,
+                    // and PluginUpdateManager needs that distinct from the empty string it
+                    // publishes when it resolved and found no api jar.
+                    hostApiVersion = { System.getProperty("boss.api.version") },
                 )
 
             // Create and start realtime service for live updates

--- a/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
+++ b/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
@@ -96,14 +96,24 @@ class PluginUpdateManager(
      */
     private val hostBossVersion: String = "",
     /**
-     * Returns the installed boss-plugin-api (runtime API layer) version,
-     * compared against each candidate's `minApiVersion`. A lambda because the
-     * manager is constructed before the api layer resolves at startup — the
-     * host passes `{ System.getProperty("boss.api.version") ?: "" }` so the
-     * value is read at check time. Blank disables the gate (fail-open); the
-     * loader's own minApiVersion check remains the backstop.
+     * Returns the installed boss-plugin-api (runtime API layer) version, compared against each
+     * candidate's `minApiVersion`. A lambda because the manager is constructed before the api
+     * layer resolves at startup, so the value is read at check time.
+     *
+     * The three results mean different things and are treated differently by
+     * [satisfiesMinApiVersion]:
+     *
+     * - `null`: the api layer has NOT resolved yet. The host passes
+     *   `{ System.getProperty("boss.api.version") }` and the property is absent until
+     *   `DynamicPluginManager.initializeApiLayer` publishes it.
+     * - `""`: it resolved and found no api jar. `ApiClassLoader.apiVersion` is null on a first
+     *   run offline, and the host publishes that as an empty property.
+     * - a version: the api jar's `Implementation-Version`, falling back to its `plugin.json`.
+     *
+     * Defaults to `{ "" }` so a manager constructed without host awareness (dev builds, tests)
+     * keeps the fail-open answer it has always had.
      */
-    private val hostApiVersion: () -> String = { "" },
+    private val hostApiVersion: () -> String? = { "" },
 ) {
     private val logger = BossLogger.forComponent("PluginUpdateManager")
 
@@ -212,6 +222,10 @@ class PluginUpdateManager(
             val failed = mutableMapOf<String, String>()
             val notices = mutableListOf<IncompatibleNotice>()
 
+            // One read for the whole sweep. See the api branch below for why re-reading it
+            // per use is wrong.
+            val installedApi = hostApiVersion()
+
             for ((pluginId, installedVersion) in installedPlugins) {
                 try {
                     val pluginResult = repositoryManager.getPlugin(pluginId)
@@ -242,10 +256,15 @@ class PluginUpdateManager(
                                 ),
                             )
                             listeners.forEach { it.onUpdateRejectedAsIncompatible(notice) }
-                        } else if (!satisfiesMinApiVersion(candidate.minApiVersion)) {
-                            // Newer version exists but requires a newer runtime
-                            // API layer (boss-plugin-api jar) than installed.
-                            // Report it as an advisory; never auto-install.
+                        } else if (!satisfiesMinApiVersion(candidate.minApiVersion, installedApi)) {
+                            // Newer version exists but the installed runtime API layer
+                            // (boss-plugin-api jar) does not satisfy its floor, or could not be
+                            // read at all. Report it as an advisory; never auto-install.
+                            //
+                            // installedApi is read once for the whole sweep: the api layer
+                            // resolving is exactly the event this branch is about, so reading
+                            // it again here could report a host version that would have
+                            // satisfied the floor the check just failed.
                             val notice =
                                 IncompatibleNotice(
                                     pluginId = pluginId,
@@ -253,19 +272,36 @@ class PluginUpdateManager(
                                     currentVersion = installedVersion,
                                     advertisedLatest = candidate.version,
                                     requiredApiVersion = candidate.minApiVersion,
-                                    hostApiVersion = hostApiVersion(),
+                                    hostApiVersion = installedApi ?: "",
                                 )
                             notices.add(notice)
-                            logger.info(
-                                LogCategory.SYSTEM,
-                                "Skipping plugin update requiring newer API layer",
-                                mapOf(
-                                    "pluginId" to pluginId,
-                                    "advertisedLatest" to candidate.version,
-                                    "requiredApiVersion" to candidate.minApiVersion,
-                                    "hostApiVersion" to hostApiVersion(),
-                                ),
-                            )
+                            // Two different reasons reach here and a user chasing "why is there
+                            // no update" needs to tell them apart: the candidate really does
+                            // want a newer api, or this host cannot say what api it has. The
+                            // second is a host problem, can persist, and is a WARN.
+                            if (installedApi == null || SemanticVersion.parse(installedApi) == null) {
+                                logger.warn(
+                                    LogCategory.SYSTEM,
+                                    "Withholding plugin update: cannot read the installed API layer version",
+                                    mapOf(
+                                        "pluginId" to pluginId,
+                                        "advertisedLatest" to candidate.version,
+                                        "requiredApiVersion" to candidate.minApiVersion,
+                                        "hostApiVersion" to (installedApi ?: "<unresolved>"),
+                                    ),
+                                )
+                            } else {
+                                logger.info(
+                                    LogCategory.SYSTEM,
+                                    "Skipping plugin update requiring newer API layer",
+                                    mapOf(
+                                        "pluginId" to pluginId,
+                                        "advertisedLatest" to candidate.version,
+                                        "requiredApiVersion" to candidate.minApiVersion,
+                                        "hostApiVersion" to installedApi,
+                                    ),
+                                )
+                            }
                             listeners.forEach { it.onUpdateRejectedAsIncompatible(notice) }
                         } else if (isIpcCompatible(candidate.minIpcVersion)) {
                             updates.add(createUpdateInfo(candidate, installedVersion))
@@ -619,14 +655,36 @@ class PluginUpdateManager(
      * An unparseable `minApiVersion` still fails open, via the shared helper. That value comes
      * from the store rather than from us, and one malformed row should withhold nothing.
      */
-    // Guard clauses, for the same reason satisfiesVersionFloor carries this suppression: the
-    // no-floor case and the unknown-installed case are separate rules, and folding them into
-    // one expression would hide which of them withheld an update.
+    // Guard clauses, for the same reason satisfiesVersionFloor carries this suppression: each
+    // case below is a separate rule with a different reason, and folding them into one
+    // expression would hide which of them withheld an update.
     @Suppress("ReturnCount")
-    private fun satisfiesMinApiVersion(minApiVersion: String): Boolean {
-        if (minApiVersion.isBlank()) return true
-        val installed = hostApiVersion()
-        if (installed.isBlank() || SemanticVersion.parse(installed) == null) return false
+    private fun satisfiesMinApiVersion(
+        minApiVersion: String,
+        installed: String?,
+    ): Boolean {
+        // `required` first, and via parse rather than isBlank: parse rejects blank, so a
+        // candidate with no floor and a candidate with a MALFORMED floor both fail open here
+        // unconditionally. Asking about `installed` first made the malformed case depend on
+        // the host version, which contradicted this function's own documentation.
+        SemanticVersion.parse(minApiVersion) ?: return true
+
+        // Not resolved YET: fail closed. This is the case the gate exists for. Declining is
+        // recoverable, because the next check re-reads the property and by then the api layer
+        // has resolved; swapping a jar whose floor we could not check is not.
+        if (installed == null) return false
+
+        // Resolved, but no api jar was found. Unlike the case above this can persist for a
+        // whole session, so failing closed here would withhold every floor-declaring update
+        // indefinitely on such a host. Keep the answer this code has always given, which is
+        // also what DynamicPluginLoader does: it skips minApiVersion validation outright when
+        // currentApiVersion is null rather than rejecting.
+        if (installed.isBlank()) return true
+
+        // Resolved to something we cannot read: fail closed, and the caller logs this reason
+        // separately, because it is a property of THIS host rather than of the candidate.
+        if (SemanticVersion.parse(installed) == null) return false
+
         return satisfiesFloor(required = minApiVersion, installed = installed)
     }
 

--- a/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
+++ b/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
@@ -600,12 +600,35 @@ class PluginUpdateManager(
         satisfiesFloor(required = minBossVersion, installed = hostBossVersion)
 
     /**
-     * True when the installed runtime API layer satisfies a candidate's
-     * `minApiVersion`. Same helper as [satisfiesMinBossVersion]; the loader's
-     * own minApiVersion check is the backstop.
+     * True when the installed runtime API layer satisfies a candidate's `minApiVersion`.
+     *
+     * Fails CLOSED when a floor IS declared but the installed API version cannot be
+     * established, which is the opposite of [satisfiesVersionFloor] and deliberate.
+     *
+     * The shared helper answers true for a blank or unparseable `installed`, and that is right
+     * for its other callers: the home grid would rather show a tile, and the retirement check
+     * has its own fail-closed wrapper. It is wrong here. `hostApiVersion` is
+     * `System.getProperty("boss.api.version")`, so an API layer that has not resolved yet
+     * reads as blank, the floor is skipped, and the update is installed. The loader then
+     * rejects it on the same floor, but only AFTER the jar has been swapped, which is how
+     * Toolbox 1.8.4 on BOSS 9.2.25 left a broken plugin behind rather than no update.
+     *
+     * Declining to offer an update is recoverable: the next check re-reads the property, and
+     * by then the API layer has resolved. Swapping a jar the host cannot load is not.
+     *
+     * An unparseable `minApiVersion` still fails open, via the shared helper. That value comes
+     * from the store rather than from us, and one malformed row should withhold nothing.
      */
-    private fun satisfiesMinApiVersion(minApiVersion: String): Boolean =
-        satisfiesFloor(required = minApiVersion, installed = hostApiVersion())
+    // Guard clauses, for the same reason satisfiesVersionFloor carries this suppression: the
+    // no-floor case and the unknown-installed case are separate rules, and folding them into
+    // one expression would hide which of them withheld an update.
+    @Suppress("ReturnCount")
+    private fun satisfiesMinApiVersion(minApiVersion: String): Boolean {
+        if (minApiVersion.isBlank()) return true
+        val installed = hostApiVersion()
+        if (installed.isBlank() || SemanticVersion.parse(installed) == null) return false
+        return satisfiesFloor(required = minApiVersion, installed = installed)
+    }
 
     /**
      * True when [installed] satisfies the [required] floor.

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/FakeSingleVersionRepository.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/FakeSingleVersionRepository.kt
@@ -1,0 +1,44 @@
+package ai.rever.boss.plugin.updater
+
+import ai.rever.boss.plugin.repository.PluginInfo
+import ai.rever.boss.plugin.repository.PluginRepository
+import ai.rever.boss.plugin.repository.PluginSearchFilter
+import ai.rever.boss.plugin.repository.PluginSearchResult
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Minimal remote [PluginRepository] that always resolves to [latest].
+ *
+ * Shared because three update-manager test classes each want the same "the store advertises
+ * exactly this one version" fixture, and each had grown its own copy of these ten overrides.
+ */
+internal class FakeSingleVersionRepository(
+    private val latest: PluginInfo,
+    override val id: String = "fake-remote",
+    override val name: String = "Fake Remote",
+) : PluginRepository {
+    override val isLocal = false
+    override val isAvailable = true
+
+    override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(listOf(latest))
+
+    override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
+        Result.success(PluginSearchResult(listOf(latest), totalCount = 1))
+
+    override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> =
+        Result.success(if (pluginId == latest.pluginId) latest else null)
+
+    override suspend fun getPluginVersions(pluginId: String): Result<List<PluginInfo>> =
+        Result.success(if (pluginId == latest.pluginId) listOf(latest) else emptyList())
+
+    override suspend fun downloadPlugin(
+        pluginId: String,
+        version: String?,
+        targetPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Result<String> = Result.success(targetPath)
+
+    override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
+
+    override suspend fun refresh(): Result<Unit> = Result.success(Unit)
+}

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerApiFloorFailClosedTest.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerApiFloorFailClosedTest.kt
@@ -1,29 +1,26 @@
 package ai.rever.boss.plugin.updater
 
 import ai.rever.boss.plugin.repository.PluginInfo
-import ai.rever.boss.plugin.repository.PluginRepository
 import ai.rever.boss.plugin.repository.PluginRepositoryManager
-import ai.rever.boss.plugin.repository.PluginSearchFilter
-import ai.rever.boss.plugin.repository.PluginSearchResult
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * A declared `minApiVersion` must not be skipped just because the installed API layer cannot be
- * read.
+ * A declared `minApiVersion` must not be skipped just because the installed API layer version
+ * could not be read - but "could not be read" has two meanings and only one of them may withhold
+ * updates indefinitely.
  *
- * `hostApiVersion` is `System.getProperty("boss.api.version")`, published once the API plugin
- * resolves. Before that it is blank, and [satisfiesVersionFloor] answers true for a blank
- * installed version - correct for the home grid, wrong here, because it lets an update whose
- * floor the host does not meet reach the jar swap. The loader rejects it afterwards, leaving a
- * broken plugin rather than no update.
+ * `hostApiVersion` returns null before `DynamicPluginManager.initializeApiLayer` publishes
+ * `boss.api.version`, and the empty string once it ran and found no api jar
+ * (`ApiClassLoader.apiVersion` is null on a first run offline). The first is transient and worth
+ * failing closed on; the second can last a whole session, and failing closed there would
+ * withhold every floor-declaring plugin update on that host forever.
  *
- * terminal-tab 2.5.74 declares `minApiVersion` 1.0.88 and implements renameTab / tabActivity /
- * initialCommand against it. On a host still carrying API 1.0.87 those symbols are absent, so
- * "offered but broken" is materially worse than "not offered yet".
+ * The case that motivated the gate: terminal-tab 2.5.74 declares `minApiVersion` 1.0.88 and
+ * implements renameTab / tabActivity / initialCommand against it. On a host carrying API 1.0.87
+ * those symbols are absent, so "offered but broken" is worse than "not offered yet".
  */
 class PluginUpdateManagerApiFloorFailClosedTest {
     private val pluginId = "com.example.demo"
@@ -40,21 +37,27 @@ class PluginUpdateManagerApiFloorFailClosedTest {
 
     private fun manager(
         latest: PluginInfo,
-        installedApi: String,
+        installedApi: String?,
     ): PluginUpdateManager {
-        val repos = PluginRepositoryManager().apply { addRepository(FakeApiFloorRepository(latest)) }
+        val repos = PluginRepositoryManager().apply { addRepository(FakeSingleVersionRepository(latest)) }
         return PluginUpdateManager(
             repositoryManager = repos,
             hostApiVersion = { installedApi },
         )
     }
 
+    private suspend fun check(
+        minApi: String,
+        installedApi: String?,
+    ) = manager(candidate("2.5.74", minApi = minApi), installedApi = installedApi)
+        .checkForUpdates(mapOf(pluginId to "2.5.71"))
+
+    // ---- the API layer has not resolved yet: fail closed ----
+
     @Test
     fun `declared floor with an unresolved API layer is not offered`() =
         runTest {
-            val mgr = manager(candidate("2.5.74", minApi = "1.0.88"), installedApi = "")
-
-            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+            val result = check(minApi = "1.0.88", installedApi = null)
 
             assertTrue(
                 result.availableUpdates.isEmpty(),
@@ -67,36 +70,64 @@ class PluginUpdateManagerApiFloorFailClosedTest {
         }
 
     @Test
-    fun `declared floor with an unparseable API version is not offered`() =
+    fun `declared floor with an unreadable API version is not offered`() =
         runTest {
-            val mgr = manager(candidate("2.5.74", minApi = "1.0.88"), installedApi = "not-a-version")
-
-            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+            // A locally built api jar whose Implementation-Version is not strict semver.
+            val result = check(minApi = "1.0.88", installedApi = "not-a-version")
 
             assertTrue(result.availableUpdates.isEmpty())
             assertEquals(1, result.incompatibleNotices.size)
         }
 
-    @Test
-    fun `no declared floor is still offered when the API layer is unresolved`() =
-        runTest {
-            // The guard must key on the floor, not on the installed version. Every plugin
-            // version published before min_api_version existed carries "", and gating those
-            // would withhold every update on a host whose API has not resolved yet.
-            val mgr = manager(candidate("2.5.74", minApi = ""), installedApi = "")
+    // ---- resolved, but no api jar present: keep the pre-existing fail-open answer ----
 
-            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+    @Test
+    fun `declared floor with a resolved but absent api jar is still offered`() =
+        runTest {
+            // Blank means initializeApiLayer ran and found no jar, which can persist for the
+            // whole session. Withholding here would be an indefinite outage, and the loader
+            // does not reject in this state either - it skips minApiVersion validation.
+            val result = check(minApi = "1.0.88", installedApi = "")
+
+            assertEquals(1, result.availableUpdates.size)
+            assertTrue(result.incompatibleNotices.isEmpty())
+        }
+
+    // ---- no floor, or a floor we cannot parse: fail open unconditionally ----
+
+    @Test
+    fun `no declared floor is offered even when the API layer is unresolved`() =
+        runTest {
+            // Every version published before min_api_version existed carries "". Gating those
+            // would withhold every update on a host whose API had not resolved.
+            val result = check(minApi = "", installedApi = null)
 
             assertEquals(1, result.availableUpdates.size)
             assertTrue(result.incompatibleNotices.isEmpty())
         }
 
     @Test
+    fun `a malformed floor is offered regardless of the installed version`() =
+        runTest {
+            // The floor is store data, not ours, and one malformed row must not withhold a
+            // plugin's updates. Both combinations are pinned because the guard order decides
+            // this: asking about the installed version first made the malformed case depend
+            // on it, which contradicted the documented behaviour.
+            val resolved = check(minApi = "garbage", installedApi = "1.0.88")
+            assertEquals(1, resolved.availableUpdates.size, "malformed floor, resolved host")
+            assertTrue(resolved.incompatibleNotices.isEmpty())
+
+            val unresolved = check(minApi = "garbage", installedApi = null)
+            assertEquals(1, unresolved.availableUpdates.size, "malformed floor, unresolved host")
+            assertTrue(unresolved.incompatibleNotices.isEmpty())
+        }
+
+    // ---- ordinary comparisons ----
+
+    @Test
     fun `satisfied floor is offered`() =
         runTest {
-            val mgr = manager(candidate("2.5.74", minApi = "1.0.88"), installedApi = "1.0.88")
-
-            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+            val result = check(minApi = "1.0.88", installedApi = "1.0.88")
 
             assertEquals(1, result.availableUpdates.size)
             assertEquals("2.5.74", result.availableUpdates.first().newVersion)
@@ -107,43 +138,21 @@ class PluginUpdateManagerApiFloorFailClosedTest {
     fun `floor one patch above the installed API is not offered`() =
         runTest {
             // The exact terminal-tab case: 1.0.87 against a 1.0.88 floor.
-            val mgr = manager(candidate("2.5.74", minApi = "1.0.88"), installedApi = "1.0.87")
-
-            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+            val result = check(minApi = "1.0.88", installedApi = "1.0.87")
 
             assertTrue(result.availableUpdates.isEmpty())
             assertEquals("1.0.87", result.incompatibleNotices.first().hostApiVersion)
         }
-}
 
-/** Minimal remote [PluginRepository] that always resolves to [latest]. */
-private class FakeApiFloorRepository(
-    private val latest: PluginInfo,
-) : PluginRepository {
-    override val id = "fake-api-floor"
-    override val name = "Fake API Floor"
-    override val isLocal = false
-    override val isAvailable = true
+    @Test
+    fun `a prerelease installed API still satisfies its release floor`() =
+        runTest {
+            // satisfiesVersionFloor compares the release core only, and
+            // PluginUpdateManagerBossVersionGateTest pins that for the Boss gate. This gate now
+            // parses the installed version itself before delegating, so pin it here too.
+            val result = check(minApi = "1.0.88", installedApi = "1.0.88-alpha.1")
 
-    override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(listOf(latest))
-
-    override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
-        Result.success(PluginSearchResult(listOf(latest), totalCount = 1))
-
-    override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> =
-        Result.success(if (pluginId == latest.pluginId) latest else null)
-
-    override suspend fun getPluginVersions(pluginId: String): Result<List<PluginInfo>> =
-        Result.success(if (pluginId == latest.pluginId) listOf(latest) else emptyList())
-
-    override suspend fun downloadPlugin(
-        pluginId: String,
-        version: String?,
-        targetPath: String,
-        onProgress: ((Float) -> Unit)?,
-    ): Result<String> = Result.success(targetPath)
-
-    override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
-
-    override suspend fun refresh(): Result<Unit> = Result.success(Unit)
+            assertEquals(1, result.availableUpdates.size)
+            assertTrue(result.incompatibleNotices.isEmpty())
+        }
 }

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerApiFloorFailClosedTest.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerApiFloorFailClosedTest.kt
@@ -1,0 +1,149 @@
+package ai.rever.boss.plugin.updater
+
+import ai.rever.boss.plugin.repository.PluginInfo
+import ai.rever.boss.plugin.repository.PluginRepository
+import ai.rever.boss.plugin.repository.PluginRepositoryManager
+import ai.rever.boss.plugin.repository.PluginSearchFilter
+import ai.rever.boss.plugin.repository.PluginSearchResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A declared `minApiVersion` must not be skipped just because the installed API layer cannot be
+ * read.
+ *
+ * `hostApiVersion` is `System.getProperty("boss.api.version")`, published once the API plugin
+ * resolves. Before that it is blank, and [satisfiesVersionFloor] answers true for a blank
+ * installed version - correct for the home grid, wrong here, because it lets an update whose
+ * floor the host does not meet reach the jar swap. The loader rejects it afterwards, leaving a
+ * broken plugin rather than no update.
+ *
+ * terminal-tab 2.5.74 declares `minApiVersion` 1.0.88 and implements renameTab / tabActivity /
+ * initialCommand against it. On a host still carrying API 1.0.87 those symbols are absent, so
+ * "offered but broken" is materially worse than "not offered yet".
+ */
+class PluginUpdateManagerApiFloorFailClosedTest {
+    private val pluginId = "com.example.demo"
+
+    private fun candidate(
+        version: String,
+        minApi: String,
+    ) = PluginInfo(
+        pluginId = pluginId,
+        displayName = "Demo",
+        version = version,
+        minApiVersion = minApi,
+    )
+
+    private fun manager(
+        latest: PluginInfo,
+        installedApi: String,
+    ): PluginUpdateManager {
+        val repos = PluginRepositoryManager().apply { addRepository(FakeApiFloorRepository(latest)) }
+        return PluginUpdateManager(
+            repositoryManager = repos,
+            hostApiVersion = { installedApi },
+        )
+    }
+
+    @Test
+    fun `declared floor with an unresolved API layer is not offered`() =
+        runTest {
+            val mgr = manager(candidate("2.5.74", minApi = "1.0.88"), installedApi = "")
+
+            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+
+            assertTrue(
+                result.availableUpdates.isEmpty(),
+                "a floor we cannot prove is met must not be offered",
+            )
+            assertEquals(1, result.incompatibleNotices.size)
+            val notice = result.incompatibleNotices.first()
+            assertEquals("2.5.74", notice.advertisedLatest)
+            assertEquals("1.0.88", notice.requiredApiVersion)
+        }
+
+    @Test
+    fun `declared floor with an unparseable API version is not offered`() =
+        runTest {
+            val mgr = manager(candidate("2.5.74", minApi = "1.0.88"), installedApi = "not-a-version")
+
+            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+
+            assertTrue(result.availableUpdates.isEmpty())
+            assertEquals(1, result.incompatibleNotices.size)
+        }
+
+    @Test
+    fun `no declared floor is still offered when the API layer is unresolved`() =
+        runTest {
+            // The guard must key on the floor, not on the installed version. Every plugin
+            // version published before min_api_version existed carries "", and gating those
+            // would withhold every update on a host whose API has not resolved yet.
+            val mgr = manager(candidate("2.5.74", minApi = ""), installedApi = "")
+
+            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+
+            assertEquals(1, result.availableUpdates.size)
+            assertTrue(result.incompatibleNotices.isEmpty())
+        }
+
+    @Test
+    fun `satisfied floor is offered`() =
+        runTest {
+            val mgr = manager(candidate("2.5.74", minApi = "1.0.88"), installedApi = "1.0.88")
+
+            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+
+            assertEquals(1, result.availableUpdates.size)
+            assertEquals("2.5.74", result.availableUpdates.first().newVersion)
+            assertTrue(result.incompatibleNotices.isEmpty())
+        }
+
+    @Test
+    fun `floor one patch above the installed API is not offered`() =
+        runTest {
+            // The exact terminal-tab case: 1.0.87 against a 1.0.88 floor.
+            val mgr = manager(candidate("2.5.74", minApi = "1.0.88"), installedApi = "1.0.87")
+
+            val result = mgr.checkForUpdates(mapOf(pluginId to "2.5.71"))
+
+            assertTrue(result.availableUpdates.isEmpty())
+            assertEquals("1.0.87", result.incompatibleNotices.first().hostApiVersion)
+        }
+}
+
+/** Minimal remote [PluginRepository] that always resolves to [latest]. */
+private class FakeApiFloorRepository(
+    private val latest: PluginInfo,
+) : PluginRepository {
+    override val id = "fake-api-floor"
+    override val name = "Fake API Floor"
+    override val isLocal = false
+    override val isAvailable = true
+
+    override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(listOf(latest))
+
+    override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
+        Result.success(PluginSearchResult(listOf(latest), totalCount = 1))
+
+    override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> =
+        Result.success(if (pluginId == latest.pluginId) latest else null)
+
+    override suspend fun getPluginVersions(pluginId: String): Result<List<PluginInfo>> =
+        Result.success(if (pluginId == latest.pluginId) listOf(latest) else emptyList())
+
+    override suspend fun downloadPlugin(
+        pluginId: String,
+        version: String?,
+        targetPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Result<String> = Result.success(targetPath)
+
+    override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
+
+    override suspend fun refresh(): Result<Unit> = Result.success(Unit)
+}

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerBossVersionGateTest.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerBossVersionGateTest.kt
@@ -1,11 +1,7 @@
 package ai.rever.boss.plugin.updater
 
 import ai.rever.boss.plugin.repository.PluginInfo
-import ai.rever.boss.plugin.repository.PluginRepository
 import ai.rever.boss.plugin.repository.PluginRepositoryManager
-import ai.rever.boss.plugin.repository.PluginSearchFilter
-import ai.rever.boss.plugin.repository.PluginSearchResult
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -41,7 +37,7 @@ class PluginUpdateManagerBossVersionGateTest {
         latest: PluginInfo,
         hostBossVersion: String,
     ): PluginUpdateManager {
-        val repos = PluginRepositoryManager().apply { addRepository(FakeRepository(latest)) }
+        val repos = PluginRepositoryManager().apply { addRepository(FakeSingleVersionRepository(latest)) }
         return PluginUpdateManager(
             repositoryManager = repos,
             hostBossVersion = hostBossVersion,
@@ -128,36 +124,4 @@ class PluginUpdateManagerBossVersionGateTest {
 
             assertEquals(1, result.availableUpdates.size)
         }
-}
-
-/** Minimal remote [PluginRepository] that always resolves to [latest]. */
-private class FakeRepository(
-    private val latest: PluginInfo,
-) : PluginRepository {
-    override val id = "fake-remote"
-    override val name = "Fake Remote"
-    override val isLocal = false
-    override val isAvailable = true
-
-    override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(listOf(latest))
-
-    override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
-        Result.success(PluginSearchResult(listOf(latest), totalCount = 1))
-
-    override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> =
-        Result.success(if (pluginId == latest.pluginId) latest else null)
-
-    override suspend fun getPluginVersions(pluginId: String): Result<List<PluginInfo>> =
-        Result.success(if (pluginId == latest.pluginId) listOf(latest) else emptyList())
-
-    override suspend fun downloadPlugin(
-        pluginId: String,
-        version: String?,
-        targetPath: String,
-        onProgress: ((Float) -> Unit)?,
-    ): Result<String> = Result.success(targetPath)
-
-    override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
-
-    override suspend fun refresh(): Result<Unit> = Result.success(Unit)
 }

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerCheckCompatTest.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerCheckCompatTest.kt
@@ -1,11 +1,7 @@
 package ai.rever.boss.plugin.updater
 
 import ai.rever.boss.plugin.repository.PluginInfo
-import ai.rever.boss.plugin.repository.PluginRepository
 import ai.rever.boss.plugin.repository.PluginRepositoryManager
-import ai.rever.boss.plugin.repository.PluginSearchFilter
-import ai.rever.boss.plugin.repository.PluginSearchResult
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -36,7 +32,7 @@ class PluginUpdateManagerCheckCompatTest {
         latest: PluginInfo,
         isCompatible: (String) -> Boolean,
     ): PluginUpdateManager {
-        val repos = PluginRepositoryManager().apply { addRepository(FakeRemoteRepository(latest)) }
+        val repos = PluginRepositoryManager().apply { addRepository(FakeSingleVersionRepository(latest)) }
         return PluginUpdateManager(
             repositoryManager = repos,
             hostIpcVersion = "1.0.0",
@@ -82,36 +78,4 @@ class PluginUpdateManagerCheckCompatTest {
             assertTrue(result.availableUpdates.isEmpty())
             assertTrue(result.incompatibleNotices.isEmpty())
         }
-}
-
-/** Minimal remote [PluginRepository] that always resolves to [latest]. */
-private class FakeRemoteRepository(
-    private val latest: PluginInfo,
-) : PluginRepository {
-    override val id = "fake-remote"
-    override val name = "Fake Remote"
-    override val isLocal = false
-    override val isAvailable = true
-
-    override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(listOf(latest))
-
-    override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
-        Result.success(PluginSearchResult(listOf(latest), totalCount = 1))
-
-    override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> =
-        Result.success(if (pluginId == latest.pluginId) latest else null)
-
-    override suspend fun getPluginVersions(pluginId: String): Result<List<PluginInfo>> =
-        Result.success(if (pluginId == latest.pluginId) listOf(latest) else emptyList())
-
-    override suspend fun downloadPlugin(
-        pluginId: String,
-        version: String?,
-        targetPath: String,
-        onProgress: ((Float) -> Unit)?,
-    ): Result<String> = Result.success(targetPath)
-
-    override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
-
-    override suspend fun refresh(): Result<Unit> = Result.success(Unit)
 }


### PR DESCRIPTION
## The hole

`satisfiesMinApiVersion` delegated straight to `satisfiesVersionFloor`, whose first line is:

```kotlin
if (required.isBlank() || installed.isBlank()) return true
```

`installed` here is `hostApiVersion()`, i.e. `System.getProperty("boss.api.version")`, which `DynamicPluginManager` publishes only once the API plugin resolves. The manager is deliberately constructed before that, which is why the value is read through a lambda. So an update check that runs before the API layer resolves reads blank, **skips the floor entirely, and offers the update**.

The loader then rejects it on the same floor, but only after the jar has been swapped. That leaves a broken plugin rather than no update, which is precisely the Toolbox 1.8.4 on BOSS 9.2.25 failure the surrounding comments already cite.

Concretely: terminal-tab 2.5.74 declares `minApiVersion` 1.0.88 and implements `renameTab`, `tabActivity` / `tabActivityFlow` and the `initialCommand` split overloads against it. On a host still carrying API 1.0.87 those symbols do not exist.

## The fix

Fail closed in the update path, but **only when a floor is actually declared**:

```kotlin
if (minApiVersion.isBlank()) return true
val installed = hostApiVersion()
if (installed.isBlank() || SemanticVersion.parse(installed) == null) return false
return satisfiesFloor(required = minApiVersion, installed = installed)
```

Declining an update is recoverable: the next check re-reads the property and by then the API layer has resolved. Swapping in a jar the host cannot load is not.

Two cases stay fail-open on purpose:

- **A blank `minApiVersion`.** Every plugin version published before the `min_api_version` column existed carries `""`. Gating those would withhold every update on a host whose API had not yet resolved, which is a far bigger outage than the bug being fixed.
- **An unparseable `minApiVersion`.** That value comes from the store, not from us, and one malformed row should not withhold a plugin's updates.

## `satisfiesVersionFloor` is deliberately unchanged

It has four callers, and the other three want the fail-open answer:

| Caller | Why fail-open is right there |
|---|---|
| `StoreHomeCatalogProvider:138-139` | the home grid would rather show a tile than hide it |
| `RetiredPluginIds:90` | wraps it in its own fail-closed logic |
| `RetiredPlugins:288` | same, and its KDoc says so explicitly |

`RetiredPluginsTest` pins that behaviour in three places ("answers TRUE for a blank version, by design"). Changing the shared helper would have broken retirement handling and hidden store rows during startup, so the change is scoped to the one caller where a wrong answer swaps a jar.

## Verification

New test file `PluginUpdateManagerApiFloorFailClosedTest`, 5 cases.

**The two new assertions were confirmed to fail against the unfixed code** before the fix was kept. With `satisfiesMinApiVersion` reverted:

```
PluginUpdateManagerApiFloorFailClosedTest > declared floor with an unparseable API version is not offered() FAILED
PluginUpdateManagerApiFloorFailClosedTest > declared floor with an unresolved API layer is not offered() FAILED
5 tests completed, 2 failed
```

The other three passed in that same run, which is the point: they cover the cases that must keep working (no floor declared, floor satisfied, floor one patch above installed), so they are guarding behaviour rather than sitting vacuously green.

With the fix in place: all 5 pass, the whole `:plugin-platform:plugin-updater:desktopTest` module passes, `*RetiredPlugins*` in `:composeApp:desktopTest` passes, and `detekt` + `ktlintCheck` are clean on the changed module. The `@Suppress("ReturnCount")` matches the justified suppression `satisfiesVersionFloor` already carries.

## Related

Found while answering whether a user on API 1.0.87 would be offered terminal-tab 2.5.74. They will not, provided their API version resolves. This closes the path where it does not.

Still open and worth separate work: the `IncompatibleNotice` this raises is exposed on a StateFlow and dispatched to listeners, but **nothing in the app consumes it** (only the updater's own tests do), so a withheld update is silent to the user. Same observability gap as #394.