### PR TITLE
fix(plugin-store): implement plugin metadata timestamp parsing

### DIFF
--- a/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreClient.kt
+++ b/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreClient.kt
@@ -672,15 +672,24 @@ data class PluginDetailResponse(
             else -> PluginType.PANEL
         }
 
-    private fun parseTimestamp(timestamp: String): Long {
-        // Simple ISO timestamp parsing - return 0 if parsing fails
-        return try {
-            // Remove timezone info and parse
-            0L // TODO: Implement proper timestamp parsing if needed
-        } catch (_: Exception) {
+    /**
+     * Parses an ISO-8601 timestamp (e.g. `2024-05-12T14:30:00Z`, or with a numeric offset) into
+     * epoch milliseconds. BossConsole#337: this used to be a stub that always returned `0L`, so
+     * every plugin fetched from the store showed "Last Updated"/"Published" as the Unix epoch
+     * in the Toolbox UI. Falls back to `0L` for a blank, missing, or malformed string - never
+     * throws into the caller, matching the field's own `= ""` default for a store response that
+     * omits it.
+     */
+    private fun parseTimestamp(timestamp: String): Long =
+        if (timestamp.isBlank()) {
             0L
+        } else {
+            runCatching {
+                java.time.Instant
+                    .parse(timestamp)
+                    .toEpochMilli()
+            }.getOrDefault(0L)
         }
-    }
 }
 
 @Serializable

--- a/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreTimestampParsingTest.kt
+++ b/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreTimestampParsingTest.kt
@@ -1,0 +1,56 @@
+package ai.rever.boss.plugin.repository.remote
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * BossConsole#337: `PluginDetailResponse.toPluginInfo()`'s `publishedAt` used to be a stub that
+ * always returned `0L` regardless of what `updatedAt` held, so every plugin fetched from the
+ * store showed "Last Updated" as the Unix epoch in the Toolbox UI.
+ *
+ * Exercised through the real client's `toPluginInfo()`, not a lookalike parser, matching this
+ * file's own convention next to it (`PluginStoreResponseDecodingTest`) - the property under test
+ * is that the real response type produces a real timestamp.
+ */
+class PluginStoreTimestampParsingTest {
+    private fun responseWithUpdatedAt(updatedAt: String) =
+        PluginDetailResponse(
+            id = "0f6a1c62-0000-4000-8000-000000000001",
+            pluginId = "ai.rever.boss.plugin.dynamic.example",
+            displayName = "Example",
+            description = "",
+            authorName = "RISA Labs",
+            type = "tab",
+            apiVersion = "1.0",
+            verified = true,
+            updatedAt = updatedAt,
+        )
+
+    @Test
+    fun `an ISO-8601 timestamp with a Z offset parses to real epoch millis`() {
+        val info = responseWithUpdatedAt("2024-05-12T14:30:00Z").toPluginInfo()
+
+        assertEquals(1715524200000L, info.publishedAt)
+    }
+
+    @Test
+    fun `an ISO-8601 timestamp with a numeric offset parses too`() {
+        val info = responseWithUpdatedAt("2024-05-12T14:30:00+00:00").toPluginInfo()
+
+        assertEquals(1715524200000L, info.publishedAt)
+    }
+
+    @Test
+    fun `a blank updatedAt falls back to 0 rather than throwing`() {
+        val info = responseWithUpdatedAt("").toPluginInfo()
+
+        assertEquals(0L, info.publishedAt)
+    }
+
+    @Test
+    fun `a malformed timestamp falls back to 0 rather than throwing`() {
+        val info = responseWithUpdatedAt("not-a-timestamp").toPluginInfo()
+
+        assertEquals(0L, info.publishedAt)
+    }
+}


### PR DESCRIPTION
## What

Fixes #337: `PluginStoreClient.parseTimestamp` was a stub with a `// TODO: Implement proper timestamp parsing if needed` that always returned `0L`, so every plugin fetched from the store showed "Last Updated"/"Published" as the Unix epoch in the Toolbox UI regardless of what the server actually sent.

## Changes

Parses the ISO-8601 timestamp the store sends (e.g. `2024-05-12T14:30:00Z`, or with a numeric offset) via `java.time.Instant`, falling back to `0L` for a blank, missing, or malformed string rather than throwing - matching the field's own empty-string default for a response that omits it.

Used `java.time` rather than adding `kotlinx-datetime` as a new dependency: this module already imports `java.util.*` directly in the same `commonMain` source set (it has exactly one real target, `jvm("desktop")`), so introducing a second time library for one function wouldn't buy anything.

## Testing

New `PluginStoreTimestampParsingTest` (4 tests), exercising the real `PluginDetailResponse.toPluginInfo()` rather than the private parser directly - matching the convention already established next to it in `PluginStoreResponseDecodingTest`:
- a `Z`-suffixed timestamp parses to the correct epoch millis
- a numeric-offset timestamp parses too
- a blank `updatedAt` falls back to `0L`
- a malformed timestamp falls back to `0L`

`:plugin-platform:plugin-repository:ktlintCheck`, `:detekt`, `:desktopTest` - all clean.
