### PR TITLE
fix(deep-link): stop logging Linux's expected APP_OPEN_URI gap as an error (#410)

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
@@ -274,6 +274,19 @@ actual object DeepLinkHandler {
                         _deepLinkFlow.value = uri
                     }
                 }
+            } catch (e: UnsupportedOperationException) {
+                // Documented outcome on Linux: the JDK's X11 Desktop peer supports no
+                // APP_OPEN_URI action (see processCommandLineArgs's KDoc), so this always
+                // throws there. Not an error - argv already delivers these links, both at
+                // cold start and forwarded to a running instance over the single-instance
+                // channel - but logging it at ERROR read as a broken feature on every Linux
+                // launch (BossConsole#410). Same pattern setupOpenFileHandler already uses
+                // for the equivalent APP_OPEN_FILE gap.
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Desktop.setOpenURIHandler not supported on this platform",
+                    mapOf("reason" to (e.message ?: "unsupported")),
+                )
             } catch (e: Exception) {
                 logger.error(LogCategory.SYSTEM, "Failed to set up deep link handler", error = e)
             }


### PR DESCRIPTION
## What

Part 1 of #410's two Linux dogfood findings: `DeepLinkHandler` logging `UnsupportedOperationException` for `APP_OPEN_URI` as an ERROR on every Linux launch, which reads as a broken feature.

## Why

`Desktop.setOpenURIHandler` throws `UnsupportedOperationException` on Linux - the JDK's X11 `Desktop` peer supports no `APP_OPEN_URI` action, as `processCommandLineArgs`'s own KDoc in this file already documents. `setupDefaultHandler()` (the Linux/other-platforms branch) caught this with a generic `catch (e: Exception)` that logs at `ERROR` with a full stack trace, even though it's a fully expected, harmless outcome.

The actual delivery already works on Linux through a different path: `processCommandLineArgs` reads `boss://` links out of `argv` at cold start (`Exec=<app> %u` in the generated `.desktop` file), and `main.kt` forwards them to an already-running instance over the single-instance channel when the lock is already held - both OS-agnostic, neither depending on `setOpenURIHandler`. So nothing is actually broken; the log just says otherwise.

This exact situation already has an established fix pattern in the same file: `setupOpenFileHandler()` catches the equivalent `APP_OPEN_FILE` gap with a specific `UnsupportedOperationException` branch first, logged at `DEBUG` as "not an error", before falling through to the generic `Exception` catch. `setupDefaultHandler()` was just missing that same branch.

## Scope

This addresses only the log-noise half of #410. The second half (Skiko `Cannot create Linux GL context` warning on the reporter's VM) is a separate, harder rendering/upstream question - the reporter says the UI stays usable, so it's left out of scope here rather than folded into an unrelated log-level fix.

## Testing

- `:composeApp:ktlintCheck :composeApp:detekt` - clean
- No dedicated test file exists for `DeepLinkHandler` (it's `Desktop`-API glue tied to a singleton's `init` block, not independently testable without an interactive AWT/X11 environment - the same reason `WindowsProtocolHandler`'s equivalent catch has no dedicated test either). Verified by inspection against `setupOpenFileHandler`'s already-reviewed, identically-shaped catch order in the same file.
- `:composeApp:desktopTest` targeted at `DeepLinkRoutingTest`, `OsOpenArgumentsTest`, `SettingsDeepLinkTest` (the pure-function tests this file's other logic has) - pass
