### PR TITLE
fix(browser): drain an in-flight call before closing the browser

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCall.kt
@@ -227,7 +227,7 @@ internal class BoundedBrowserCall(
     val backlog: Int get() = executor.queue.size
 
     /**
-     * Stop accepting new calls.
+     * Stop accepting new calls, and wait briefly for whatever is already running to finish.
      *
      * `shutdown()` and not `shutdownNow()`: a call already inside JxBrowser cannot be interrupted,
      * so interrupting would buy nothing, and work already queued still deserves to run. The thread
@@ -238,9 +238,27 @@ internal class BoundedBrowserCall(
      * owner usually just posted. Both are reachable-object concerns only, and the executor's thread
      * retires on its own after [IDLE_THREAD_TTL_SECONDS], so the whole instance becomes garbage with
      * whatever owned it. Later calls answer null via the rejected-dispatch path in [call].
+     *
+     * **BossConsole#300.** A call already in flight on [dispatcher] cannot be interrupted - see
+     * [call]'s KDoc - so a caller that closes the underlying browser right after this returns can
+     * still touch it from two threads at once: this thread finishing `browser.close()`, and
+     * [dispatcher]'s thread still inside a native round trip that started before shutdown. The
+     * bounded [awaitTermination][ThreadPoolExecutor.awaitTermination] here narrows that window for
+     * the common case - an in-flight call that was always going to finish in milliseconds now does
+     * so before the caller proceeds - without reintroducing the freeze this class exists to prevent:
+     * the wait itself is bounded, so a genuinely wedged call (the case [call]'s deadline exists for)
+     * still lets shutdown return, having merely waited [drainTimeoutMs] rather than forever. It
+     * cannot close the window when the in-flight call *is* the wedge - there is no JxBrowser API on
+     * this version able to interrupt a blocking round trip already inside the native call, which is
+     * the whole reason [call] confines it to its own thread instead of trying to cancel it.
      */
-    fun shutdown() {
+    fun shutdown(drainTimeoutMs: Long = SHUTDOWN_DRAIN_TIMEOUT_MS) {
         executor.shutdown()
+        try {
+            executor.awaitTermination(drainTimeoutMs, TimeUnit.MILLISECONDS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
     }
 
     companion object {
@@ -259,5 +277,17 @@ internal class BoundedBrowserCall(
 
         /** Long enough to serve a burst of calls on one thread, short enough not to hold one idle. */
         private const val IDLE_THREAD_TTL_SECONDS = 30L
+
+        /**
+         * How long [shutdown] waits for an in-flight call to drain before the caller proceeds to
+         * close the browser anyway (BossConsole#300). Costs nothing in the overwhelmingly common
+         * case - [ThreadPoolExecutor.awaitTermination] returns immediately once the queue and the
+         * one worker thread are both idle, which is where an instance sits between calls - and only
+         * this long in the rare case something was genuinely still running. Short relative to
+         * [DEFAULT_TIMEOUT_MS] on purpose: this is a best-effort narrowing of a race window, not
+         * another deadline a caller is meant to notice, and [POP_OUT_EDT_TIMEOUT_MS] in
+         * `BrowserHandleImpl` is the precedent for what a teardown path already tolerates waiting.
+         */
+        private const val SHUTDOWN_DRAIN_TIMEOUT_MS = 1_000L
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BoundedBrowserCallTest.kt
@@ -282,6 +282,57 @@ class BoundedBrowserCallTest {
         }
     }
 
+    /**
+     * BossConsole#300: an in-flight call cannot be interrupted, so a caller that closes the
+     * underlying browser right after `shutdown()` returns could otherwise still race a call from
+     * before shutdown that is finishing up on [BoundedBrowserCall.dispatcher]'s thread. Waiting for
+     * a call that was always going to finish quickly narrows that window before the caller proceeds.
+     */
+    @Test
+    fun `shutdown waits for a fast in-flight call to finish before it returns`() {
+        val call = BoundedBrowserCall("test-bounded-drain-fast")
+        val entered = CountDownLatch(1)
+        val finished =
+            java.util.concurrent.atomic
+                .AtomicBoolean(false)
+        call.post {
+            entered.countDown()
+            Thread.sleep(50)
+            finished.set(true)
+        }
+        entered.await()
+
+        call.shutdown(generous)
+
+        assertTrue(finished.get(), "shutdown returned before the in-flight call finished")
+    }
+
+    /**
+     * The other half of the trade: the drain wait is itself bounded, so a call that is genuinely
+     * wedged - the exact case [BoundedBrowserCall.call]'s own deadline exists for - still lets
+     * `shutdown` return, having merely waited its own timeout rather than forever. Waiting forever
+     * here would reintroduce the freeze this class exists to prevent, just moved from a plugin's
+     * await into every caller's teardown path.
+     */
+    @Test
+    fun `shutdown does not wait past its own drain timeout for a wedged call`() {
+        val call = BoundedBrowserCall("test-bounded-drain-wedge")
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        call.post {
+            entered.countDown()
+            release.await()
+        }
+        entered.await()
+        try {
+            val elapsed = measureTimeMillis { call.shutdown(timeout) }
+            assertTrue(elapsed < generous, "shutdown waited ${elapsed}ms - the drain bound did not hold")
+            assertTrue(elapsed >= timeout, "shutdown returned after ${elapsed}ms, before its own ${timeout}ms bound")
+        } finally {
+            release.countDown()
+        }
+    }
+
     /** The caller's own cancellation is not swallowed by the shutdown handling above. */
     @Test
     fun `a caller's cancellation still propagates`() {


### PR DESCRIPTION
## What this PR is, and is not

Issue #300 reports that `executeJavaScript` is a synchronous, non-cancellation-aware native call: a plugin's own `withTimeoutOrNull` around it can only abandon the *caller's wait*, not the call itself, which stays running and can race a concurrent `handle.dispose()` - touching the same native object from two threads at once.

**Investigated before writing any code, and the finding changes the scope of what's left to do here.** The severe half of this bug - the one that made it dangerous rather than just imprecise - is already fixed. `BrowserHandleImpl.executeJavaScript` no longer runs on `Dispatchers.Main` as the issue describes; it goes through `BoundedBrowserCall`, which confines every blocking round trip to one dedicated daemon thread and bounds the *wait* correctly regardless of the caller's own dispatcher (`BoundedBrowserCallTest` already pins this exhaustively - the wedge-survives-and-degrades behavior, the confined-caller regression, the reporting). A wedged renderer no longer freezes the app.

What was **not** yet closed is the residual window the issue's core report is actually about: `BoundedBrowserCall.shutdown()` stopped new work from being accepted but never waited for whatever was *already running* - so a caller (`BrowserHandleImpl.dispose()`) could call `shutdown()` and proceed straight to `browser.close()` while a call from just before shutdown was still finishing on the dedicated thread.

## Change

`shutdown()` now waits, bounded (`1000ms`, matching the order of magnitude `POP_OUT_EDT_TIMEOUT_MS` already establishes as tolerable in this same teardown path), for that in-flight call to drain before returning, via `ThreadPoolExecutor.awaitTermination`. Costs nothing in the overwhelmingly common case - `awaitTermination` returns immediately once the one worker thread and its queue are both idle, which is where an instance sits between calls - and only the bound in the rare case something was genuinely still running.

## Disclosed, not claimed as a full fix

This narrows the race for the common case (a call that was always going to finish quickly) rather than closing it:

- It cannot help when the in-flight call **is** the wedge `BoundedBrowserCall`'s own deadline exists for. Waiting unboundedly for a genuinely stuck call would reintroduce the exact freeze this class exists to prevent, just moved from a plugin's `await` into every caller's teardown path - so the wait has to stay bounded, which means the window isn't fully closed in that case.
- There is no JxBrowser API on the version this repo is pinned to that can interrupt a blocking round trip already inside the native call - which is the whole reason `BoundedBrowserCall` confines it to its own thread instead of trying to cancel it. Closing this completely needs JxBrowser's own cooperation, which the issue's own analysis already concluded isn't available today.

## Testing

Two new tests in `BoundedBrowserCallTest`, matching the file's existing before/after pattern for the deadline: `shutdown waits for a fast in-flight call to finish before it returns`, and `shutdown does not wait past its own drain timeout for a wedged call`.

`:composeApp:ktlintCheck`, `:composeApp:detekt` - clean. Full `:composeApp:desktopTest`: 3728 tests, 2 failed (pre-existing Windows-only symlink failures, unrelated), 14 skipped.
