### PR TITLE
fix(browser): don't clobber a copy that lands during paste-without-formatting

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -2826,6 +2826,23 @@ object FluckEngine {
      * than through `browser.zoom()` so the plugin's zoom-percent indicator stays in step - see
      * [applyBrowserZoom].
      */
+
+    /**
+     * Whether the Cmd+Shift+V clipboard-restore should proceed (BossConsole#205).
+     *
+     * The restore is a time-based guess at when Chromium has finished consuming the plain-text
+     * substitution, and it used to run unconditionally - so a Cmd+C landing in that window was
+     * silently overwritten by the pre-paste contents, with no signal to the user. Only restoring
+     * when the clipboard still holds exactly the plain text this code wrote means a copy that
+     * happened in the meantime wins instead of being clobbered.
+     *
+     * Pure and `internal` for testability - the caller reads the live clipboard, this decides.
+     */
+    internal fun shouldRestoreClipboardAfterPaste(
+        currentClipboardText: String?,
+        plainTextWeWrote: String,
+    ): Boolean = currentClipboardText == plainTextWeWrote
+
     fun setupKeyboardInterceptor(
         browser: com.teamdev.jxbrowser.browser.Browser,
         ownerWindowId: String? = null,
@@ -3124,12 +3141,32 @@ object FluckEngine {
                                                 ).keyModifiers(pasteModifiers)
                                                 .build(),
                                         )
-                                        // Restore original clipboard after paste completes
+                                        // Restore original clipboard after paste completes.
+                                        //
+                                        // BossConsole#205: this restore is unconditional and time-based, so
+                                        // anything the user copies during the 200ms window used to be silently
+                                        // replaced by the pre-paste contents with no signal - a Cmd+C landing in
+                                        // that window was simply lost. Only restoring when the clipboard still
+                                        // holds exactly the plain text we wrote means a copy that happened in the
+                                        // meantime wins instead of being clobbered.
+                                        //
+                                        // Known, and deliberate: this does not close every race the issue names.
+                                        // Two Cmd+Shift+V presses within 200ms of each other can still restore in
+                                        // the wrong order (the second press's "original" is the first press's
+                                        // plain-text substitution, not the true original), and the 200ms is still
+                                        // a guess at Chromium's own paste-consumption timing. Neither has a clean
+                                        // fix without reintroducing the injected-JS path #204 deliberately removed
+                                        // - this closes the specific, common race (an ordinary copy landing in the
+                                        // window), not every race the delay-based approach can produce.
                                         if (originalContents != null) {
                                             CoroutineScope(Dispatchers.IO).launch {
                                                 delay(200)
                                                 try {
-                                                    clipboard.setContents(originalContents, null)
+                                                    val stringFlavor = java.awt.datatransfer.DataFlavor.stringFlavor
+                                                    val currentText = clipboard.getData(stringFlavor) as? String
+                                                    if (shouldRestoreClipboardAfterPaste(currentText, plainText)) {
+                                                        clipboard.setContents(originalContents, null)
+                                                    }
                                                 } catch (_: Exception) {
                                                 }
                                             }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ClipboardRestoreAfterPasteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ClipboardRestoreAfterPasteTest.kt
@@ -1,0 +1,32 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * BossConsole#205: `FluckEngine`'s Cmd+Shift+V ("paste without formatting") restores the
+ * pre-paste clipboard after a fixed 200ms delay. That restore used to be unconditional, so
+ * anything the user copied during the window was silently replaced with no signal - a Cmd+C
+ * landing there was simply lost. [FluckEngine.shouldRestoreClipboardAfterPaste] is the fix:
+ * restore only when the clipboard still holds exactly the plain text this code wrote, so a copy
+ * that happened in the meantime wins instead of being clobbered.
+ */
+class ClipboardRestoreAfterPasteTest {
+    @Test
+    fun `restores when nothing else was copied in the meantime`() {
+        assertTrue(FluckEngine.shouldRestoreClipboardAfterPaste("hello world", "hello world"))
+    }
+
+    @Test
+    fun `does not restore when the user copied something else during the window`() {
+        // The exact race #205 reports: a Cmd+C landing in the 200ms window used to be silently
+        // overwritten by the restore.
+        assertFalse(FluckEngine.shouldRestoreClipboardAfterPaste("something the user just copied", "hello world"))
+    }
+
+    @Test
+    fun `does not restore when the clipboard was cleared in the meantime`() {
+        assertFalse(FluckEngine.shouldRestoreClipboardAfterPaste(null, "hello world"))
+    }
+}


### PR DESCRIPTION
## 

Fixes #205: `FluckEngine`'s Cmd+Shift+V ("paste without formatting") swaps the clipboard to a plain-text version, dispatches a synthetic paste, waits a fixed 200ms, then restores the original clipboard unconditionally. Anything the user copied during those 200ms was silently replaced by the pre-paste contents with no signal - a Cmd+C landing in that window was simply lost.

## Approach chosen

The issue itself lays out three options with real tradeoffs and no clean winner:
1. Don't restore at all (loses original formatting for a later paste elsewhere).
2. Restore only if the clipboard still holds exactly what was written (a user copy in the window wins).
3. Drive the paste through JS with the plain text as an explicit argument (closest to correct, but reintroduces the injected-JS path #204 deliberately removed).

Went with **option 2** - restores only when the clipboard still holds exactly the plain text this code wrote, so a copy that happened in the meantime wins instead of being clobbered. It's the smallest change that closes the specific race the issue reports, and doesn't reintroduce anything #204 removed on purpose.

The decision is extracted into a small, pure, `internal` function (`shouldRestoreClipboardAfterPaste`) so it's testable without a live JxBrowser `Browser` instance, which the surrounding key-interceptor handler otherwise requires end-to-end.

## Disclosed, not silently left

This does not close every race the issue names - said plainly in the code comment, not just here:
- Two Cmd+Shift+V presses within 200ms of each other can still restore in the wrong order (the second press's "original" is the first press's plain-text substitution, not the true original).
- The 200ms remains a guess at Chromium's own paste-consumption timing.

Neither has a clean fix without option 3's tradeoff, which the issue's own analysis already ruled out.

## Testing

New `ClipboardRestoreAfterPasteTest` (3 tests): a matching copy restores, a differing copy does not (the actual race this fixes), a cleared clipboard does not restore.

`:composeApp:ktlintCheck`, `:composeApp:detekt` - clean. Full `:composeApp:desktopTest`: 3727 tests, 2 failed (pre-existing Windows-only symlink failures, unrelated), 14 skipped.
