### PR TITLE
test(ipc): await subscriber readiness before publishing a batch

### DIFF
--- a/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
+++ b/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.ipc.services.EventBusServiceImpl
 import com.google.protobuf.ByteString
 import io.grpc.ManagedChannelBuilder
 import io.grpc.ServerBuilder
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -24,7 +25,6 @@ import kotlin.test.assertTrue
 class EventBusServiceTest {
     private companion object {
         const val POLL_MS = 25L
-        const val SETTLE_MS = 100L
         const val BATCH_SIZE = 3
     }
 
@@ -73,20 +73,6 @@ class EventBusServiceTest {
             publish()
             delay(POLL_MS)
         }
-    }
-
-    /**
-     * Wait until a subscription has been registered with the service.
-     *
-     * Weaker than [publishUntilDelivered] — the count increments when the RPC handler runs, which is still
-     * ahead of the flow being collected — but it is what a test asserting an exact event count can use,
-     * since republishing would change the count it asserts. Still strictly better than a fixed sleep.
-     */
-    private suspend fun awaitSubscriberRegistered() {
-        while (eventBusService.activeSubscribers < 1) {
-            delay(POLL_MS)
-        }
-        delay(SETTLE_MS)
     }
 
     @Test
@@ -185,22 +171,33 @@ class EventBusServiceTest {
                 val stub = EventBusServiceGrpcKt.EventBusServiceCoroutineStub(channel!!)
 
                 val received = mutableListOf<EventEnvelope>()
+                val ready = CompletableDeferred<Unit>()
                 val subscribeRequest =
                     SubscribeRequest
                         .newBuilder()
                         .setSubscriberId("batch-subscriber")
                         .addEventTypes("BatchEvent")
+                        .addEventTypes("ReadyProbe")
                         .build()
 
                 val subscriberJob =
                     launch {
                         stub.subscribe(subscribeRequest).collect { envelope ->
-                            received.add(envelope)
-                            if (received.size == BATCH_SIZE) return@collect
+                            if (envelope.eventType == "ReadyProbe") {
+                                ready.complete(Unit)
+                            } else {
+                                received.add(envelope)
+                            }
                         }
                     }
 
-                awaitSubscriberRegistered()
+                // Observing a probe proves this stream is collecting. Retry only probes, so delayed
+                // delivery cannot duplicate the batch or hide a batch with missing entries.
+                val probe = EventEnvelope.newBuilder().setEventType("ReadyProbe").build()
+                while (!ready.isCompleted) {
+                    stub.publish(probe)
+                    delay(POLL_MS)
+                }
 
                 val batchRequest =
                     PublishBatchRequest
@@ -216,19 +213,7 @@ class EventBusServiceTest {
                             },
                         ).build()
 
-                // awaitSubscriberRegistered() is the weaker guard the class doc warns about: the RPC
-                // handler having run is still ahead of the flow actually being collected, and this
-                // batch - unlike the single-event tests - cannot use publishUntilDelivered's
-                // republish-until-the-subscriber-reacts pattern verbatim, since republishing an
-                // already-arriving batch would inflate the count this test asserts exactly. Republish
-                // the whole batch only while NOTHING has arrived yet: a truly-missed publish (the
-                // MutableSharedFlow has no replay) means all three were lost together, so resending
-                // then cannot double a partial delivery - which is what actually reproduced this
-                // flake on the Windows CI runner (the slowest leg, same as the class doc's history).
-                while (received.isEmpty() && subscriberJob.isActive) {
-                    stub.publishBatch(batchRequest)
-                    delay(POLL_MS)
-                }
+                assertTrue(stub.publishBatch(batchRequest).success)
 
                 // Wait for the three, rather than sleeping long enough that they have probably arrived. The
                 // enclosing withTimeout is the bound if they never do, so a real failure reports as a
@@ -238,7 +223,11 @@ class EventBusServiceTest {
                 }
                 subscriberJob.cancel()
 
-                assertEquals(BATCH_SIZE, received.size, "Should receive all 3 batch events")
+                assertEquals(
+                    (1..BATCH_SIZE).map { "event-$it" },
+                    received.map { it.payload.toStringUtf8() },
+                    "Should receive each batch event once, in order",
+                )
             }
         }
 

--- a/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
+++ b/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
@@ -216,7 +216,19 @@ class EventBusServiceTest {
                             },
                         ).build()
 
