### PR TITLE
fix(updater): remember an unsupported-OS refusal so it stops being re-offered (#119)

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
@@ -21,7 +21,17 @@ import kotlin.time.Duration
  * coordinator is the single owner that can [shutdown], windows hold handles that
  * cannot.
  */
-class UpdateManager {
+class UpdateManager internal constructor(
+    /**
+     * Test-only seam for the "real manager check/install path" (BossConsole#119's
+     * review asked for exactly this, not a test against [claimStagedUpdate] in
+     * isolation): [UpdateService] is a fixed no-arg `expect`/`actual` type with no
+     * injectable release source reachable from here, so this substitutes at the one
+     * layer up instead. All-null by default, which is production behavior
+     * unchanged - [updateService] is still the sole real caller.
+     */
+    private val testHooks: UpdateManagerTestHooks = UpdateManagerTestHooks(),
+) {
     private val logger = BossLogger.forComponent("UpdateManager")
 
     // Internal for access by VersionListManager
@@ -167,7 +177,7 @@ class UpdateManager {
             _updateState.value = UpdateState.CheckingForUpdates
             _lastCheckTime.value = Clock.System.now()
 
-            val updateInfo = updateService.checkForUpdates()
+            val updateInfo = testHooks.checkForUpdates?.invoke() ?: updateService.checkForUpdates()
             _updateInfo.value = updateInfo
 
             when {
@@ -306,10 +316,10 @@ class UpdateManager {
         try {
             _updateState.value = UpdateState.Downloading(0f)
 
+            val onProgress: (Float) -> Unit = { progress -> _updateState.value = UpdateState.Downloading(progress) }
             val downloadPath =
-                updateService.downloadUpdate(updateInfo) { progress ->
-                    _updateState.value = UpdateState.Downloading(progress)
-                }
+                testHooks.downloadUpdate?.invoke(updateInfo, onProgress)
+                    ?: updateService.downloadUpdate(updateInfo, onProgress)
 
             if (downloadPath != null) {
                 _updateState.value = UpdateState.ReadyToInstall(downloadPath)
@@ -412,21 +422,45 @@ class UpdateManager {
             return false
         }
         return try {
-            val outcome = updateService.installUpdate(downloadPath)
+            val outcome = testHooks.installUpdate?.invoke(downloadPath) ?: updateService.installUpdate(downloadPath)
             if (outcome.succeeded) {
                 _updateState.value = UpdateState.RestartRequired
             } else {
                 // Prefer the installer's own explanation. It is the only place that
                 // knows *why* — e.g. a release requiring a newer macOS than this
                 // Mac runs — and a generic string there is indistinguishable from
-                // a crash to the user.
-                _updateState.value = UpdateState.Error(outcome.errorMessage ?: "Installation failed")
+                // a crash to the user. The error is shown FIRST, unconditionally -
+                // persistence below must never be what decides whether the user
+                // sees why their install just failed.
+                _updateState.value =
+                    UpdateState.Error(
+                        outcome.errorMessage ?: "Installation failed",
+                        isUnsupportedOs = outcome.isUnsupportedOs,
+                    )
+                if (outcome.isUnsupportedOs) persistUnsupportedOsDismissal()
             }
             outcome.succeeded
         } catch (e: Exception) {
             _updateState.value = UpdateState.Error("Installation failed: ${e.message}")
             false
         }
+    }
+
+    /**
+     * Remember the currently-offered version as dismissed (BossConsole#119), so a later
+     * automatic check does not re-offer - and re-download - a release this machine cannot run.
+     *
+     * Reuses [UpdateSettings.lastDismissedVersion], the same storage [dismissVersion] writes,
+     * but deliberately does not call [dismissVersion] itself: that hides the dialog and resets
+     * the state to [UpdateState.Idle], which here would erase the refusal message
+     * [installUpdate] just set instead of explaining it. A forced/manual check still bypasses
+     * this the same way it bypasses a user dismissal; a different, newer version is unaffected,
+     * since only the version [_updateInfo] currently names is recorded.
+     */
+    private suspend fun persistUnsupportedOsDismissal() {
+        val unsupportedVersion = _updateInfo.value?.latestVersion ?: return
+        UpdateSettings.lastDismissedVersion = unsupportedVersion.toString()
+        UpdateSettingsManager.saveSettings()
     }
 
     /**
@@ -471,6 +505,24 @@ class UpdateManager {
 }
 
 /**
+ * Test-only substitutes for [UpdateManager]'s three [UpdateService] calls (BossConsole#119).
+ *
+ * All default to null, so a `UpdateManager()` production instance behaves exactly as if this
+ * type did not exist. Bundled into one object, matching this codebase's own `Hooks` convention
+ * (e.g. `PluginArtifactCleanup.Hooks`), rather than three separate constructor parameters.
+ *
+ * Grouped as three because a check-refuse-recheck cycle test needs a controlled release
+ * (`checkForUpdates`), a way to get from `UpdateAvailable` to the `ReadyToInstall` state
+ * `installUpdate` requires without touching a real filesystem (`downloadUpdate`), and a
+ * controlled refusal (`installUpdate`) - not because each is independently useful alone.
+ */
+internal class UpdateManagerTestHooks(
+    val checkForUpdates: (suspend () -> UpdateInfo)? = null,
+    val downloadUpdate: (suspend (UpdateInfo, (Float) -> Unit) -> String?)? = null,
+    val installUpdate: (suspend (String) -> InstallOutcome)? = null,
+)
+
+/**
  * Update state sealed class
  */
 sealed class UpdateState {
@@ -498,6 +550,15 @@ sealed class UpdateState {
 
     data class Error(
         val message: String,
+        /**
+         * True when this failure is [InstallOutcome.isUnsupportedOs] (BossConsole#119):
+         * the release this Mac cannot run, rather than an ordinary install failure.
+         * [UpdateManager.installUpdate] also persists a dismissal for this case, so a
+         * later automatic check does not re-offer (and re-download) the same version -
+         * but the error itself stays visible here rather than resetting to [Idle], since
+         * unlike [UpdateManager.dismissVersion] the user did not ask to dismiss anything.
+         */
+        val isUnsupportedOs: Boolean = false,
     ) : UpdateState()
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateService.kt
@@ -71,10 +71,17 @@ data class VersionInfo(
  * `LSMinimumSystemVersion` this Mac does not meet. Flattening that to `false`
  * surfaced a red "Installation failed" with the real explanation only in a log
  * file, which is indistinguishable from a crash to the person looking at it.
+ *
+ * [isUnsupportedOs] (BossConsole#119) distinguishes that one refusal reason
+ * from every other install failure: [UpdateManager] uses it to remember this
+ * exact version so automatic checks stop re-offering (and re-downloading) a
+ * release this machine cannot run, without treating an ordinary failure the
+ * same way.
  */
 data class InstallOutcome(
     val succeeded: Boolean,
     val errorMessage: String? = null,
+    val isUnsupportedOs: Boolean = false,
 )
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/DesktopUpdateService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/DesktopUpdateService.kt
@@ -483,6 +483,11 @@ actual class UpdateService {
                 logger.error(LogCategory.SYSTEM, "Update installation failed", mapOf("error" to result.message))
                 InstallOutcome(succeeded = false, errorMessage = result.message)
             }
+
+            is InstallResult.UnsupportedOs -> {
+                logger.warn(LogCategory.SYSTEM, "Update refused - unsupported OS", mapOf("error" to result.message))
+                InstallOutcome(succeeded = false, errorMessage = result.message, isUnsupportedOs = true)
+            }
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -138,6 +138,20 @@ private fun isWindowsInstallDir(
 ): Boolean = WINDOWS_INSTALL_MARKER_DIRS.any { exists(File(directory, it).path) }
 
 /**
+ * Delete the refused artifact, and ONLY it - never a different file (BossConsole#119).
+ *
+ * A standalone, pure-filesystem operation so "cannot delete a newer staged download or an
+ * unrelated file" (the issue's review, point 2) is provable directly: it never looks anywhere
+ * but at the exact [downloadFile] passed to it, so a sibling in the same staging directory - a
+ * newer version already staged, or an unrelated file - is structurally unreachable rather than
+ * merely untested. Best-effort: a failed delete leaves the file for the next reconcile rather
+ * than blocking the refusal from being reported.
+ */
+internal fun deleteRefusedArtifact(downloadFile: File): Boolean =
+    runCatching { downloadFile.delete() }
+        .getOrDefault(false)
+
+/**
  * Platform-specific update installation logic
  *
  * This class handles the actual installation of updates for different platforms.
@@ -155,8 +169,21 @@ sealed class InstallResult {
     data class Error(
         val message: String,
     ) : InstallResult()
+
+    /**
+     * Refused because this Mac's OS is below the release's `LSMinimumSystemVersion`
+     * (BossConsole#119) - a typed subtype of [Error] rather than a flag on it, so a
+     * `when` that already exhausts [InstallResult] must decide what this means rather
+     * than silently falling into the generic branch.
+     */
+    data class UnsupportedOs(
+        val message: String,
+    ) : InstallResult()
 }
 
+// One cohesive dispatcher over every platform's install mechanics (macOS/Windows/Linux deb/rpm/jar);
+// splitting it does not reduce complexity, only adds indirection between callers who need it as a unit.
+@Suppress("LargeClass")
 object UpdateInstaller {
     private val logger = BossLogger.forComponent("UpdateInstaller")
 
@@ -547,7 +574,20 @@ object UpdateInstaller {
                     // (JxBrowser 9.4.0 took it 12.0 -> 13.0) and the release
                     // manifest carries no minimum-OS field, so nothing upstream
                     // stops the update being offered.
-                    unsupportedOsError(appBundle)?.let { return@withContext InstallResult.Error(it) }
+                    unsupportedOsError(appBundle)?.let { message ->
+                        // The refused artifact must not linger: it is the whole app,
+                        // sitting in a restricted staging directory, and every later
+                        // automatic check would otherwise re-download the same
+                        // unusable DMG (BossConsole#119). The message is captured
+                        // before the delete attempt, so a delete failure never loses it.
+                        logger.warn(
+                            LogCategory.SYSTEM,
+                            "Refusing an unsupported-OS update - removing the refused artifact",
+                            mapOf("reason" to message, "path" to downloadFile.name),
+                        )
+                        deleteRefusedArtifact(downloadFile)
+                        return@withContext InstallResult.UnsupportedOs(message)
+                    }
 
                     logger.info(LogCategory.SYSTEM, "DMG verified successfully", mapOf("appBundle" to appBundle.name))
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/DeleteRefusedArtifactTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/DeleteRefusedArtifactTest.kt
@@ -1,0 +1,42 @@
+package ai.rever.boss.updater
+
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * BossConsole#119's review, point 2: the artifact an unsupported-OS refusal removes must be
+ * exactly the one that was refused - never a newer version already staged, and never an
+ * unrelated file that happens to share the staging directory.
+ */
+class DeleteRefusedArtifactTest {
+    private val tempDir = createTempDirectory("delete-refused-artifact-test").toFile()
+
+    @AfterTest
+    fun cleanup() {
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun `removes only the exact refused file`() {
+        val refused = File(tempDir, "BOSS-9.5.3-Universal.dmg").apply { writeText("refused") }
+        val newerStaged =
+            File(tempDir, "BOSS-9.5.4-Universal.dmg").apply { writeText("newer, unrelated to this refusal") }
+        val unrelated = File(tempDir, "notes.txt").apply { writeText("some other file in the same directory") }
+
+        assertTrue(deleteRefusedArtifact(refused))
+
+        assertFalse(refused.exists(), "the refused artifact must actually be gone")
+        assertTrue(newerStaged.exists(), "a newer staged download must survive")
+        assertTrue(unrelated.exists(), "an unrelated file in the same directory must survive")
+    }
+
+    @Test
+    fun `a missing file is reported as not deleted, without throwing`() {
+        val alreadyGone = File(tempDir, "already-gone.dmg")
+        assertFalse(deleteRefusedArtifact(alreadyGone))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateManagerUnsupportedOsCycleTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateManagerUnsupportedOsCycleTest.kt
@@ -1,0 +1,139 @@
+package ai.rever.boss.updater
+
+import ai.rever.boss.utils.Version
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * BossConsole#119: an install refused as unsupported-OS must be remembered so an automatic
+ * check stops re-offering (and re-downloading) that exact version, while a forced/manual check
+ * still offers it and a different, newer version is unaffected.
+ *
+ * Exercised through the real [UpdateManager] check -> download -> install -> recheck path via
+ * [UpdateManagerTestHooks], not just [UpdateSettings.lastDismissedVersion] or
+ * [claimStagedUpdate] in isolation - those already have coverage elsewhere
+ * ([StagedUpdateClaimTest]), and neither proves the manager actually wires the two together.
+ */
+class UpdateManagerUnsupportedOsCycleTest {
+    private val currentVersion = Version(major = 9, minor = 5, patch = 2)
+    private val refusedVersion = Version(major = 9, minor = 5, patch = 3)
+    private val newerVersion = Version(major = 9, minor = 5, patch = 4)
+
+    private var savedDismissed: String? = null
+
+    @BeforeTest
+    fun setUp() {
+        savedDismissed = UpdateSettings.lastDismissedVersion
+        UpdateSettings.lastDismissedVersion = null
+    }
+
+    @AfterTest
+    fun tearDown() {
+        UpdateSettings.lastDismissedVersion = savedDismissed
+    }
+
+    private fun infoFor(latest: Version) =
+        UpdateInfo(
+            available = true,
+            currentVersion = currentVersion,
+            latestVersion = latest,
+            releaseNotes = "",
+        )
+
+    @Test
+    fun `unsupported-OS refusal suppresses only that version on the next automatic check`() =
+        runBlocking {
+            var offered = refusedVersion
+            val manager =
+                UpdateManager(
+                    UpdateManagerTestHooks(
+                        checkForUpdates = { infoFor(offered) },
+                        downloadUpdate = { _, _ -> "/tmp/BOSS-unsupported.dmg" },
+                        installUpdate = {
+                            InstallOutcome(
+                                succeeded = false,
+                                errorMessage = "This update requires macOS 26 or later - this Mac runs macOS 14.",
+                                isUnsupportedOs = true,
+                            )
+                        },
+                    ),
+                )
+
+            // An automatic check surfaces the refused version normally - nothing dismissed yet.
+            manager.checkForUpdates(force = false)
+            assertTrue(manager.updateState.value is UpdateState.UpdateAvailable, "baseline: version is on offer")
+
+            // Stage it (as the banner's "Update Now" would) so installUpdate has something to claim.
+            manager.downloadUpdate(infoFor(refusedVersion))
+            assertTrue(manager.updateState.value is UpdateState.ReadyToInstall, "staged before install")
+
+            // Install refuses it as unsupported-OS.
+            val installed = manager.installUpdate("/tmp/BOSS-unsupported.dmg")
+            assertFalse(installed, "an unsupported-OS refusal is not a successful install")
+
+            val errorState = manager.updateState.value
+            assertTrue(errorState is UpdateState.Error, "the refusal must stay visible, not reset to Idle")
+            assertTrue(errorState.isUnsupportedOs, "the refusal must be typed, not a generic Error")
+            assertEquals(
+                refusedVersion.toString(),
+                UpdateSettings.lastDismissedVersion,
+                "the refused version must be persisted as dismissed",
+            )
+
+            // An automatic check must now stay quiet about the exact same version.
+            manager.checkForUpdates(force = false)
+            assertEquals(
+                UpdateState.Idle,
+                manager.updateState.value,
+                "an automatic check must not re-offer (or re-download) a version already refused as unsupported",
+            )
+
+            // A forced/manual check must still offer it - the same bypass a user dismissal gets.
+            manager.checkForUpdates(force = true)
+            assertTrue(manager.updateState.value is UpdateState.UpdateAvailable, "a forced check bypasses the refusal")
+
+            // A different, newer version must remain eligible on an ordinary automatic check.
+            offered = newerVersion
+            manager.checkForUpdates(force = false)
+            val state = manager.updateState.value
+            assertTrue(state is UpdateState.UpdateAvailable, "an unrelated newer version must not be suppressed")
+            assertEquals(newerVersion, state.updateInfo.latestVersion)
+        }
+
+    @Test
+    fun `an ordinary install failure does not persist a dismissal`() =
+        runBlocking {
+            val manager =
+                UpdateManager(
+                    UpdateManagerTestHooks(
+                        checkForUpdates = { infoFor(refusedVersion) },
+                        downloadUpdate = { _, _ -> "/tmp/BOSS-ordinary.dmg" },
+                        installUpdate = {
+                            InstallOutcome(succeeded = false, errorMessage = "Disk full", isUnsupportedOs = false)
+                        },
+                    ),
+                )
+
+            manager.checkForUpdates(force = false)
+            manager.downloadUpdate(infoFor(refusedVersion))
+            manager.installUpdate("/tmp/BOSS-ordinary.dmg")
+
+            val errorState = manager.updateState.value
+            assertTrue(errorState is UpdateState.Error)
+            assertFalse(errorState.isUnsupportedOs)
+            assertEquals(
+                null,
+                UpdateSettings.lastDismissedVersion,
+                "an ordinary failure must not suppress future checks",
+            )
+
+            // The version must still be offered on the very next automatic check.
+            manager.checkForUpdates(force = false)
+            assertTrue(manager.updateState.value is UpdateState.UpdateAvailable)
+        }
+}


### PR DESCRIPTION
## What

Fixes #119's client-side mitigation: an install refused because this Mac's OS is below the release's `LSMinimumSystemVersion` now gets remembered, so an automatic check stops re-offering (and re-downloading) it. Independent implementation - see note at the bottom on the existing PR #343.

## The gap

`UpdateInstaller.installMacOSUpdate` already refuses an OS-incompatible release (`unsupportedOsError`), but the refusal was a plain `InstallResult.Error(message)` - indistinguishable from any other install failure. Nothing recorded *which version* had been refused, so:

1. Every subsequent automatic check re-offered the exact same unusable DMG.
2. Each offer triggered a fresh download of a multi-hundred-MB artifact the Mac was never going to be able to install.
3. The refused DMG itself was left sitting in the staging directory after the refusal, on top of the re-downloads.

## The fix

- `InstallResult` gains a typed `UnsupportedOs(message)` case alongside `Error` - a sealed subtype, not a boolean flag, so every exhaustive `when` over it (there's exactly one, in `DesktopUpdateService`) is forced to decide what it means rather than falling into the generic branch by accident.
- `InstallOutcome.isUnsupportedOs` threads that through to `UpdateManager.installUpdate`.
- On that outcome, `UpdateManager` persists the refused version via the same `UpdateSettings.lastDismissedVersion` storage `dismissVersion()` writes - but does **not** call `dismissVersion()` itself. That function hides the dialog and resets state to `Idle`, which here would erase the refusal message this branch just set instead of explaining it to the user. A forced/manual check still bypasses the persisted dismissal, exactly like it already bypasses a user's own "Later"; a different, newer version is unaffected, since only the exact refused version is recorded.
- The refused DMG is deleted. Extracted as a standalone top-level function (`deleteRefusedArtifact`) that only ever touches the one `File` it's given, so "cannot delete a newer staged download or an unrelated file" is a property of the code shape, not just something a test happens to assert - and it's directly testable without mounting a real DMG.

## Testing the full cycle, not just the pieces

`UpdateManager` builds its own `UpdateService` with no injectable release source (an existing test file's own comment - `StagedUpdateClaimTest` - says as much, which is why that file tests the compare-and-set in isolation instead). Rather than leave the check-refuse-recheck cycle untested end to end, added `UpdateManagerTestHooks`: three optional lambda seams (`checkForUpdates` / `downloadUpdate` / `installUpdate`), matching this codebase's existing `Hooks` convention (e.g. `PluginArtifactCleanup.Hooks`), all null by default so production behavior (`UpdateManager()`) is unchanged.

`UpdateManagerUnsupportedOsCycleTest` drives the real manager through: check (offers the version) -> download (stages it) -> install (refused as unsupported-OS) -> check again (automatic check stays quiet) -> check forced (still offered) -> check with a different newer version (unaffected). A second test confirms an *ordinary* install failure does not persist a dismissal.

`DeleteRefusedArtifactTest` covers the cleanup directly: a refused file is removed, a differently-named newer staged download and an unrelated file in the same directory both survive, and a missing file doesn't throw.

## What this does not do

Matches the issue's own scoping: release `min_os` metadata (pre-download filtering), Homebrew `depends_on macos:` requirements, and release-communications callouts are separate work, not attempted here.

**Manual verification**: I don't have macOS hardware in this environment, so I cannot record a live "installed on an actually-unsupported Mac" run. Everything above is verified by the full local test suite (`:composeApp:ktlintCheck :composeApp:detekt` clean; targeted `ai.rever.boss.updater.*` tests pass, including the two new files) and by reading the exact code paths involved, not by a live install.

## Note on PR #343

I'm aware #343 is open against the same issue and has unresolved review feedback (a regression test for the full check cycle, DMG cleanup, and manual verification - the same three points this PR addresses) plus a merge conflict against current `main`. This is an independent implementation from scratch, not a fork of that branch. Happy to see whichever lands first merge, and to close this one if #343 gets there first with equivalent coverage.
