### PR TITLE
fix(keymap): fix three real bugs from the same key-name vocabulary drift

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/KeyCaptureDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/KeyCaptureDialog.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.settings.keymap
 
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.keymap.model.keyName
 import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.SystemUtils
@@ -209,7 +210,13 @@ fun KeyCaptureDialog(
                                 val binding =
                                     KeyBinding(
                                         actionId = actionId,
-                                        key = capturedKey!!.keyCode.toString(),
+                                        // BossConsole#329: this used to persist the packed
+                                        // numeric keyCode, which neither matcher has an alias
+                                        // for - a rebind made here appeared to save (the list
+                                        // reformats whatever is stored) and then silently fired
+                                        // on neither path. keyName() is exactly what both
+                                        // matchers themselves derive from a live key event.
+                                        key = keyName(capturedKey!!),
                                         modifiers = capturedModifiers,
                                         context = context,
                                         category = category,
@@ -278,7 +285,10 @@ private fun buildDisplayString(
             }
         }
 
-    val keyString = formatKeyDisplay(key.keyCode.toString())
+    // Same fix as the persisted binding below: keyCode.toString() fed formatKeyDisplay a raw
+    // number, which matches none of its word-name branches, so the live preview showed the
+    // packed keyCode instead of a glyph for every key while capturing.
+    val keyString = formatKeyDisplay(keyName(key))
 
     return (modifierStrings + keyString).joinToString(if (isMac) "" else "+")
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/ShortcutTestRunner.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/ShortcutTestRunner.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.settings.keymap
 import ai.rever.boss.keymap.lifecycle.ShortcutLifecycleManager
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.keymap.model.knownCanonicalKeyNames
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -175,110 +176,37 @@ object ShortcutTestRunner {
         return result
     }
 
+    /** Compose reports F1 through F24 (a few keyboards go that far); none needs an alias. */
+    private val functionKeyName = Regex("""^f([1-9]|1[0-9]|2[0-4])$""")
+
     /**
      * Validates that a key name is recognized and will match when the user presses it.
-     * Checks against known key names that are handled by normalizeKeyName in KeymapMatcher.
      *
      * NOTE: This is a static validation that checks if the key name is in the correct format.
      * It does NOT actually simulate key presses, because creating synthetic KeyEvent objects
-     * in Compose is complex. However, it catches the most common errors:
-     * - Using character forms ("-", "=", "0") instead of word forms ("Minus", "Equals", "Zero")
-     * - Using arrow characters ("←") instead of word forms ("Left")
-     * - Using unknown key names
+     * in Compose is complex.
+     *
+     * BossConsole#375: this used to be its own hand-written set of "valid" spellings - a fourth
+     * copy of the vocabulary [ai.rever.boss.keymap.model.canonicalKeyName] already owns, and it
+     * had drifted from that one: F1-F12 were simply never added, and "Left Bracket"/"Back Slash"
+     * were already-valid aliases the real matchers accept that this copy had never learned about.
+     * It also flagged character forms ("-", "←") as errors demanding a word form - true under an
+     * earlier, pre-unification matcher, but both matchers now canonicalize *both* sides through
+     * the exact same fold before comparing, so a binding stored as "-" matches a real `-` keypress
+     * exactly as reliably as one stored as "Minus". Delegating to
+     * [ai.rever.boss.keymap.model.knownCanonicalKeyNames] instead of hand-maintaining a set here
+     * is what keeps this check unable to drift from what the matchers actually accept again.
      *
      * @return Pair<Boolean, String> - (isValid, errorMessage)
      */
-    private fun validateKeyName(keyName: String): Pair<Boolean, String> {
-        // List of valid key names (word forms that normalizeKeyName handles)
-        val validWordKeyNames =
-            setOf(
-                // Numbers
-                "Zero",
-                "One",
-                "Two",
-                "Three",
-                "Four",
-                "Five",
-                "Six",
-                "Seven",
-                "Eight",
-                "Nine",
-                // Symbols
-                "Minus",
-                "Equals",
-                "Plus",
-                "OpenBracket",
-                "CloseBracket",
-                "Slash",
-                "Backslash",
-                "Semicolon",
-                "Apostrophe",
-                "Comma",
-                "Period",
-                "Grave",
-                // Directions
-                "Left",
-                "Right",
-                "Up",
-                "Down",
-                "DirectionLeft",
-                "DirectionRight",
-                "DirectionUp",
-                "DirectionDown",
-                // Special keys
-                "Space",
-                "Spacebar",
-                "Enter",
-                "Return",
-                "Escape",
-                "Esc",
-                "Tab",
-                "Backspace",
-                "Delete",
-            )
+    internal fun validateKeyName(keyName: String): Pair<Boolean, String> {
+        val lower = keyName.lowercase()
+        val isKnown =
+            (keyName.length == 1 && keyName[0].isLetter()) ||
+                functionKeyName.matches(lower) ||
+                lower in knownCanonicalKeyNames()
 
-        // Check if it's a valid word name (case-insensitive)
-        if (validWordKeyNames.any { it.equals(keyName, ignoreCase = true) }) {
-            return Pair(true, "")
-        }
-
-        // Check if it's a single letter (A-Z)
-        if (keyName.length == 1 && keyName[0].isLetter()) {
-            return Pair(true, "")
-        }
-
-        // Check if it's a single character that should be a word name
-        val characterToWordMap =
-            mapOf(
-                // Symbols
-                "-" to "Minus",
-                "=" to "Equals",
-                "+" to "Plus",
-                // Numbers
-                "0" to "Zero",
-                "1" to "One",
-                "2" to "Two",
-                "3" to "Three",
-                "4" to "Four",
-                "5" to "Five",
-                "6" to "Six",
-                "7" to "Seven",
-                "8" to "Eight",
-                "9" to "Nine",
-                // Arrow characters
-                "←" to "Left",
-                "→" to "Right",
-                "↑" to "Up",
-                "↓" to "Down",
-            )
-
-        if (characterToWordMap.containsKey(keyName)) {
-            val correctName = characterToWordMap[keyName]
-            return Pair(false, "Key name should be '$correctName' not '$keyName'")
-        }
-
-        // Unknown key name
-        return Pair(false, "Unknown key name '$keyName' - won't match user input")
+        return if (isKnown) Pair(true, "") else Pair(false, "Unknown key name '$keyName' - won't match user input")
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapMatcher.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapMatcher.kt
@@ -6,6 +6,7 @@ import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.model.ShortcutContext
 import ai.rever.boss.keymap.model.canonicalKeyName
 import ai.rever.boss.keymap.model.canonicalModifiers
+import ai.rever.boss.keymap.model.keyName
 import ai.rever.boss.utils.SystemUtils
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -233,17 +234,7 @@ class KeymapMatcher(
         eventKey: Key,
         bindingKeyName: String,
     ): Boolean {
-        // Extract key name from the Key object
-        // Key.toString() format is "Key: X" where X is the key name
-        val eventKeyString = eventKey.toString()
-        val eventKeyName =
-            if (eventKeyString.startsWith("Key: ")) {
-                eventKeyString.substring(5).trim()
-            } else {
-                eventKey.keyCode.toString()
-            }
-
-        val eventKeyNormalized = normalizeKeyName(eventKeyName)
+        val eventKeyNormalized = normalizeKeyName(keyName(eventKey))
         val bindingKeyNormalized = normalizeKeyName(bindingKeyName)
 
         return eventKeyNormalized.equals(bindingKeyNormalized, ignoreCase = true)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/model/KeyBinding.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/model/KeyBinding.kt
@@ -43,6 +43,36 @@ internal fun canonicalKeyName(keyName: String): String {
 }
 
 /**
+ * Every spelling [canonicalKeyName] specifically recognises: every alias it folds away, plus
+ * every canonical name those aliases fold onto.
+ *
+ * Exposed for `ShortcutTestRunner.validateKeyName` (BossConsole#375), which used to maintain its
+ * own, fourth copy of this vocabulary and had drifted from it - F1-F12 were simply absent, and
+ * "Left Bracket"/"Back Slash" were already-valid aliases here that copy had never learned about.
+ * A single letter or a function key (`F1`-`F24`) needs no entry here at all: `canonicalKeyName`
+ * folds nothing for them because AWT/Compose report them identically regardless of Toolkit
+ * warm-up state, which is the only reason anything else in this table needs an alias.
+ */
+fun knownCanonicalKeyNames(): Set<String> = KEY_ALIASES.keys + KEY_ALIASES.values
+
+/**
+ * The name a Compose [Key] answers to for storage/comparison, matching exactly what
+ * [KeymapMatcher][ai.rever.boss.keymap.handler.KeymapMatcher] derives from a live key event:
+ * `Key.toString()`'s `"Key: X"` payload, or the packed numeric `keyCode` for the rare key with no
+ * name at all.
+ *
+ * Exposed so [KeyCaptureDialog][ai.rever.boss.components.settings.keymap.KeyCaptureDialog] can
+ * persist (and preview) a name the matchers actually understand, rather than always writing the
+ * packed keyCode - a rebind made through that dialog used to save as e.g. `"281474976710721"`,
+ * which both matchers reduce to itself (no alias exists for a raw number) and so never fires
+ * (BossConsole#329).
+ */
+fun keyName(key: androidx.compose.ui.input.key.Key): String {
+    val keyString = key.toString()
+    return if (keyString.startsWith("Key: ")) keyString.substring(5).trim() else key.keyCode.toString()
+}
+
+/**
  * Every spelling that is not already its own canonical name, keyed lowercase.
  *
  * A table rather than a `when` so adding a spelling is a one-line edit and the function stays
@@ -61,8 +91,8 @@ private val KEY_ALIASES: Map<String, String> =
         alias("directionup", "up", "arrowup", "↑")
         alias("directiondown", "down", "arrowdown", "↓")
         alias("space", "spacebar", "␣", " ")
-        alias("escape", "esc")
-        alias("enter", "return")
+        alias("escape", "esc", "⎋")
+        alias("enter", "return", "⏎")
         // A dedicated + key and Shift+= are the same chord to every preset: zoom in is stored as
         // Equals with a Cmd+Shift+Equals alternate.
         alias("equals", "plus", "+", "=")
@@ -76,12 +106,29 @@ private val KEY_ALIASES: Map<String, String> =
         alias("closebracket", "close bracket", "right bracket", "rightbracket", "]")
         // Shift+/ reports "?" on a US layout.
         alias("slash", "/", "?")
-        alias("backslash", "\\")
+        // "Back Slash"/"Quote"/"Back Quote" are AWT's cold-Toolkit spellings for these three -
+        // the bare-character forms already covered here are what it reports once the Toolkit has
+        // warmed up (BossConsole#372). Both must fold, since which one a given keypress produces
+        // depends on process state the matcher has no control over.
+        alias("backslash", "\\", "back slash")
         alias("semicolon", ";")
-        alias("apostrophe", "'")
+        alias("apostrophe", "'", "quote")
         alias("comma", ",")
         alias("period", ".")
-        alias("grave", "`")
+        alias("grave", "`", "back quote")
+        // Tab/Backspace/Delete need no word-form alias - AWT's cold and warm spellings both
+        // lowercase to the same thing as the Key property name - only the *glyph* AWT reports
+        // once the Toolkit is warm needs folding (BossConsole#372).
+        alias("tab", "⇥")
+        alias("backspace", "⌫")
+        alias("delete", "⌦")
+        // Key.MoveHome/Key.MoveEnd/Key.PageUp/Key.PageDown: same DirectionLeft-shaped mismatch as
+        // the arrow keys above - the Key property name and what AWT actually reports disagree, in
+        // two different ways depending on Toolkit warm-up state (BossConsole#372).
+        alias("movehome", "home", "↖")
+        alias("moveend", "end", "↘")
+        alias("pageup", "page up", "⇞")
+        alias("pagedown", "page down", "⇟")
         // Digit characters against the word forms the presets store ("One" for Cmd+1).
         listOf("zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine")
             .forEachIndexed { digit, word -> put(digit.toString(), word) }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/settings/keymap/ShortcutTestRunnerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/settings/keymap/ShortcutTestRunnerTest.kt
@@ -1,0 +1,69 @@
+package ai.rever.boss.components.settings.keymap
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * BossConsole#375: `validateKeyName` used to be its own hand-written, fourth copy of the key-name
+ * vocabulary, and it had drifted from what the real matchers accept. Running it over every key
+ * `AWTKeyboardInterceptor.getKeyName` names - every key the host can dispatch a shortcut for -
+ * found it flagging `F1`, `F5`, `F7`, `F12`, `Home`, `End`, `PageUp`, `PageDown`, `Left Bracket`,
+ * `Back Slash`, `Quote`, `Back Quote`, `Page Up`, `⇥` and `⏎` as "Unknown key name", all of which
+ * fire correctly through both real matchers.
+ */
+class ShortcutTestRunnerTest {
+    private fun assertValid(keyName: String) {
+        val (isValid, message) = ShortcutTestRunner.validateKeyName(keyName)
+        assertTrue(isValid, "'$keyName' should be a valid key name: $message")
+    }
+
+    @Test
+    fun `function keys are valid, not just the ones the old list happened to include`() {
+        assertValid("F1")
+        assertValid("F5")
+        assertValid("F7")
+        assertValid("F12")
+        assertValid("f1")
+    }
+
+    @Test
+    fun `keys the old hand-written list never learned about are valid`() {
+        assertValid("Home")
+        assertValid("End")
+        assertValid("PageUp")
+        assertValid("PageDown")
+        assertValid("Page Up")
+        assertValid("Left Bracket")
+        assertValid("Back Slash")
+        assertValid("Quote")
+        assertValid("Back Quote")
+    }
+
+    @Test
+    fun `glyphs AWT reports once the Toolkit is warm are valid`() {
+        assertValid("⇥")
+        assertValid("⏎")
+    }
+
+    @Test
+    fun `a character form is valid, not an error demanding a word form`() {
+        // Both matchers canonicalize both sides through the same fold before comparing, so a
+        // binding stored as "-" matches a real `-` keypress exactly as reliably as "Minus" does -
+        // this is no longer something to flag.
+        assertValid("-")
+        assertValid("←")
+    }
+
+    @Test
+    fun `single letters are valid`() {
+        assertValid("A")
+        assertValid("z")
+    }
+
+    @Test
+    fun `a genuinely unknown name is still rejected`() {
+        val (isValid, message) = ShortcutTestRunner.validateKeyName("NotARealKey")
+        assertTrue(!isValid, "expected 'NotARealKey' to be rejected")
+        assertTrue(message.contains("NotARealKey"), "message should name the offending key: $message")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/CanonicalKeyNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/CanonicalKeyNameTest.kt
@@ -61,8 +61,42 @@ class CanonicalKeyNameTest {
     @Test
     fun `named keys with more than one spelling`() {
         assertAllSame("Space", "Spacebar", "␣", " ")
-        assertAllSame("Escape", "Esc")
-        assertAllSame("Enter", "Return")
+        assertAllSame("Escape", "Esc", "⎋")
+        assertAllSame("Enter", "Return", "⏎")
+    }
+
+    /**
+     * BossConsole#372: `Key.toString()` falls through to AWT's `KeyEvent.getKeyText`, which is
+     * not a stable vocabulary - it answers with a word while the Toolkit is cold and a glyph once
+     * it is warm. Measured directly on macOS: `Tab` cold, `⇥` running; `Home`/`End` cold,
+     * `↖`/`↘` running; `Page Up`/`Page Down` cold, `⇞`/`⇟` running; `Back Slash`/`Quote`/
+     * `Back Quote` cold, the bare character running. `Ctrl+Tab`/`Ctrl+Shift+Tab` ship in all four
+     * presets and resolved to nothing on the Compose matcher path before this, surviving only
+     * because the AWT path still worked.
+     */
+    @Test
+    fun `glyphs AWT reports once the Toolkit is warm, alongside their cold spellings`() {
+        assertAllSame("Tab", "tab", "⇥")
+        assertAllSame("Backspace", "backspace", "⌫")
+        assertAllSame("Delete", "delete", "⌦")
+    }
+
+    @Test
+    fun `Home, End, Page Up and Page Down across their Key property name, cold AWT and glyph forms`() {
+        // Same DirectionLeft-shaped mismatch as the arrow keys: the Key property name
+        // ("MoveHome") and what AWT actually reports ("Home") disagree outright, not just by case.
+        assertAllSame("MoveHome", "Home", "↖")
+        assertAllSame("MoveEnd", "End", "↘")
+        assertAllSame("PageUp", "Page Up", "⇞")
+        assertAllSame("PageDown", "Page Down", "⇟")
+        assertNotEquals(canonicalKeyName("MoveHome"), canonicalKeyName("MoveEnd"))
+    }
+
+    @Test
+    fun `Back Slash, Quote and Back Quote are AWT's cold spellings for their bare characters`() {
+        assertAllSame("Backslash", "\\", "Back Slash", "back slash")
+        assertAllSame("Apostrophe", "'", "Quote", "quote")
+        assertAllSame("Grave", "`", "Back Quote", "back quote")
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeyNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeyNameTest.kt
@@ -1,0 +1,35 @@
+package ai.rever.boss.keymap
+
+import ai.rever.boss.keymap.model.keyName
+import androidx.compose.ui.input.key.Key
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * BossConsole#329: [KeyCaptureDialog][ai.rever.boss.components.settings.keymap.KeyCaptureDialog]
+ * used to persist `capturedKey!!.keyCode.toString()` - Compose's packed `Long`, e.g.
+ * `"281474976710721"` - which neither matcher has an alias for, so a shortcut rebound through the
+ * Shortcuts screen appeared to save (the list reformats whatever is stored) and then silently
+ * fired on neither path. [keyName] is the fix: the same `"Key: X"` extraction
+ * `KeymapMatcher.keyMatches` derives from a live event, exposed so the dialog can persist the same
+ * thing rather than a number.
+ */
+class KeyNameTest {
+    @Test
+    fun `a named key resolves to its name, not its packed keyCode`() {
+        assertEquals("A", keyName(Key.A))
+        assertNotEquals(Key.A.keyCode.toString(), keyName(Key.A))
+    }
+
+    @Test
+    fun `distinct keys stay distinct`() {
+        assertNotEquals(keyName(Key.DirectionLeft), keyName(Key.DirectionRight))
+        assertNotEquals(keyName(Key.Tab), keyName(Key.Enter))
+    }
+
+    @Test
+    fun `the same key always resolves to the same name`() {
+        assertEquals(keyName(Key.Escape), keyName(Key.Escape))
+    }
+}


### PR DESCRIPTION
## 

Three related, unclaimed bugs in the keyboard-shortcut matching system, all found by the same reviewer working outward from the chord canonicalisation that now lives in `KeyBinding.kt`.

### #329 - KeyCaptureDialog persisted a numeric keyCode instead of a name

`KeyCaptureDialog.kt` saved a rebind as Compose's packed `Key.keyCode` (e.g. `"281474976710721"`), which neither matcher has an alias for. A shortcut rebound through the Shortcuts screen looked saved - the list reformats whatever is stored - and then silently fired on neither matching path.

Fixed by extracting the `"Key: X"` derivation `KeymapMatcher` already used internally into a shared `keyName(Key)` in `KeyBinding.kt`, and having the dialog use it for the persisted binding. Found the same bug a second time while in there: `buildDisplayString`'s live preview fed the same raw `keyCode` into a word-name `when()` that could never match it, so the capture-in-progress preview showed a giant number instead of a glyph for every key. Same fix, same function. `KeymapMatcher` itself now calls the shared function too, instead of duplicating the derivation inline.

### #372 - `Key.toString()` is not a stable vocabulary

`KeymapMatcher.keyMatches` derives an event's name from `Key.toString()`, which falls through to AWT's `KeyEvent.getKeyText` - it answers with a word while the Toolkit is cold and a glyph once it's warm. Measured: `Tab`/`Home`/`End`/`PageUp`/`PageDown`/`Backspace`/`Delete` and three punctuation keys all have a cold word form and a warm glyph or spaced form, and `canonicalKeyName` folded neither. `Ctrl+Tab`/`Ctrl+Shift+Tab` - bound in all four presets - resolved to nothing on the Compose matcher path as a result, surviving only because the AWT path still worked.

Extended `KEY_ALIASES` with the missing spellings, each folding onto the same canonical name `AWTKeyboardInterceptor`'s own `getKeyName` output already reaches after canonicalization - verified against the existing realistic-key-name test rather than assumed.

### #375 - `ShortcutTestRunner.validateKeyName` was a fourth, drifted copy of the same vocabulary

Hand-written and independent of the real matchers - F1-F12 were simply never added to it, and it actively flagged already-valid spellings (`"Left Bracket"`, character forms like `"-"`) as errors, which was true under an earlier, pre-unification matcher but is stale now that both real matchers canonicalize both sides through the same fold before comparing.

Replaced with a check against a new `KeyBinding.knownCanonicalKeyNames()` - the actual alias table both real matchers use - plus single letters and F1-F24 (neither needs an alias; AWT/Compose report them identically regardless of Toolkit state).

## Testing

- Extended `CanonicalKeyNameTest` with the new glyph/spaced-word aliases (10 new assertions across 3 new test methods).
- New `KeyNameTest` for the shared `Key`-to-name extraction (3 tests).
- New `ShortcutTestRunnerTest` (6 tests) exercising every false negative #375's own issue measured directly (F1/F5/F7/F12, Home/End/PageUp/PageDown, Left Bracket/Back Slash/Quote/Back Quote, the Tab/Enter glyphs), plus confirming a genuinely unknown name is still rejected.
- `:composeApp:ktlintCheck`, `:composeApp:detekt` - clean.
- Full `:composeApp:desktopTest`: 3744 tests, 2 failed (pre-existing Windows-only symlink failures, unrelated), 14 skipped.
