### PR TITLE
Load plugin classes under the per-name lock, and register as parallel capable

### DIFF
--- a/plugin-platform/plugin-loader/detekt-baseline.xml
+++ b/plugin-platform/plugin-loader/detekt-baseline.xml
@@ -50,6 +50,7 @@
     <ID>TooGenericExceptionCaught:PluginManifestReader.kt$PluginManifestReader$e: Exception</ID>
     <ID>TooGenericExceptionCaught:PluginSignatureVerifier.kt$PluginSignatureVerifier$e: Exception</ID>
     <ID>TooManyFunctions:DynamicPluginLoader.kt$DynamicPluginLoaderImpl : DynamicPluginLoader</ID>
+    <ID>TooManyFunctions:PluginClassLoader.kt$PluginClassLoader : URLClassLoader</ID>
     <ID>TooManyFunctions:PluginClassLoaderManager.kt$PluginClassLoaderManager</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
@@ -59,6 +59,25 @@ class PluginClassLoader(
     private val sharedPackages: Set<String> = defaultSharedPackages,
 ) : URLClassLoader(urls, parent) {
     companion object {
+        init {
+            // Must run during class initialisation of the LOADER class, and it is
+            // caller-sensitive: `registerAsParallelCapable` resolves
+            // `Reflection.getCallerClass().asSubclass(ClassLoader.class)`, so a
+            // caller that is not itself a ClassLoader subclass throws
+            // ClassCastException out of a static initialiser.
+            //
+            // A Kotlin `companion object { init { } }` looks like the wrong place
+            // for that, since companion members generally compile into
+            // `PluginClassLoader$Companion`. This block does not: the compiler
+            // emits it into `PluginClassLoader.<clinit>`, so the caller is this
+            // class and the registration is valid. Verified in the bytecode, and
+            // pinned behaviourally by ParallelCapableClassLoadingTest, which
+            // asserts that `getClassLoadingLock` hands out per-name locks. Without
+            // registration it returns `this` for every name, which is exactly the
+            // silent regression this comment exists to prevent.
+            registerAsParallelCapable()
+        }
+
         private val logger = BossLogger.forComponent("PluginClassLoader")
 
         /**
@@ -276,13 +295,50 @@ class PluginClassLoader(
         val isSharedPackage = sharedPackages.any { name.startsWith(it) }
 
         return if (isSharedPackage) {
-            // Parent-first loading for shared packages
+            // Parent-first loading for shared packages. `super.loadClass` takes
+            // getClassLoadingLock itself, so this path was never the exposed one.
             super.loadClass(name, resolve)
         } else {
-            // Child-first loading for plugin classes
-            loadClassChildFirst(name, resolve)
+            // Child-first loading for plugin classes.
+            //
+            // Under the per-name lock, which overriding loadClass had bypassed
+            // entirely: `ClassLoader.loadClass` holds it around its whole
+            // find-then-define sequence, and calling findClass directly did not.
+            // Two threads could both miss findLoadedClass above, both reach
+            // defineClass, and one would get
+            // `LinkageError: attempted duplicate class definition`. Plugins are
+            // multi-threaded by construction - a Ktor server, Compose
+            // recomposition and a coroutine dispatcher can all first-touch the
+            // same class - so this was reachable rather than theoretical.
+            synchronized(getClassLoadingLock(name)) {
+                // Re-check inside the lock. The findLoadedClass above ran outside
+                // it, so the thread that lost the race must see the winner's class
+                // rather than try to define it again.
+                val definedByAnotherThread = findLoadedClass(name)
+                if (definedByAnotherThread != null) {
+                    // The winner resolves inside loadClassChildFirst; the loser has
+                    // to do it here or `resolve = true` would silently not resolve.
+                    if (resolve) {
+                        resolveClass(definedByAnotherThread)
+                    }
+                    definedByAnotherThread
+                } else {
+                    loadClassChildFirst(name, resolve)
+                }
+            }
         }
     }
+
+    /**
+     * Test seam for [ParallelCapableClassLoadingTest].
+     *
+     * `getClassLoadingLock` is protected, and what it returns is the only
+     * observable proof that the parallel-capable registration took effect: a
+     * registered loader hands out a distinct lock per class name, an unregistered
+     * one returns `this` for every name. Nothing else about the loader changes,
+     * which is why the failure mode is silent.
+     */
+    internal fun classLoadingLockFor(name: String): Any = getClassLoadingLock(name)
 
     /**
      * Load a class with child-first strategy.

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/ParallelCapableClassLoadingTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/ParallelCapableClassLoadingTest.kt
@@ -1,0 +1,199 @@
+package ai.rever.boss.plugin.loader
+
+import java.io.File
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Dependency-free classes owned by this test, in a package that is not in
+ * [PluginClassLoader.defaultSharedPackages] so they take the child-first path.
+ * There are several because the race being covered is per class name: each one
+ * gives the threads a fresh, not-yet-defined name to contend over.
+ */
+class Race00
+
+class Race01
+
+class Race02
+
+class Race03
+
+class Race04
+
+class Race05
+
+class Race06
+
+class Race07
+
+class Race08
+
+class Race09
+
+class Race10
+
+class Race11
+
+/**
+ * Cover for BossConsole#59: [PluginClassLoader] overrode `loadClass` such that
+ * the child-first path called `findClass` directly, outside
+ * `getClassLoadingLock`, and never registered as parallel capable.
+ *
+ * `ClassLoader.loadClass` holds the per-name lock across its whole
+ * find-then-define sequence. Bypassing it let two threads both miss
+ * `findLoadedClass` and both reach `defineClass`, where the loser gets
+ * `LinkageError: attempted duplicate class definition for name: ...`. Plugins
+ * are multi-threaded by construction, so this was reachable in the field, and it
+ * would have read as a regression from the unload-fallback work rather than the
+ * older, separate defect it is.
+ */
+class ParallelCapableClassLoadingTest {
+    private val tempJars = mutableListOf<File>()
+    private val loaders = mutableListOf<PluginClassLoader>()
+
+    private val hostLoader: ClassLoader = ParallelCapableClassLoadingTest::class.java.classLoader
+
+    @AfterTest
+    fun cleanup() {
+        loaders.forEach { runCatching { it.close() } }
+        tempJars.forEach { it.delete() }
+    }
+
+    private fun jarContaining(classes: List<Class<*>>): File {
+        val jar = File.createTempFile("plugin-cl-parallel-test", ".jar")
+        jar.deleteOnExit()
+        tempJars.add(jar)
+        JarOutputStream(jar.outputStream()).use { out ->
+            for (cls in classes) {
+                val path = cls.name.replace('.', '/') + ".class"
+                val bytes =
+                    requireNotNull(hostLoader.getResourceAsStream(path)) {
+                        "test class $path missing from the test classpath"
+                    }.use { it.readBytes() }
+                out.putNextEntry(JarEntry(path))
+                out.write(bytes)
+                out.closeEntry()
+            }
+        }
+        return jar
+    }
+
+    private fun loaderOver(classes: List<Class<*>>): PluginClassLoader =
+        PluginClassLoader(
+            pluginId = "ai.rever.boss.plugin.test.parallel",
+            urls = arrayOf(jarContaining(classes).toURI().toURL()),
+            parent = hostLoader,
+        ).also { loaders.add(it) }
+
+    private val raceClasses: List<Class<*>> =
+        listOf(
+            Race00::class.java,
+            Race01::class.java,
+            Race02::class.java,
+            Race03::class.java,
+            Race04::class.java,
+            Race05::class.java,
+            Race06::class.java,
+            Race07::class.java,
+            Race08::class.java,
+            Race09::class.java,
+            Race10::class.java,
+            Race11::class.java,
+        )
+
+    @Test
+    fun `the loader hands out a lock per class name`() {
+        // The observable proof that registerAsParallelCapable() took effect. An
+        // unregistered loader returns `this` from getClassLoadingLock for every
+        // name, which serialises all loading through one monitor and, more to the
+        // point here, means the registration silently did not happen. Nothing else
+        // about the loader would look different.
+        val loader = loaderOver(listOf(Race00::class.java))
+
+        val lockA = loader.classLoadingLockFor("com.example.A")
+        val lockB = loader.classLoadingLockFor("com.example.B")
+
+        assertNotSame(loader, lockA, "an unregistered loader locks on itself")
+        assertNotSame(lockA, lockB, "locks must be per class name, not global")
+    }
+
+    @Test
+    fun `the same name always returns the same lock`() {
+        // The other half: per-name locks are only useful if two threads asking for
+        // one name agree on which monitor to take.
+        val loader = loaderOver(listOf(Race00::class.java))
+        assertSame(
+            loader.classLoadingLockFor("com.example.A"),
+            loader.classLoadingLockFor("com.example.A"),
+        )
+    }
+
+    @Test
+    fun `concurrent first loads of one name never define it twice`() {
+        // The failure itself. Every thread is released onto the same fresh class
+        // name at once, and reading the bytes out of the jar keeps the
+        // find-then-define window wide enough to lose. Repeated over several
+        // names because each name can only be raced once per loader.
+        val loader = loaderOver(raceClasses)
+        val threads = 8
+        val pool = Executors.newFixedThreadPool(threads)
+        val failures = java.util.concurrent.ConcurrentLinkedQueue<Throwable>()
+
+        try {
+            for (cls in raceClasses) {
+                val barrier = CyclicBarrier(threads)
+                val tasks =
+                    (0 until threads).map {
+                        Callable {
+                            barrier.await(30, TimeUnit.SECONDS)
+                            runCatching { loader.loadClass(cls.name) }
+                                .onFailure { failures.add(it) }
+                                .getOrNull()
+                        }
+                    }
+                val results = pool.invokeAll(tasks).map { it.get(30, TimeUnit.SECONDS) }
+
+                // One winner, and everyone else must see the winner's class. Two
+                // distinct Class objects for one name in one loader is the
+                // duplicate definition, whether or not the JVM reported it.
+                val distinct = results.filterNotNull().distinct()
+                assertEquals(
+                    1,
+                    distinct.size,
+                    "one name must resolve to one class; got ${distinct.size} for ${cls.name}",
+                )
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+
+        assertEquals(
+            emptyList(),
+            failures.map { it.toString() },
+            "no thread may fail; a duplicate definition surfaces here as LinkageError",
+        )
+    }
+
+    @Test
+    fun `a concurrent load still resolves to the plugin copy, not the host copy`() {
+        // Locking must not have quietly changed which loader wins. These classes
+        // exist in the test classpath as well as in the jar, so a child-first miss
+        // would hand back the parent's copy and the test would still see one
+        // consistent answer.
+        val loader = loaderOver(listOf(Race00::class.java))
+        val loaded = loader.loadClass(Race00::class.java.name)
+
+        assertSame(loader, loaded.classLoader, "child-first must still win for plugin-owned classes")
+        assertTrue(loaded !== Race00::class.java, "the plugin copy is a distinct Class from the host copy")
+    }
+}


### PR DESCRIPTION
Closes #59.

## Reproduced first

Before writing the fix I wrote the test and ran it against unmodified `main`. Eight threads released simultaneously onto one not-yet-defined plugin class:

```
java.lang.LinkageError: loader ai.rever.boss.plugin.loader.PluginClassLoader @344344fa
attempted duplicate class definition for ai.rever.boss.plugin.loader.Race00.
```

That is the failure the issue predicted, so it is reachable rather than theoretical.

`ClassLoader.loadClass` holds `getClassLoadingLock(name)` across its whole find-then-define sequence. Overriding `loadClass` and calling `findClass` directly skipped that, so two threads could both miss `findLoadedClass` and both reach `defineClass`.

## The fix

The child-first branch now runs under `synchronized(getClassLoadingLock(name))`, re-checking `findLoadedClass` inside the lock so the losing thread returns the winner's class rather than defining its own, and resolving it there since the winner resolves inside `loadClassChildFirst`.

The shared-package branch is untouched. `super.loadClass` already takes the lock itself, so it was never the exposed path.

`registerAsParallelCapable()` goes in the companion's `init`. It is what makes `getClassLoadingLock` return a per-name lock instead of the loader object: without it the synchronized block above is still correct but serialises all class loading for a plugin onto one monitor, which is also the shape that makes parent delegation deadlock-prone.

## The part that nearly made this silently useless

`registerAsParallelCapable` is caller-sensitive. It resolves `Reflection.getCallerClass().asSubclass(ClassLoader.class)`, so a caller that is not itself a `ClassLoader` subclass throws `ClassCastException` out of a static initialiser. Kotlin has no static init block, and companion members generally compile into `PluginClassLoader$Companion`, which is not a ClassLoader, so `companion object { init { ... } }` looks like the wrong place for it.

It is not. The compiler emits this block into `PluginClassLoader.<clinit>`, not the companion's constructor:

```
static {};
  ...
  12: invokestatic  #394  // Method java/net/URLClassLoader.registerAsParallelCapable:()Z
```

`PluginClassLoader$Companion.<init>` contains no such call, so the caller is the loader class and the registration is valid.

I did not want that resting on a bytecode observation, because a refactor or a compiler change could move it with no visible symptom: an unregistered loader behaves identically except that `getClassLoadingLock` returns `this`. So `ParallelCapableClassLoadingTest` asserts per-name locks directly, and that assertion fails on `main` today.

## Tests

`ParallelCapableClassLoadingTest`, four cases. Two of them fail on the unmodified loader, which I verified by reverting each half:

- **the loader hands out a lock per class name** - fails with `expected: not same but was: <PluginClassLoader(...)>`, i.e. the unregistered loader locking on itself
- **concurrent first loads of one name never define it twice** - fails with the `LinkageError` above

The other two guard what must not change: one name maps to one lock, and child-first still wins for plugin-owned classes rather than silently falling through to the host copy.

The race is run over twelve fresh class names, since each name can only be raced once per loader, with a `CyclicBarrier` releasing all threads together.

## One judgement call to flag

The test needs `getClassLoadingLock`, which is protected, so I added an `internal` seam. That tipped `PluginClassLoader` over detekt's `TooManyFunctions` threshold and I added a baseline entry, alongside the existing ones for `DynamicPluginLoaderImpl` and `PluginClassLoaderManager` in the same file.

I would rather have avoided growing the baseline. The alternatives were worse: reflection cannot reach a protected member of a `java.base` class under the module system, the class is final so a test subclass cannot widen access, and dropping the seam would mean the parallel-capable registration has no behavioural cover at all, which is precisely the silent failure mode described above. Happy to take a different suggestion.

## Verification

- `:plugin-platform:plugin-loader:desktopTest`: **97 tests, 0 failures**
- `:composeApp:desktopTest`: **3723 tests, 0 failures**
- `ktlintCheck` and `detekt` clean on the module

This is independent of #401 and touches no file in common.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