-                stub.publishBatch(batchRequest)
+                // awaitSubscriberRegistered() is the weaker guard the class doc warns about: the RPC
+                // handler having run is still ahead of the flow actually being collected, and this
+                // batch - unlike the single-event tests - cannot use publishUntilDelivered's
+                // republish-until-the-subscriber-reacts pattern verbatim, since republishing an
+                // already-arriving batch would inflate the count this test asserts exactly. Republish
+                // the whole batch only while NOTHING has arrived yet: a truly-missed publish (the
+                // MutableSharedFlow has no replay) means all three were lost together, so resending
+                // then cannot double a partial delivery - which is what actually reproduced this
+                // flake on the Windows CI runner (the slowest leg, same as the class doc's history).
+                while (received.isEmpty() && subscriberJob.isActive) {
+                    stub.publishBatch(batchRequest)
+                    delay(POLL_MS)
+                }
 
                 // Wait for the three, rather than sleeping long enough that they have probably arrived. The
                 // enclosing withTimeout is the bound if they never do, so a real failure reports as a

--- a/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
+++ b/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
@@ -195,6 +195,7 @@ class EventBusServiceTest {
                 // delivery cannot duplicate the batch or hide a batch with missing entries.
                 val probe = EventEnvelope.newBuilder().setEventType("ReadyProbe").build()
                 while (!ready.isCompleted) {
+                    assertTrue(subscriberJob.isActive, "Subscriber ended before receiving the readiness probe")
                     stub.publish(probe)
                     delay(POLL_MS)
                 }
@@ -203,7 +204,7 @@ class EventBusServiceTest {
                     PublishBatchRequest
                         .newBuilder()
                         .addAllEvents(
-                            (1..3).map { i ->
+                            (1..BATCH_SIZE).map { i ->
                                 EventEnvelope
                                     .newBuilder()
                                     .setEventType("BatchEvent")
@@ -215,10 +216,10 @@ class EventBusServiceTest {
 
                 assertTrue(stub.publishBatch(batchRequest).success)
 
-                // Wait for the three, rather than sleeping long enough that they have probably arrived. The
-                // enclosing withTimeout is the bound if they never do, so a real failure reports as a
-                // timeout instead of an off-by-a-few count that reads like a delivery bug.
+                // Wait for the complete batch. Fail immediately if the stream ends; the enclosing
+                // timeout bounds a live stream that never delivers all expected events.
                 while (received.size < BATCH_SIZE) {
+                    assertTrue(subscriberJob.isActive, "Subscriber ended before receiving the complete batch")
                     delay(POLL_MS)
                 }
                 subscriberJob.cancel()


### PR DESCRIPTION
The batch delivery integration test could publish before its gRPC subscriber began collecting and lose events. It now retries a separate readiness probe until that same stream receives it, then publishes the measured batch exactly once. The assertion checks all three payloads in order and the RPC success response.

A client-side empty list does not prove the server dropped a batch: delivery can still be in flight. The service also emits batch entries individually, so startup can lose only a prefix. The readiness handshake avoids both assumptions without changing production behavior or relying on a fixed settling delay.

Credit: Antriksh (@Antriksh1984) identified and isolated the Windows batch-test flake in the original submission, carried forward from #428. The review agent replaced the batch retries with probe-based readiness, strengthened payload assertions, and removed the obsolete settling helper. These review repairs are separate from the original contribution. The resource-loading work from #428 was independently merged as #325 by Shikhar Goel (@sgoel2be24-cyber) and promoted by #430; it is not part of this PR.

Validation: latest head 225ab24e5 passes all 49 local IPC tests (zero failures/errors/skips), :boss-ipc:ktlintCheck and :boss-ipc:detekt under the shared build lock. Hosted run 34416828958 passes Linux, macOS, Windows and all quality/compatibility/database/shell/version jobs. Claude follow-up 34416843557 reviewed 225ab24e5 and found it correct, with no regressions or blocking findings (https://github.com/risa-labs-inc/BossConsole/pull/433#issuecomment-5610167635). Prior head 761dce756 passed all hosted platforms and received a completed Claude review confirming the readiness repair correct with no regressions.

The latest review follow-up also uses BATCH_SIZE for construction and expectations and explicitly fails if the subscriber ends before readiness or complete delivery. These are agent quality repairs; original author credit above is unchanged. No production/UI behavior changes or live-app validation required.
