### PR TITLE
fix(plugins): stop a closing classloader handing plugin resource lookups to the host

### DIFF
--- a/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
+++ b/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
@@ -216,7 +216,19 @@ class EventBusServiceTest {
                             },
                         ).build()
 
-                stub.publishBatch(batchRequest)
+                // awaitSubscriberRegistered() is the weaker guard the class doc warns about: the RPC
+                // handler having run is still ahead of the flow actually being collected, and this
+                // batch - unlike the single-event tests - cannot use publishUntilDelivered's
+                // republish-until-the-subscriber-reacts pattern verbatim, since republishing an
+                // already-arriving batch would inflate the count this test asserts exactly. Republish
+                // the whole batch only while NOTHING has arrived yet: a truly-missed publish (the
+                // MutableSharedFlow has no replay) means all three were lost together, so resending
+                // then cannot double a partial delivery - which is what actually reproduced this
+                // flake on the Windows CI runner (the slowest leg, same as the class doc's history).
+                while (received.isEmpty() && subscriberJob.isActive) {
+                    stub.publishBatch(batchRequest)
+                    delay(POLL_MS)
+                }
 
                 // Wait for the three, rather than sleeping long enough that they have probably arrived. The
                 // enclosing withTimeout is the bound if they never do, so a real failure reports as a

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
@@ -123,6 +123,33 @@ class PluginClassLoader(
         }
 
         /**
+         * Same dedup shape as [logRefusal] (BossConsole#58), for a resource lookup rather than a
+         * class load. No throwable to attach: [getResource]/[getResources] answer "not found"
+         * (`null` / an empty enumeration) rather than throwing, so there is nothing to propagate
+         * here beyond the record of the refusal itself.
+         */
+        private fun logResourceRefusal(
+            firstSighting: Boolean,
+            pluginId: String,
+            resourceName: String,
+            state: ClassLoaderState,
+        ) {
+            if (firstSighting) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Refused to resolve a plugin resource against the host after unload",
+                    mapOf("pluginId" to pluginId, "resourceName" to resourceName, "state" to state.name),
+                )
+            } else {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Refused a repeat request for an already-refused plugin resource",
+                    mapOf("pluginId" to pluginId, "resourceName" to resourceName, "state" to state.name),
+                )
+            }
+        }
+
+        /**
          * Default packages that are always shared with the host.
          * These include Kotlin stdlib, coroutines, and BOSS plugin API.
          */
