### PR TITLE
fix(urls): reject out-of-range ports in OS-opened URLs

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/UrlOpenValidation.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/UrlOpenValidation.kt
@@ -80,7 +80,11 @@ internal object UrlOpenValidation {
         return authority.substring(0, colon).ifEmpty { null }
     }
 
-    /** A port from 0 through 65535, or `:`, which browsers accept as "default port". */
+    /**
+     * A numeric port from 0 through 65535, or `:` for the default port.
+     * Zero is deliberately accepted as a numeric value, not rewritten to the default.
+     * This syntax gate leaves unsafe-port policy and reachability to the browser.
+     */
     private fun isValidPortSuffix(suffix: String): Boolean {
         if (!suffix.startsWith(':')) return false
         // Leading zeros do not affect the port value, even when their count

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/UrlOpenValidation.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/UrlOpenValidation.kt
@@ -80,13 +80,16 @@ internal object UrlOpenValidation {
         return authority.substring(0, colon).ifEmpty { null }
     }
 
-    /** `:1234`, or `:` with nothing after it, which browsers accept as "default port". */
+    /** A port from 0 through 65535, or `:`, which browsers accept as "default port". */
     private fun isValidPortSuffix(suffix: String): Boolean {
         if (!suffix.startsWith(':')) return false
+        // Leading zeros do not affect the port value, even when their count
+        // would overflow an integer parser. Empty and all-zero ports are valid.
+        val port = suffix.drop(1).trimStart('0')
         // `in '0'..'9'`, not Char.isDigit(): isDigit is true for every Unicode
         // decimal digit, so ":٣३" (Arabic-Indic and Devanagari threes)
         // validated as a port and the URL reached the browser. Verified with
         // Character.isDigit on the JDK in use.
-        return suffix.drop(1).all { it in '0'..'9' }
+        return port.isEmpty() || (port.all { it in '0'..'9' } && port.toIntOrNull()?.let { it <= 65535 } == true)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/UrlOpenValidationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/UrlOpenValidationTest.kt
@@ -51,6 +51,40 @@ class UrlOpenValidationTest {
     }
 
     @Test
+    fun `accepts port boundaries and an empty default port`() {
+        for (host in listOf("localhost", "127.0.0.1", "[::1]")) {
+            accepts("http://$host:0/")
+            accepts("https://$host:65535/path")
+            accepts("https://$host:/path")
+        }
+    }
+
+    @Test
+    fun `refuses ports above the maximum without integer overflow`() {
+        for (host in listOf("localhost", "127.0.0.1", "[::1]")) {
+            refuses("http://$host:65536/")
+            refuses("https://$host:4294967296/path")
+            refuses("http://$host:${"9".repeat(100)}/")
+        }
+    }
+
+    @Test
+    fun `leading zeros do not change whether a port is valid`() {
+        val zeros = "0".repeat(100)
+        accepts("http://localhost:${zeros}65535/")
+        accepts("http://[::1]:$zeros/")
+        refuses("http://localhost:${zeros}65536/")
+    }
+
+    @Test
+    fun `refuses signed and non ASCII ports`() {
+        refuses("http://localhost:-1/")
+        refuses("http://localhost:+80/")
+        refuses("http://localhost:8.0/")
+        refuses("http://localhost:\u0663\u0969/")
+    }
+
+    @Test
     fun `refuses every scheme but http and https`() {
         refuses("file:///etc/passwd")
         refuses("javascript:alert(1)")

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/UrlOpenValidationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/UrlOpenValidationTest.kt
@@ -71,6 +71,9 @@ class UrlOpenValidationTest {
     @Test
     fun `leading zeros do not change whether a port is valid`() {
         val zeros = "0".repeat(100)
+        accepts("http://localhost:007/")
+        refuses("http://localhost:0x50/")
+        refuses("http://[::1]:0-1/")
         accepts("http://localhost:${zeros}65535/")
         accepts("http://[::1]:$zeros/")
         refuses("http://localhost:${zeros}65536/")


### PR DESCRIPTION
﻿## Description

An OS-opened URL such as `http://localhost:65536/` passed BOSS's URL validation because the port check only required ASCII digits. The browser cannot open that address.

Validate the numeric port range of 0 through 65535 before opening a browser tab. Strip leading zeros before parsing so long, valid zero-padded ports remain accepted. Empty ports still select the default port, and signed or non-ASCII ports remain rejected.

## Type of Change

- [x] Bug fix
- [x] Tests

## Version Impact

- [x] Patch version, handled by automated version management

## Testing Checklist

- [x] Tested locally on Windows with Java 17 installed and discovered by Gradle
- [x] Reproduced the bug with two failing regression tests before the fix
- [x] All 12 URL validation tests pass after the fix, with zero failures or skips
- [x] Desktop production and test sources compile successfully
- [ ] Full project test suite and other operating systems

```powershell
.\gradlew.bat :composeApp:desktopTest --tests '*UrlOpenValidationTest*' --console=plain
```

Coverage includes hostname, IPv4 and bracketed IPv6 URLs; ports 0, 65535 and 65536; integer overflow; long leading-zero padding; empty default ports; and signed/non-ASCII values.

## Code Quality

- [x] Self-reviewed the final diff
- [x] ktlint 1.8.0 passes for both changed files
- [x] detekt 1.23.8 passes for both changed files using the repository configuration and module baseline
- [x] `git diff --check` passes

Formatting and static analysis were run through an isolated Gradle runner using the repository's pinned tool versions.

## Review Focus Areas

- Port range boundaries and overflow handling
- Preserving valid default and zero-padded ports

## Pre-merge Checklist

- [x] Based on the latest fetched upstream `main`
- [x] Commit message and PR title describe the change
- [ ] Required CI checks pass
