### PR TITLE
Feat/239 chrome density and small screen defaults

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/BossApp.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/BossApp.kt
@@ -9,11 +9,15 @@ import ai.rever.boss.app.BossAppScaffold
 import ai.rever.boss.app.BossAppStartupEffects
 import ai.rever.boss.app.rememberBossAppState
 import ai.rever.boss.app.rememberFocusModeReveal
+import ai.rever.boss.layout.ChromeDimens
+import ai.rever.boss.layout.LocalChromeDimens
 import ai.rever.boss.components.registery.PanelRegistry
 import ai.rever.boss.filetypes.DefaultAppsOfferHost
 import ai.rever.boss.focusmode.FocusModeSettingsManager
 import ai.rever.boss.window.WindowAppearanceSettingsManager
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -59,13 +63,20 @@ fun ComponentContext.BossApp(
     // Focus mode + window appearance settings drive the chrome.
     val focusModeSettings by FocusModeSettingsManager.currentSettings.collectAsState()
     val windowAppearanceSettings by WindowAppearanceSettingsManager.currentSettings.collectAsState()
+    val chromeDimens =
+        remember(windowAppearanceSettings.density) {
+            ChromeDimens.of(windowAppearanceSettings.density)
+        }
     val reveal = rememberFocusModeReveal(focusModeSettings)
 
     // Menu actions can force-reveal sidebars, so they take the reveal state too.
     BossAppMenuActionEffects(state, reveal)
 
     BossTheme {
-        BossAppCompositionLocals(state) {
+        CompositionLocalProvider(
+            LocalChromeDimens provides chromeDimens,
+        ) {
+            BossAppCompositionLocals(state) {
             BossAppScaffold(
                 state = state,
                 reveal = reveal,
@@ -84,6 +95,7 @@ fun ComponentContext.BossApp(
             // like AuthBrandSite. It raises nothing on the windows that are not
             // the first, and nothing at all once the offer has been made.
             DefaultAppsOfferHost(isFirstWindow = state.isFirstWindow)
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -643,6 +643,10 @@ internal fun BossAppDialogs(state: BossAppState) {
                         MenuActionsHandler.triggerToggleFocusMode(windowId)
                     }
 
+                    KeymapActions.CHROME_DENSITY_CYCLE -> {
+                        MenuActionsHandler.triggerChromeDensityCycle(windowId)
+                    }
+
                     KeymapActions.SETTINGS_OPEN -> {
                         MenuActionsHandler.triggerOpenSettings(windowId)
                     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppMenuActionEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppMenuActionEffects.kt
@@ -21,6 +21,8 @@ import ai.rever.boss.components.workspaces.applyWorkspace
 import ai.rever.boss.components.workspaces.extractCurrentWorkspace
 import ai.rever.boss.components.workspaces.workspaceManager
 import ai.rever.boss.focusmode.FocusModeSettingsManager
+
+import ai.rever.boss.layout.ChromeDensity
 import ai.rever.boss.plugin.browser.ActiveBrowserRegistry
 import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabType
@@ -321,6 +323,25 @@ internal fun BossAppMenuActionEffects(
                 if (eventWindowId == windowId) {
                     coroutineScope.launch {
                         FocusModeSettingsManager.toggleFocusMode()
+                    }
+                }
+            }.launchIn(this)
+    }
+
+    LaunchedEffect(windowId) {
+        MenuActionsHandler.chromeDensityCycleEvents
+            .onEach { eventWindowId ->
+                if (eventWindowId == windowId) {
+                    coroutineScope.launch {
+                        val settings = WindowAppearanceSettingsManager.currentSettings.value
+                        val nextDensity = when (settings.density) {
+                            ChromeDensity.COMPACT -> ChromeDensity.COMFORTABLE
+                            ChromeDensity.COMFORTABLE -> ChromeDensity.SPACIOUS
+                            ChromeDensity.SPACIOUS -> ChromeDensity.COMPACT
+                        }
+                        WindowAppearanceSettingsManager.updateSettings(
+                            settings.copy(density = nextDensity),
+                        )
                     }
                 }
             }.launchIn(this)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/model/KeymapActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/model/KeymapActions.kt
@@ -90,6 +90,7 @@ object KeymapActions {
     // View/UI Actions
     const val FOCUS_MODE_TOGGLE = "view.focus_mode_toggle"
     const val SETTINGS_OPEN = "view.settings_open"
+    const val CHROME_DENSITY_CYCLE = "view.chrome_cycle"
 
     // Help Actions
     const val HELP_SHORTCUTS = "help.shortcuts"
@@ -164,6 +165,7 @@ object KeymapActions {
             GLOBAL_SEARCH_OPEN to "Open global search (Double-Shift)",
             FOCUS_MODE_TOGGLE to "Toggle Focus Mode (hide/show UI bars)",
             SETTINGS_OPEN to "Open application settings",
+            CHROME_DENSITY_CYCLE to "Cycle Chrome density (Compact/Comfortable/Spacious)",
             HELP_SHORTCUTS to "Show keyboard shortcuts help dialog",
             TEST_EXTERNAL_LINK to "Test external link handling (debug)",
         )
@@ -218,6 +220,7 @@ object KeymapActions {
             GLOBAL_SEARCH_OPEN to Categories.SEARCH,
             FOCUS_MODE_TOGGLE to Categories.VIEW,
             SETTINGS_OPEN to Categories.VIEW,
+            CHROME_DENSITY_CYCLE to Categories.VIEW,
             HELP_SHORTCUTS to Categories.HELP,
             TEST_EXTERNAL_LINK to Categories.DEBUG,
         )
@@ -272,6 +275,7 @@ object KeymapActions {
             GLOBAL_SEARCH_OPEN to ShortcutContext.GLOBAL,
             FOCUS_MODE_TOGGLE to ShortcutContext.GLOBAL,
             SETTINGS_OPEN to ShortcutContext.GLOBAL,
+            CHROME_DENSITY_CYCLE to ShortcutContext.GLOBAL,
             HELP_SHORTCUTS to ShortcutContext.GLOBAL,
             TEST_EXTERNAL_LINK to ShortcutContext.GLOBAL,
         )
@@ -326,6 +330,7 @@ object KeymapActions {
             GLOBAL_SEARCH_OPEN,
             FOCUS_MODE_TOGGLE,
             SETTINGS_OPEN,
+            CHROME_DENSITY_CYCLE,
             HELP_SHORTCUTS,
             TEST_EXTERNAL_LINK,
         )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/presets/KeymapPresets.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/presets/KeymapPresets.kt
@@ -258,6 +258,14 @@ object KeymapPresets {
                     category = KeymapActions.Categories.VIEW,
                     description = KeymapActions.getDescription(KeymapActions.SETTINGS_OPEN),
                 ),
+                KeyBinding(
+                    actionId = KeymapActions.CHROME_DENSITY_CYCLE,
+                    key = "D",
+                    modifiers = listOf("Cmd", "Shift"),
+                    context = ShortcutContext.GLOBAL,
+                    category = KeymapActions.Categories.VIEW,
+                    description = KeymapActions.getDescription(KeymapActions.CHROME_DENSITY_CYCLE),
+                ),
                 // Help
                 KeyBinding(
                     actionId = KeymapActions.HELP_SHORTCUTS,
@@ -541,6 +549,14 @@ object KeymapPresets {
                     category = KeymapActions.Categories.VIEW,
                     description = KeymapActions.getDescription(KeymapActions.SETTINGS_OPEN),
                 ),
+                KeyBinding(
+                    actionId = KeymapActions.CHROME_DENSITY_CYCLE,
+                    key = "D",
+                    modifiers = listOf("Cmd", "Shift"),
+                    context = ShortcutContext.GLOBAL,
+                    category = KeymapActions.Categories.VIEW,
+                    description = KeymapActions.getDescription(KeymapActions.CHROME_DENSITY_CYCLE),
+                ),
                 // Help - VS Code uses ? for keyboard shortcuts cheatsheet
                 KeyBinding(
                     actionId = KeymapActions.HELP_SHORTCUTS,
@@ -823,6 +839,14 @@ object KeymapPresets {
                     context = ShortcutContext.GLOBAL,
                     category = KeymapActions.Categories.VIEW,
                     description = KeymapActions.getDescription(KeymapActions.SETTINGS_OPEN),
+                ),
+                KeyBinding(
+                    actionId = KeymapActions.CHROME_DENSITY_CYCLE,
+                    key = "D",
+                    modifiers = listOf("Cmd", "Shift"),
+                    context = ShortcutContext.GLOBAL,
+                    category = KeymapActions.Categories.VIEW,
+                    description = KeymapActions.getDescription(KeymapActions.CHROME_DENSITY_CYCLE),
                 ),
                 // Help - IntelliJ style
                 KeyBinding(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/presets/PresetDefinitions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/presets/PresetDefinitions.kt
@@ -210,6 +210,14 @@ object EmacsPresetDefinition {
                     category = KeymapActions.Categories.VIEW,
                     description = KeymapActions.getDescription(KeymapActions.SETTINGS_OPEN),
                 ),
+                KeyBinding(
+                    actionId = KeymapActions.CHROME_DENSITY_CYCLE,
+                    key = "D",
+                    modifiers = listOf("Ctrl", "Shift"),
+                    context = ShortcutContext.GLOBAL,
+                    category = KeymapActions.Categories.VIEW,
+                    description = KeymapActions.getDescription(KeymapActions.CHROME_DENSITY_CYCLE),
+                ),
                 // Help - Emacs: C-h ? (help) - simplified to ? (Shift+/)
                 KeyBinding(
                     actionId = KeymapActions.HELP_SHORTCUTS,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeDimens.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeDimens.kt
@@ -22,6 +22,13 @@ enum class ChromeDensity {
     SPACIOUS,
 }
 
+val ChromeDensity.label: String
+    get() = when (this) {
+        ChromeDensity.COMPACT -> "Compact"
+        ChromeDensity.COMFORTABLE -> "Comfortable"
+        ChromeDensity.SPACIOUS -> "Spacious"
+    }
+
 /**
  * The heights and widths of every host chrome bar, resolved from a [ChromeDensity].
  *

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/MenuActionsHandler.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/MenuActionsHandler.kt
@@ -102,6 +102,10 @@ object MenuActionsHandler {
     private val _toggleFocusModeEvents = MutableSharedFlow<String>(extraBufferCapacity = 10)
     val toggleFocusModeEvents: SharedFlow<String> = _toggleFocusModeEvents.asSharedFlow()
 
+    private val _chromeDensityCycleEvents = MutableSharedFlow<String>(extraBufferCapacity = 10)
+
+    val chromeDensityCycleEvents: SharedFlow<String> = _chromeDensityCycleEvents.asSharedFlow()
+
     private val _splitVerticallyEvents = MutableSharedFlow<String>(extraBufferCapacity = 10)
     val splitVerticallyEvents: SharedFlow<String> = _splitVerticallyEvents.asSharedFlow()
 
@@ -456,10 +460,14 @@ object MenuActionsHandler {
     }
 
     /**
-     * Trigger a "Split Vertically" action for the specified window.
-     *
-     * @param windowId The ID of the window where the action was triggered
+     * Trigger a "Cycle Chrome Density" action for the specified window.
      */
+    fun triggerChromeDensityCycle(windowId: String) {
+
+        _chromeDensityCycleEvents.tryEmit(windowId)
+
+    }
+
     fun triggerSplitVertically(windowId: String) {
         _splitVerticallyEvents.tryEmit(windowId)
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
@@ -70,6 +70,7 @@ data class WindowAppearanceSettings(
     /** Whether the right icon strip is on screen. See [showTopBar]. */
     val showRightStrip: Boolean = false,
     val density: ChromeDensity = ChromeDensity.COMFORTABLE,
+    val profileAppliedForSize: String? = null,
     /**
      * How tabs in the main (top) tab bar are sized.
      * Default: SHRINK_TO_FIT (Safari behaviour)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.window
 
+import ai.rever.boss.layout.ChromeDensity
+
 import ai.rever.boss.utils.SystemUtils
 import kotlinx.serialization.Serializable
 
@@ -67,6 +69,7 @@ data class WindowAppearanceSettings(
     val showLeftStrip: Boolean = false,
     /** Whether the right icon strip is on screen. See [showTopBar]. */
     val showRightStrip: Boolean = false,
+    val density: ChromeDensity = ChromeDensity.COMFORTABLE,
     /**
      * How tabs in the main (top) tab bar are sized.
      * Default: SHRINK_TO_FIT (Safari behaviour)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/search/SettingsSearchEntries.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/search/SettingsSearchEntries.kt
@@ -419,6 +419,7 @@ private fun windowAppearanceEntries() =
         setting("Show Bottom Bar", "Bars", "chrome", "window", "status")
         setting("Show Left Strip", "Bars", "chrome", "sidebar")
         setting("Show Right Strip", "Bars", "chrome", "sidebar")
+        setting("Density", "Bars", "compact", "comfortable", "spacious", "chrome", "scale", "size")
         setting("Applies to", "Bars")
         group("Menus")
         setting("Native Context Menus", "Menus", "right click", "macos", "nsmenu")

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/WindowAppearanceSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/WindowAppearanceSettings.kt
@@ -9,6 +9,9 @@ import ai.rever.boss.components.settings.shared.SettingsInfoRow
 import ai.rever.boss.components.settings.shared.SettingsSection
 import ai.rever.boss.components.settings.shared.SettingsSlider
 import ai.rever.boss.components.settings.shared.SettingsToggle
+
+import ai.rever.boss.layout.ChromeDensity
+import ai.rever.boss.layout.label
 import ai.rever.boss.plugin.ui.menu.NativeContextMenus
 import ai.rever.boss.window.TabBarPosition
 import ai.rever.boss.window.TabBarVerticalWidthRange
@@ -279,6 +282,34 @@ private fun BarsSection() {
                 },
             )
         }
+
+        SettingsDropdown(
+
+            label = "Density",
+
+            options = ChromeDensity.entries.map { it.label },
+
+            selectedOption = settings.density.label,
+
+            onOptionSelected = { selected ->
+
+                val density = ChromeDensity.entries.first { it.label == selected }
+
+                coroutineScope.launch {
+
+                    WindowAppearanceSettingsManager.updateSettings(
+
+                        settings.copy(density = density),
+
+                    )
+
+                }
+
+            },
+
+            description = "Controls the size of the window chrome bars.",
+
+        )
 
         SettingsInfoRow(
             label = "Applies to",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -775,6 +775,11 @@ object AWTKeyboardInterceptor {
                 true
             }
 
+            KeymapActions.CHROME_DENSITY_CYCLE -> {
+                MenuActionsHandler.triggerChromeDensityCycle(windowId)
+                true
+            }
+
             // Panel Navigation.
             //
             // Gated on there being somewhere to navigate TO, mirroring the `enabled` flag on the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowAppearanceSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowAppearanceSettingsManager.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.window
 
+import ai.rever.boss.layout.ChromeDensity
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.SystemUtils
 import ai.rever.boss.utils.logging.BossLogger
@@ -21,6 +22,31 @@ import java.io.File
  * - Synchronous load on init, asynchronous save
  * - Graceful error handling with fallback to defaults
  */
+private const val SMALL_SCREEN_HEIGHT_THRESHOLD_DP = 900
+private const val SMALL_SCREEN_WIDTH_THRESHOLD_DP = 1200
+
+internal data class ChromeScreenProfile(
+    val density: ChromeDensity,
+    val showBottomBar: Boolean,
+    val showLeftStrip: Boolean,
+    val showRightStrip: Boolean,
+)
+
+internal fun defaultChromeScreenProfile(
+    screenWidthDp: Int?,
+    screenHeightDp: Int?,
+): ChromeScreenProfile {
+    val compact = screenHeightDp != null && screenHeightDp < SMALL_SCREEN_HEIGHT_THRESHOLD_DP
+    val narrow = screenWidthDp != null && screenWidthDp < SMALL_SCREEN_WIDTH_THRESHOLD_DP
+
+    return ChromeScreenProfile(
+        density = if (compact) ChromeDensity.COMPACT else ChromeDensity.COMFORTABLE,
+        showBottomBar = !compact,
+        showLeftStrip = !narrow,
+        showRightStrip = !narrow,
+    )
+}
+
 actual object WindowAppearanceSettingsManager {
     private val logger = BossLogger.forComponent("WindowAppearanceSettingsManager")
     private val settingsFile = BossDirectories.resolve("window-appearance-settings.json")
@@ -128,8 +154,20 @@ actual object WindowAppearanceSettingsManager {
         //
         // Stamped current: a fresh file is already on this build's defaults and must not be
         // migrated on the next launch as though it were an older one.
+        val (screenWidthDp, screenHeightDp) =
+            runCatching {
+                val toolkit = java.awt.Toolkit.getDefaultToolkit()
+                toolkit.screenSize.let { it.width to it.height }
+            }.getOrNull() ?: (null to null)
+
+        val profile = defaultChromeScreenProfile(screenWidthDp, screenHeightDp)
+
         return WindowAppearanceSettings(
             showTitleBar = SystemUtils.isMacOS,
+            showBottomBar = profile.showBottomBar,
+            showLeftStrip = profile.showLeftStrip,
+            showRightStrip = profile.showRightStrip,
+            density = profile.density,
             settingsVersion = WindowAppearanceSettings.CURRENT_SETTINGS_VERSION,
         )
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowAppearanceSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowAppearanceSettingsManager.kt
@@ -22,7 +22,7 @@ import java.io.File
  * - Synchronous load on init, asynchronous save
  * - Graceful error handling with fallback to defaults
  */
-private const val SMALL_SCREEN_HEIGHT_THRESHOLD_DP = 900
+private const val SMALL_SCREEN_HEIGHT_THRESHOLD_DP = 1000
 private const val SMALL_SCREEN_WIDTH_THRESHOLD_DP = 1200
 
 internal data class ChromeScreenProfile(
@@ -41,7 +41,7 @@ internal fun defaultChromeScreenProfile(
 
     return ChromeScreenProfile(
         density = if (compact) ChromeDensity.COMPACT else ChromeDensity.COMFORTABLE,
-        showBottomBar = !compact,
+        showBottomBar = true,
         showLeftStrip = !narrow,
         showRightStrip = !narrow,
     )
@@ -156,11 +156,18 @@ actual object WindowAppearanceSettingsManager {
         // migrated on the next launch as though it were an older one.
         val (screenWidthDp, screenHeightDp) =
             runCatching {
-                val toolkit = java.awt.Toolkit.getDefaultToolkit()
-                toolkit.screenSize.let { it.width to it.height }
+                val screenSize = java.awt.Toolkit.getDefaultToolkit().screenSize
+                screenSize.width to screenSize.height
             }.getOrNull() ?: (null to null)
 
         val profile = defaultChromeScreenProfile(screenWidthDp, screenHeightDp)
+
+        val profileAppliedForSize =
+            if (screenWidthDp != null && screenHeightDp != null) {
+                "${screenWidthDp}x${screenHeightDp}"
+            } else {
+                "unknown"
+            }
 
         return WindowAppearanceSettings(
             showTitleBar = SystemUtils.isMacOS,
@@ -168,6 +175,7 @@ actual object WindowAppearanceSettingsManager {
             showLeftStrip = profile.showLeftStrip,
             showRightStrip = profile.showRightStrip,
             density = profile.density,
+            profileAppliedForSize = profileAppliedForSize,
             settingsVersion = WindowAppearanceSettings.CURRENT_SETTINGS_VERSION,
         )
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowAppearanceScreenProfileTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowAppearanceScreenProfileTest.kt
@@ -1,0 +1,82 @@
+package ai.rever.boss.window
+
+import ai.rever.boss.layout.ChromeDensity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WindowAppearanceScreenProfileTest {
+
+    @Test
+    fun `short screen gets compact density and hides bottom bar`() {
+        val profile = defaultChromeScreenProfile(
+            screenWidthDp = 1470,
+            screenHeightDp = 899,
+        )
+
+        assertEquals(ChromeDensity.COMPACT, profile.density)
+        assertEquals(false, profile.showBottomBar)
+        assertEquals(true, profile.showLeftStrip)
+        assertEquals(true, profile.showRightStrip)
+    }
+
+    @Test
+    fun `900dp height stays comfortable`() {
+        val profile = defaultChromeScreenProfile(
+            screenWidthDp = 1470,
+            screenHeightDp = 900,
+        )
+
+        assertEquals(ChromeDensity.COMFORTABLE, profile.density)
+        assertEquals(true, profile.showBottomBar)
+    }
+
+    @Test
+    fun `narrow screen hides both strips`() {
+        val profile = defaultChromeScreenProfile(
+            screenWidthDp = 1199,
+            screenHeightDp = 1000,
+        )
+
+        assertEquals(false, profile.showLeftStrip)
+        assertEquals(false, profile.showRightStrip)
+        assertEquals(ChromeDensity.COMFORTABLE, profile.density)
+        assertEquals(true, profile.showBottomBar)
+    }
+
+    @Test
+    fun `1200dp width keeps both strips`() {
+        val profile = defaultChromeScreenProfile(
+            screenWidthDp = 1200,
+            screenHeightDp = 1000,
+        )
+
+        assertEquals(true, profile.showLeftStrip)
+        assertEquals(true, profile.showRightStrip)
+    }
+
+    @Test
+    fun `large screen keeps all comfortable defaults`() {
+        val profile = defaultChromeScreenProfile(
+            screenWidthDp = 1920,
+            screenHeightDp = 1080,
+        )
+
+        assertEquals(ChromeDensity.COMFORTABLE, profile.density)
+        assertEquals(true, profile.showBottomBar)
+        assertEquals(true, profile.showLeftStrip)
+        assertEquals(true, profile.showRightStrip)
+    }
+
+    @Test
+    fun `unknown dimensions keep comfortable defaults`() {
+        val profile = defaultChromeScreenProfile(
+            screenWidthDp = null,
+            screenHeightDp = null,
+        )
+
+        assertEquals(ChromeDensity.COMFORTABLE, profile.density)
+        assertEquals(true, profile.showBottomBar)
+        assertEquals(true, profile.showLeftStrip)
+        assertEquals(true, profile.showRightStrip)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowAppearanceScreenProfileTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowAppearanceScreenProfileTest.kt
@@ -14,20 +14,32 @@ class WindowAppearanceScreenProfileTest {
         )
 
         assertEquals(ChromeDensity.COMPACT, profile.density)
-        assertEquals(false, profile.showBottomBar)
+        assertEquals(true, profile.showBottomBar)
         assertEquals(true, profile.showLeftStrip)
         assertEquals(true, profile.showRightStrip)
     }
 
     @Test
-    fun `900dp height stays comfortable`() {
+    fun `1000dp height stays comfortable`() {
         val profile = defaultChromeScreenProfile(
             screenWidthDp = 1470,
-            screenHeightDp = 900,
+            screenHeightDp = 1000,
         )
 
         assertEquals(ChromeDensity.COMFORTABLE, profile.density)
         assertEquals(true, profile.showBottomBar)
+    }
+
+    @Test
+    fun `13 inch MacBook Air height gets compact density`() {
+        val profile = defaultChromeScreenProfile(
+            screenWidthDp = 1470,
+            screenHeightDp = 956,
+        )
+        assertEquals(ChromeDensity.COMPACT, profile.density)
+        assertEquals(true, profile.showBottomBar)
+        assertEquals(true, profile.showLeftStrip)
+        assertEquals(true, profile.showRightStrip)
     }
 
     @Test


### PR DESCRIPTION
# 📋 Pull Request

## Description

Implements the remaining chrome density and small-screen default work for #239.

This improves the available viewport on smaller laptop displays by introducing a centralized chrome density system and applying screen-size-aware defaults on first launch. Users can also change the density manually through Window Appearance settings or the new keymap action.

## 🔄 Type of Change

* [ ] 🐛 **Bug fix** (non-breaking change that fixes an issue)
* [x] ✨ **New feature** (non-breaking change that adds functionality)
* [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
* [ ] 🔧 **Configuration change** (changes to build scripts, CI/CD, or project configuration)
* [ ] 📚 **Documentation** (documentation only changes)
* [x] 🧹 **Refactoring** (code change that neither fixes a bug nor adds a feature)
* [ ] ⚡ **Performance improvement** (code change that improves performance)
* [x] 🧪 **Tests** (adding missing tests for new functionality)

## 📦 Version Impact

* [x] **No version change needed**
* [ ] **Patch version** (bug fixes, small improvements) - `x.x.+1`
* [ ] **Minor version** (new features, enhancements) - `x.+1.0`
* [ ] **Major version** (breaking changes) - `+1.0.0`

## ✅ Testing Checklist

### 🧪 **Local Testing**

* [x] I have tested this change locally on my development machine
* [x] All existing tests pass with my changes
* [x] I have added new tests for new functionality (if applicable)
* [x] I have verified the fix/feature works as intended

### 🖥️ **Platform Testing**

* [x] 🍎 **macOS** - Tested and working
* [ ] 🪟 **Windows** - Tested and working
* [ ] 🐧 **Linux** - Tested and working
* [ ] 📱 **Mobile** (iOS/Android) - Tested if applicable
* [ ] 🌐 **Web** (WASM) - Tested if applicable

### 🏗️ **Build Verification**

* [x] Project builds successfully with my changes
* [x] No new build warnings introduced
* [ ] Distribution packages (DMG/MSI/JAR) can be created successfully
* [ ] Version system integration tested (if version-related changes)

## 🔍 Code Quality

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to documentation (if needed)
* [x] My changes generate no new warnings or errors

## 🚀 CI/CD Integration

* [x] This PR will trigger appropriate CI/CD workflows
* [x] I understand that all status checks must pass before merging
* [x] I have considered the impact on our centralized version management system

## 📸 Screenshots/Media

This change affects window chrome layout and appearance.

### Before

On smaller laptop displays, the fixed-height chrome can consume a significant portion of the available viewport.

### After

Chrome dimensions can now be scaled through the shared density system, with Compact density selected automatically for small-height displays on first launch. Narrow displays also disable the side strips by default.

No screenshots included because the implementation was verified through the existing desktop test suite and local build verification.

## 🔗 Related Issues

Closes #239

## 📝 Additional Context

### 🎯 **Motivation and Context**

The existing window chrome uses fixed dimensions that can take up a substantial portion of the browser viewport on smaller laptop displays. The goal of this change is to provide sensible defaults for smaller screens while still allowing users to control the appearance themselves.

### 🧠 **Implementation Details**

* Added `ChromeDensity` with `COMPACT`, `COMFORTABLE`, and `SPACIOUS` modes.
* Centralized chrome dimensions through `ChromeDimens` and `LocalChromeDimens`.
* Wired the selected density into the application theme so chrome components use a single source of truth.
* Added a **Density** selector to Window Appearance settings.
* Added the `view.chrome_cycle` keymap action for cycling between density modes.
* Added first-run screen-size-aware defaults:

  * Displays below the small-height threshold use Compact density.
  * Narrow displays disable the left and right chrome strips by default.
* Added `profileAppliedForSize` to record the screen profile applied during initial settings creation.
* Existing user settings are preserved and are not continuously overridden when the window is resized.
* The bottom bar remains enabled; Compact density changes sizing only.

### ⚠️ **Breaking Changes**

None.

Existing window appearance settings remain compatible, and the new density setting defaults to `COMFORTABLE`.

### 🔮 **Future Considerations**

The density system provides a shared foundation for future chrome sizing adjustments without requiring individual components to maintain separate dimension values.

## 👀 Review Focus Areas

* [x] **Logic and Algorithm**: Screen-size profile selection and density handling
* [ ] **Performance**: Potential performance implications
* [ ] **Security**: Security considerations and best practices
* [x] **Platform Compatibility**: Desktop/macOS behavior
* [x] **User Experience**: Density controls and small-screen defaults
* [ ] **Documentation**: Accuracy and completeness

## 🚨 Pre-merge Checklist

* [ ] All conversations have been resolved
* [ ] Code has been rebased on latest main branch
* [x] Commit messages are clear and descriptive
* [x] PR title accurately describes the change
* [x] Ready for production deployment

---

<!-- 
🤖 **Automated Checks**

This PR will automatically trigger:
- Cross-platform build verification
- Code quality analysis
- Security scanning
- Version system validation
- Integration testing

All checks must pass before merge is allowed.
-->

**Thank you for contributing to BOSS! 🎉**