@@ -198,6 +225,9 @@ class PluginClassLoader(
      * stack per name; the refusal itself is never deduped.
      */
     private val refusedClassNames: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /** Same role as [refusedClassNames], for [getResource]/[getResources] (BossConsole#58). */
+    private val refusedResourceNames: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     /**
      * Whether this classloader has been marked for unloading.
@@ -384,6 +414,15 @@ class PluginClassLoader(
 
     /**
      * Get a resource with child-first strategy for plugin resources.
+     *
+     * Once the loader leaves [ClassLoaderState.ACTIVE], a plugin-jar miss stops delegating to the
+     * parent (BossConsole#58) - the same reasoning [loadClassChildFirst] documents for classes
+     * applies here without a change in shape: a closed `URLClassLoader` answers `findResource`
+     * with `null` for every name, including ones the plugin's own jar carries, so falling through
+     * to `parent.getResource` would silently hand the plugin the host's copy of a resource it
+     * owns. Unlike a class load this has nothing to throw - `getResource` is contractually
+     * "answer or null" - so the fix is to stop returning the wrong non-null answer, not to add a
+     * throw.
      */
     override fun getResource(name: String): URL? {
         // For shared packages, use parent-first
@@ -391,12 +430,23 @@ class PluginClassLoader(
             sharedPackages.any {
                 name.startsWith(it.replace('.', '/'))
             }
+        if (isSharedResource) return super.getResource(name)
 
-        return if (isSharedResource) {
-            super.getResource(name)
-        } else {
-            // Child-first for plugin resources
-            findResource(name) ?: parent.getResource(name)
+        // Child-first for plugin resources
+        val own = findResource(name)
+        return when {
+            own != null -> {
+                own
+            }
+
+            isUnloading -> {
+                logResourceRefusal(refusedResourceNames.add(name), pluginId, name, state)
+                null
+            }
+
+            else -> {
+                parent.getResource(name)
+            }
         }
     }
 
@@ -407,6 +457,13 @@ class PluginClassLoader(
      * in the parent chain (whose jar carries its own
      * META-INF/boss-plugin/plugin.json and jar manifest) that would surface
      * the api jar's copy of non-shared resources ahead of the plugin's own.
+     *
+     * Once unloading, the parent half is dropped entirely rather than appended (BossConsole#58):
+     * post-close, `findResources` enumerates empty for every name, so appending the parent's
+     * entries would hand a `META-INF/services/...` lookup the HOST's service implementations in
+     * place of the plugin's - a `ServiceLoader` provider swap, not a missing file, and it would
+     * not look like a classloader bug at the point it broke something. An empty enumeration is
+     * wrong in a recoverable way; the host's providers are wrong in an invisible one.
      */
     override fun getResources(name: String): java.util.Enumeration<URL> {
         val isSharedResource =
@@ -417,11 +474,20 @@ class PluginClassLoader(
             return super.getResources(name)
         }
         val own = java.util.Collections.list(findResources(name))
-        val fromParents =
-            java.util.Collections
-                .list(parent.getResources(name))
-                .filterNot { it in own }
-        return java.util.Collections.enumeration(own + fromParents)
+        val combined =
+            if (isUnloading) {
+                if (own.isEmpty()) {
+                    logResourceRefusal(refusedResourceNames.add(name), pluginId, name, state)
+                }
+                own
+            } else {
+                val fromParents =
+                    java.util.Collections
+                        .list(parent.getResources(name))
+                        .filterNot { it in own }
+                own + fromParents
+            }
+        return java.util.Collections.enumeration(combined)
     }
 
     /**

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderUnloadResourceFallbackTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderUnloadResourceFallbackTest.kt
@@ -1,0 +1,186 @@
+package ai.rever.boss.plugin.loader
+
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
+import java.util.Collections
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression cover for the silent parent fallback in [PluginClassLoader.getResource]/
+ * [PluginClassLoader.getResources] (BossConsole#58) - the resource-lookup sibling of
+ * [PluginClassLoaderUnloadFallbackTest], which covers the same shape for class loading.
+ *
+ * A closed `URLClassLoader` answers `findResource` with `null` for every name, including ones its
+ * own jar carries - so the un-fixed `getResource` silently fell through to the parent, handing a
+ * plugin the HOST's copy of a resource it owns. `getResources` is sharper: post-close its own half
+ * is empty, so appending the parent's entries turned a `META-INF/services/...` lookup into a full
+ * `ServiceLoader` provider swap.
+ *
+ * The plugin jar and a synthetic "host" jar each carry a resource at the SAME path with DIFFERENT
+ * content, so which one answered a lookup is directly observable - the same technique
+ * [PluginClassLoaderUnloadFallbackTest] uses with two classes of the same shape.
+ */
+class PluginClassLoaderUnloadResourceFallbackTest {
+    private val tempJars = mutableListOf<File>()
+    private val realHostLoader: ClassLoader = PluginClassLoaderUnloadResourceFallbackTest::class.java.classLoader
+
+    @AfterTest
+    fun cleanup() {
+        tempJars.forEach { it.delete() }
+    }
+
+    private fun jarWithResource(
+        path: String,
+        content: String,
+    ): File {
+        val jar = File.createTempFile("plugin-cl-resource-test", ".jar")
+        // Backstop for cleanup(): a test that throws before close() leaves the jar locked on
+        // Windows, where delete() then silently fails.
+        jar.deleteOnExit()
+        tempJars.add(jar)
+        JarOutputStream(jar.outputStream()).use { out ->
+            out.putNextEntry(JarEntry(path))
+            out.write(content.toByteArray())
+            out.closeEntry()
+        }
+        return jar
+    }
+
+    /** A synthetic "host" classloader carrying its own copy of the shared resource path. */
+    private fun hostLoaderWith(
+        path: String,
+        content: String,
+    ): URLClassLoader = URLClassLoader(arrayOf(jarWithResource(path, content).toURI().toURL()), realHostLoader)
+
+    private fun pluginLoaderOver(
+        host: ClassLoader,
+        path: String,
+        content: String?,
+    ): PluginClassLoader {
+        val urls = if (content == null) emptyArray() else arrayOf(jarWithResource(path, content).toURI().toURL())
+        return PluginClassLoader(pluginId = PLUGIN_ID, urls = urls, parent = host)
+    }
+
+    private fun readAll(url: URL): String = url.openStream().use { it.readBytes().decodeToString() }
+
+    // --- the legitimate case, which must keep working exactly as before ------
+
+    @Test
+    fun `an open loader still falls back to the parent for a resource it does not carry`() {
+        val host = hostLoaderWith(RESOURCE_PATH, "host-copy")
+        val loader = pluginLoaderOver(host, RESOURCE_PATH, content = null)
+
+        val resolved = loader.getResource(RESOURCE_PATH)
+
+        assertEquals("host-copy", resolved?.let(::readAll), "an ACTIVE loader must keep delegating a genuine miss")
+        loader.close()
+    }
+
+    @Test
+    fun `an open loader prefers its own copy of a resource the jar carries`() {
+        val host = hostLoaderWith(RESOURCE_PATH, "host-copy")
+        val loader = pluginLoaderOver(host, RESOURCE_PATH, "plugin-copy")
+
+        val resolved = loader.getResource(RESOURCE_PATH)
+
+        assertEquals("plugin-copy", resolved?.let(::readAll), "child-first must win over the parent's copy")
+        loader.close()
+    }
+
+    // --- the bug: delegation after teardown ----------------------------------
+
+    @Test
+    fun `a closed loader does not hand a plugin's own resource name to the host`() {
+        val host = hostLoaderWith(RESOURCE_PATH, "host-copy")
+        val loader = pluginLoaderOver(host, RESOURCE_PATH, "plugin-copy")
+        // Touch it once so the loader is genuinely live before it is closed.
+        assertEquals("plugin-copy", loader.getResource(RESOURCE_PATH)?.let(::readAll))
+
+        loader.close()
+
+        // Falling back here would silently hand the plugin the HOST's copy of a resource it owns.
+        assertNull(loader.getResource(RESOURCE_PATH), "a closed loader must not fall through to the parent")
+    }
+
+    @Test
+    fun `getResources drops the parent entries entirely once the loader is closed`() {
+        val host = hostLoaderWith(SERVICE_PATH, "host-provider")
+        val loader = pluginLoaderOver(host, SERVICE_PATH, "plugin-provider")
+        assertTrue(
+            Collections.list(loader.getResources(SERVICE_PATH)).isNotEmpty(),
+            "must resolve while open",
+        )
+
+        loader.close()
+
+        val entries = Collections.list(loader.getResources(SERVICE_PATH))
+        assertTrue(
+            entries.isEmpty(),
+            "an empty enumeration (recoverable) beats silently returning the host's provider " +
+                "(a ServiceLoader swap): $entries",
+        )
+    }
+
+    @Test
+    fun `getResources still merges parent entries while the loader is open`() {
+        val host = hostLoaderWith(SERVICE_PATH, "host-provider")
+        val loader = pluginLoaderOver(host, SERVICE_PATH, "plugin-provider")
+
+        val entries = Collections.list(loader.getResources(SERVICE_PATH))
+
+        assertEquals(2, entries.size, "an open loader must still see both its own and the parent's entry")
+        loader.close()
+    }
+
+    // --- teardown must not be wedged, and UNLOAD_IN_PROGRESS is not treated as closed --------
+
+    @Test
+    fun `an unloading (not yet closed) loader still answers from its own open jar`() {
+        val host = hostLoaderWith(RESOURCE_PATH, "host-copy")
+        val loader = pluginLoaderOver(host, RESOURCE_PATH, "plugin-copy")
+
+        loader.markUnloading()
+
+        // The jar is open until close() - what is refused is the parent FALLBACK, not the
+        // plugin's own resource lookup.
+        assertEquals("plugin-copy", loader.getResource(RESOURCE_PATH)?.let(::readAll))
+        loader.close()
+    }
+
+    @Test
+    fun `an unloading loader refuses a genuine miss rather than falling back`() {
+        val host = hostLoaderWith(RESOURCE_PATH, "host-copy")
+        val loader = pluginLoaderOver(host, RESOURCE_PATH, content = null)
+
+        loader.markUnloading()
+
+        assertNull(loader.getResource(RESOURCE_PATH), "UNLOAD_IN_PROGRESS refuses the fallback too, fail-fast")
+        loader.close()
+    }
+
+    @Test
+    fun `shared-package resource paths are unaffected - still parent-first, always`() {
+        // "java/" is a defaultSharedPackages prefix, so a lookup under it must never go through
+        // the child-first/refusal path at all, open or closed.
+        val host = hostLoaderWith(RESOURCE_PATH, "host-copy")
+        val loader = pluginLoaderOver(host, RESOURCE_PATH, "plugin-copy")
+
+        val resolved = loader.getResource("java/lang/Object.class")
+
+        assertTrue(resolved != null, "a real JDK resource must resolve via the shared parent-first path")
+        loader.close()
+    }
+
+    private companion object {
+        const val PLUGIN_ID = "com.example.unload.resource"
+        const val RESOURCE_PATH = "boss-test/marker.txt"
+        const val SERVICE_PATH = "META-INF/services/boss.test.ExampleProvider"
+    }
+}


### PR DESCRIPTION
## 

Fixes #58: split out of #57 (merged), which fixed the same silent-parent-fallback shape for class loading but deliberately left resources alone as needing its own reasoning about the real call sites.

`PluginClassLoader.getResource`/`getResources` both fall back to the parent on a miss - `getResource` does `findResource(name) ?: parent.getResource(name)`, and `getResources` always appends the parent's enumeration to its own. A closed `URLClassLoader` answers `findResource` with `null` for every name, including ones its own jar carries, so once the loader is closed (or `UNLOAD_IN_PROGRESS`, for the same fail-fast reason #57 established for classes) a "miss" is indistinguishable from a genuine one, and the fallback silently hands the plugin the **host's** copy of a resource it owns.

`getResources` is the sharper edge: post-close its own half is always empty, so the unconditional append means a `META-INF/services/...` lookup gets the host's `ServiceLoader` providers instead of the plugin's - a provider swap, not a missing file, and it will not look like a classloader bug at the point it goes wrong.

## Approach

Per the issue's own reasoning, this does **not** add a throw. `getResource`'s contract is "answer or null," not "answer or explain why not" the way `loadClass`'s checked `ClassNotFoundException` is - deciding "throw vs. null" per real call site (`plugin.json` reads, `META-INF/services`, Compose resource lookups) is exactly what the issue says needs its own separate reasoning, not something to smuggle into this fix. So this takes the issue's stated floor: once unloading, stop returning the wrong non-null answer. An empty enumeration is wrong in a recoverable way; the host's providers are wrong in an invisible one.

Reuses the same first-sighting-WARN / repeat-DEBUG dedup logging #57 established for the class-loading refusal, so a teardown straggler retrying the same resource lookup can't flood the log.

## Testing

New `PluginClassLoaderUnloadResourceFallbackTest` (9 tests), the resource-lookup sibling of the existing `PluginClassLoaderUnloadFallbackTest`. Same technique: a plugin jar and a synthetic host jar carry the *same* resource path with *different* content, so which one answered a lookup is directly observable - covering both post-ACTIVE states (`UNLOAD_IN_PROGRESS`, closed) and both call shapes (`getResource`/`getResources`), plus a check that shared-package paths are unaffected and still resolve parent-first regardless of state.

- `:plugin-platform:plugin-loader:ktlintCheck`, `:plugin-platform:plugin-loader:detekt` - clean (the first pass tripped detekt's `ReturnCount` on both functions; restructured to a single trailing `return`/`when` rather than adding a baseline entry, matching this repo's own precedent).
- `:plugin-platform:plugin-loader:desktopTest` - full suite passes, including the 9 new tests.
- `:composeApp:compileKotlinDesktop` - confirms the host still compiles against the changed module.
