### PR TITLE
fix(plugin): wait for SupabaseConfig before starting the manifest sync

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/SystemPluginManifestService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/SystemPluginManifestService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -227,8 +228,25 @@ object SystemPluginManifestService {
         started = true
         onAdditions = onNewPluginsInstallable
 
-        scope.launch { refreshFromRemote() }
+        scope.launch {
+            awaitSupabaseInitialized()
+            refreshFromRemote()
+        }
         subscribeToChanges()
+    }
+
+    /**
+     * BossConsole#370: `startSync` used to run before `SupabaseConfig` finished its own async
+     * `initialize()` call in the Compose UI layer, so the startup fetch and the first
+     * subscribe attempt both hit `SupabaseConfig.client`'s "not initialized" throw - logged as a
+     * warning here and, for the subscription, driving an unnecessary first trip through
+     * [subscribeToChanges]'s backoff retry loop. `SupabaseConfig.isInitialized` already exists
+     * for exactly this; suspending here once, before either launched coroutine touches the
+     * client, replaces a guaranteed-to-fail-once startup path with a wait for the real
+     * precondition.
+     */
+    private suspend fun awaitSupabaseInitialized() {
+        SupabaseConfig.isInitialized.first { it }
     }
 
     // Block body, not expression body: the early `return`s inside withLock are
@@ -303,6 +321,8 @@ object SystemPluginManifestService {
 
     private fun subscribeToChanges() {
         scope.launch {
+            awaitSupabaseInitialized()
+
             var backoffMs = 5_000L
             val maxBackoffMs = 60_000L
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/SystemPluginManifestSyncOrderingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/SystemPluginManifestSyncOrderingTest.kt
@@ -1,0 +1,48 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.services.supabase.SupabaseConfig
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * BossConsole#370: `SystemPluginManifestService.startSync()` used to launch its startup fetch and
+ * Realtime subscription before `SupabaseConfig` finished its own async `initialize()` call in the
+ * Compose UI layer, so both routines' first attempt hit `SupabaseConfig.client`'s "not
+ * initialized" throw. The fix waits on `SupabaseConfig.isInitialized` first; this pins the
+ * precondition itself - that a coroutine awaiting it genuinely suspends until `initialize()` runs,
+ * rather than racing it - since `awaitSupabaseInitialized` is private and this is the contract it
+ * relies on.
+ */
+class SystemPluginManifestSyncOrderingTest {
+    @AfterTest
+    fun cleanup() {
+        SupabaseConfig.clear()
+    }
+
+    @Test
+    fun `a coroutine awaiting isInitialized does not complete before initialize is called`() =
+        runTest {
+            SupabaseConfig.clear()
+            assertFalse(SupabaseConfig.isInitialized.value, "precondition: not yet initialized")
+
+            val waiter = async { SupabaseConfig.isInitialized.first { it } }
+            // Let the waiter actually start and register as a collector on the still-false flow,
+            // rather than asserting on a coroutine that has merely been scheduled but never run -
+            // that would pass unconditionally, proving nothing about suspension.
+            runCurrent()
+
+            assertFalse(waiter.isCompleted, "the waiter must still be suspended before initialize() runs")
+
+            SupabaseConfig.initialize("example.supabase.co", "test-anon-key")
+            runCurrent()
+
+            assertTrue(waiter.isCompleted, "the waiter must resolve once initialize() runs")
+            assertTrue(waiter.await())
+        }
+}


### PR DESCRIPTION
## 
Fixes #370: `SystemPluginManifestService.startSync()` ran its startup fetch and Realtime subscription before `SupabaseConfig` finished its own async `initialize()` call in the Compose UI layer. Both routines' first attempt hit `SupabaseConfig.client`'s "not initialized" throw:

- The startup fetch (`refreshFromRemote()`) caught it and logged a `Supabase client not initialized`-shaped warning.
- The Realtime subscription caught it too, but that meant an unnecessary first trip through `subscribeToChanges()`'s exponential-backoff retry loop before it ever actually connected.

## Change

`SupabaseConfig.isInitialized` already exists as a `StateFlow<Boolean>` for exactly this. Both of `startSync`'s launched coroutines now suspend on it once, before touching the client, via a small `awaitSupabaseInitialized()` helper - replacing a startup path that was guaranteed to fail once with a wait for the real precondition.

The existing "catch up on (re)connect" comment in `subscribeToChanges` - there because this same race could also just lose entirely, dropping updates until the next reconnect - stays accurate and unchanged. This closes the race at the front door rather than only compensating for it after the fact.

## Testing

New `SystemPluginManifestSyncOrderingTest` exercises the actual mechanism the fix relies on: a coroutine awaiting `SupabaseConfig.isInitialized` genuinely suspends - verified via `TestCoroutineScheduler.runCurrent()` so the assertion is against a coroutine that has actually started and registered as a collector, not one merely scheduled and never run, which would pass unconditionally and prove nothing - until `initialize()` is called, then resolves.

`:composeApp:ktlintCheck`, `:composeApp:detekt` - clean. Full `:composeApp:desktopTest` run separately alongside the timestamp-parsing fix (#337, split into its own PR since the artifact tracks them as separate ideas): 3736 tests, 2 failed (pre-existing Windows-only symlink failures, unrelated), 14 skipped.
