### PR TITLE
feat(remote-ui): a wants_keys capability gate for out-of-process plugin surfaces

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceComponent.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin.remote
 
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceDescriptor
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceHost
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.ui.sdk.UIEventMapper
@@ -26,15 +27,9 @@ internal class RemoteSurfaceComponent(
 
     /**
      * Whether the plugin behind this surface declared [RemoteUiSurfaceDescriptor.wantsKeys].
-     * Read opportunistically off the registry rather than carried through a new
-     * [RemoteUiSurfaceHost] callback: the descriptor is immutable for a surface's whole lifetime, so
-     * there is nothing to keep in sync once read, and by the time either existing callback fires at
-     * least once the registration [registry].[RemoteUiSurfaceRegistry.surfaceOf] would read is
-     * already there - [RemoteUiSurfaceRegistry.attach]'s replay always calls
-     * [RemoteUiSurfaceHost.onConnectionChanged] (even with `false`) once the surface is registered,
-     * and [RemoteUiSurfaceHost.onTreeUpdated] never fires before it either. Stays at its safe
-     * `false` default for the entire window before either callback, matching every other "nothing
-     * has told us yet" state this component starts in.
+     * Refreshed on tree/connection delivery. This snapshot only controls the renderer's tap;
+     * a same-owner replacement can precede its next callback or recomposition. The receiving
+     * surface also checks its own immutable descriptor when enqueueing keys.
      */
     private val _wantsKeys = mutableStateOf(false)
 
@@ -57,7 +52,7 @@ internal class RemoteSurfaceComponent(
             }
         }
 
-    /** Re-read [RemoteUiSurfaceDescriptor.wantsKeys] off the registry; a no-op before registration. */
+    /** Re-read [RemoteUiSurfaceDescriptor.wantsKeys] off the registry; false before registration. */
     private fun refreshWantsKeys() {
         _wantsKeys.value = registry.surfaceOf(surfaceId)?.descriptor?.wantsKeys == true
     }
@@ -135,7 +130,7 @@ internal class RemoteSurfaceComponent(
         if (!registry.emit(surfaceId, proto)) {
             logger.debug(
                 LogCategory.UI,
-                "Dropped UI event: no plugin holds this surface",
+                "Dropped UI event: surface unavailable or capability not declared",
                 mapOf("surfaceId" to surfaceId),
             )
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceComponent.kt
@@ -25,6 +25,20 @@ internal class RemoteSurfaceComponent(
     private val _connected = mutableStateOf(false)
 
     /**
+     * Whether the plugin behind this surface declared [RemoteUiSurfaceDescriptor.wantsKeys].
+     * Read opportunistically off the registry rather than carried through a new
+     * [RemoteUiSurfaceHost] callback: the descriptor is immutable for a surface's whole lifetime, so
+     * there is nothing to keep in sync once read, and by the time either existing callback fires at
+     * least once the registration [registry].[RemoteUiSurfaceRegistry.surfaceOf] would read is
+     * already there - [RemoteUiSurfaceRegistry.attach]'s replay always calls
+     * [RemoteUiSurfaceHost.onConnectionChanged] (even with `false`) once the surface is registered,
+     * and [RemoteUiSurfaceHost.onTreeUpdated] never fires before it either. Stays at its safe
+     * `false` default for the entire window before either callback, matching every other "nothing
+     * has told us yet" state this component starts in.
+     */
+    private val _wantsKeys = mutableStateOf(false)
+
+    /**
      * The transport's view of this panel.
      *
      * Kept private rather than implemented by the class: these are calls the registry makes *into* the
@@ -33,13 +47,20 @@ internal class RemoteSurfaceComponent(
     private val surfaceHost =
         object : RemoteUiSurfaceHost {
             override fun onTreeUpdated(tree: WidgetTree) {
+                refreshWantsKeys()
                 updateTree(tree)
             }
 
             override fun onConnectionChanged(connected: Boolean) {
+                refreshWantsKeys()
                 _connected.value = connected
             }
         }
+
+    /** Re-read [RemoteUiSurfaceDescriptor.wantsKeys] off the registry; a no-op before registration. */
+    private fun refreshWantsKeys() {
+        _wantsKeys.value = registry.surfaceOf(surfaceId)?.descriptor?.wantsKeys == true
+    }
 
     /** Whether a plugin process is currently streaming this panel's surface. */
     val connected: State<Boolean> get() = _connected
@@ -53,6 +74,7 @@ internal class RemoteSurfaceComponent(
         RemoteSurfaceContent(
             tree = tree,
             connected = _connected.value,
+            wantsKeys = _wantsKeys.value,
             onEvent = { nodeId, event -> sendUIEvent(nodeId, event) },
         )
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceComponent.kt
@@ -41,21 +41,18 @@ internal class RemoteSurfaceComponent(
      */
     private val surfaceHost =
         object : RemoteUiSurfaceHost {
+            override fun onKeyCapabilityChanged(wantsKeys: Boolean) {
+                _wantsKeys.value = wantsKeys
+            }
+
             override fun onTreeUpdated(tree: WidgetTree) {
-                refreshWantsKeys()
                 updateTree(tree)
             }
 
             override fun onConnectionChanged(connected: Boolean) {
-                refreshWantsKeys()
                 _connected.value = connected
             }
         }
-
-    /** Re-read [RemoteUiSurfaceDescriptor.wantsKeys] off the registry; false before registration. */
-    private fun refreshWantsKeys() {
-        _wantsKeys.value = registry.surfaceOf(surfaceId)?.descriptor?.wantsKeys == true
-    }
 
     /** Whether a plugin process is currently streaming this panel's surface. */
     val connected: State<Boolean> get() = _connected

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceContent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceContent.kt
@@ -11,10 +11,11 @@ import androidx.compose.runtime.Composable
 internal fun RemoteSurfaceContent(
     tree: WidgetTree?,
     connected: Boolean,
+    wantsKeys: Boolean = false,
     onEvent: (String, WidgetEvent) -> Unit,
 ) {
     Column {
         if (!connected) Text("Remote surface disconnected")
-        tree?.let { RemoteWidgetRenderer(tree = it, onEvent = onEvent) }
+        tree?.let { RemoteWidgetRenderer(tree = it, onEvent = onEvent, wantsKeys = wantsKeys) }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
@@ -96,14 +96,10 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  * what the field ignores bubbles this far. That is the same "host first, then the specific thing, then
  * the surface" ordering one level down.
  *
- * **The surface is deliberately not a focus target of its own.** An earlier revision ended this chain
- * in `.focusable()`, which made a surface with no interactive content a Tab stop that began streaming
- * every unclaimed key-down to a separate OS process — with no plugin identity, no capability model and
- * nothing visible in the UI. Reviewers were unanimous that that is the wrong default to ship, and the
- * directions are not symmetric: granting it later behind a declared `wants_keys` on `UIRegistration` is
- * additive, whereas revoking it after a plugin has shipped against it is a negotiation. So a surface
- * receives keys only once something inside it holds focus — which is every surface built for
- * interaction, and none of the ones with no business seeing keystrokes.
+ * **The surface is deliberately not a focus target of its own.** The renderer adds this tap only
+ * when registration declares `wants_keys`; the outgoing surface queue enforces the same declaration.
+ * Even an opted-in surface receives keys only while an interactive child holds focus. The declaration
+ * is not user consent and does not create a Tab stop for a surface containing only labels.
  *
  * ## Cost
  *

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.plugin.remote
 
 import ai.rever.boss.components.overlays.ContextMenu
 import ai.rever.boss.components.overlays.ContextMenuItem
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceDescriptor
 import ai.rever.boss.plugin.ui.BossColorScheme
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.ui.sdk.*
@@ -34,19 +35,29 @@ import androidx.compose.ui.unit.sp
  *
  * @param tree      The widget tree to render
  * @param onEvent   Callback for UI events, forwarded to the owning plugin as proto `UIEvent`s
+ * @param wantsKeys Whether the plugin declared [RemoteUiSurfaceDescriptor.wantsKeys] at
+ *   registration. False (the default) omits the key tap entirely, so unclaimed
+ *   [ai.rever.boss.ipc.proto.KeyEvent]s never reach a plugin that never asked to see them — not
+ *   even the ones a focused interactive child (a text field's own unhandled keys, a button)
+ *   would otherwise let bubble this far. See [forwardUnclaimedKeys] for the full policy this
+ *   gates, and why the gate belongs here rather than on the plugin's own widget tree.
  */
 @Composable
 fun RemoteWidgetRenderer(
     tree: WidgetTree,
     onEvent: (nodeId: String, event: WidgetEvent) -> Unit = { _, _ -> },
+    wantsKeys: Boolean = false,
 ) {
     val root = tree.nodes[tree.rootId] ?: return
     // A wrapper only so the surface has one node above the whole tree to tap keys at — see
     // Modifier.forwardUnclaimedKeys for why that node is the right place and why it never consumes.
     // propagateMinConstraints so a root that fills its parent still does; the Box is otherwise
-    // transparent to layout.
+    // transparent to layout. The tap itself is added only for a surface that declared wantsKeys —
+    // omitting it, rather than adding it and having it decline everything, means a plugin that
+    // never asked for keys has no code path here that ever sees one, regardless of what inside
+    // its own tree happens to hold focus.
     Box(
-        modifier = Modifier.forwardUnclaimedKeys(onEvent),
+        modifier = if (wantsKeys) Modifier.forwardUnclaimedKeys(onEvent) else Modifier,
         propagateMinConstraints = true,
     ) {
         RenderNode(node = root, tree = tree, onEvent = onEvent)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
@@ -35,12 +35,10 @@ import androidx.compose.ui.unit.sp
  *
  * @param tree      The widget tree to render
  * @param onEvent   Callback for UI events, forwarded to the owning plugin as proto `UIEvent`s
- * @param wantsKeys Whether the plugin declared [RemoteUiSurfaceDescriptor.wantsKeys] at
- *   registration. False (the default) omits the key tap entirely, so unclaimed
- *   [ai.rever.boss.ipc.proto.KeyEvent]s never reach a plugin that never asked to see them — not
- *   even the ones a focused interactive child (a text field's own unhandled keys, a button)
- *   would otherwise let bubble this far. See [forwardUnclaimedKeys] for the full policy this
- *   gates, and why the gate belongs here rather than on the plugin's own widget tree.
+ * @param wantsKeys The latest observed [RemoteUiSurfaceDescriptor.wantsKeys] declaration.
+ *   False (the default) omits the key tap. A replacement registration can precede its next callback
+ *   or recomposition, so the receiving surface queue also enforces its own declaration before
+ *   delivering any key. See [forwardUnclaimedKeys] for host-keymap and focused-widget routing.
  */
 @Composable
 fun RemoteWidgetRenderer(
@@ -52,10 +50,8 @@ fun RemoteWidgetRenderer(
     // A wrapper only so the surface has one node above the whole tree to tap keys at — see
     // Modifier.forwardUnclaimedKeys for why that node is the right place and why it never consumes.
     // propagateMinConstraints so a root that fills its parent still does; the Box is otherwise
-    // transparent to layout. The tap itself is added only for a surface that declared wantsKeys —
-    // omitting it, rather than adding it and having it decline everything, means a plugin that
-    // never asked for keys has no code path here that ever sees one, regardless of what inside
-    // its own tree happens to hold focus.
+    // transparent to layout. Only the observed wantsKeys=true installs a tap; the receiving queue
+    // also rejects keys when a replacement registration has opted out before this state refreshes.
     Box(
         modifier = if (wantsKeys) Modifier.forwardUnclaimedKeys(onEvent) else Modifier,
         propagateMinConstraints = true,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -377,6 +377,7 @@ class PluginUIServiceBridge(
             displayName = displayName,
             iconName = iconName,
             defaultSlot = defaultSlot,
+            wantsKeys = wantsKeys,
         )
 
     private fun registrationResponse(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -368,8 +368,8 @@ class PluginUIServiceBridge(
     /**
      * Everything a registration declares beyond identity.
      *
-     * Kept on the surface for the follow-up that places it in the window, which is what needs
-     * `surface_type` to choose panel vs tab and `default_slot` to position a panel.
+     * Placement uses the type, name, icon and slot; the renderer and receiving event queue use
+     * wantsKeys to gate unclaimed raw keys. All fields belong to this registration.
      */
     private fun UIRegistration.descriptor(): RemoteUiSurfaceDescriptor =
         RemoteUiSurfaceDescriptor(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -192,9 +192,12 @@ class RemoteUiSurface internal constructor(
      * mean either blocking the frame or handing the event to a coroutine that can be reordered against
      * its neighbours.
      *
-     * @return `false` when the surface is closed — a late event is dropped, never thrown at the caller.
+     * @return `false` when the surface is closed or a key was not requested.
      */
     internal fun emit(event: UIEvent): Boolean {
+        // A composed renderer can still hold the previous registration's capability until its next
+        // callback/recomposition. Enforce the receiving registration's immutable policy at enqueue.
+        if (event.hasKey() && !descriptor.wantsKeys) return false
         if (outgoing.trySend(event).isFailure) return false
         // DROP_OLDEST evicts inside the channel, so overflow has to be inferred from outside it: the
         // buffer cannot hold more than its capacity, so a count above it means this send probably

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -41,10 +41,8 @@ class RemoteUiSurface internal constructor(
     /**
      * What the plugin declared about this surface at registration.
      *
-     * Retained but unused today: placing a remote surface in the window is the follow-up this transport
-     * unblocks, and that is what will need `surface_type` to pick panel vs tab, `default_slot` to place a
-     * panel, and the name and icon to label it. Dropping them here would mean re-plumbing the protocol
-     * later for data it already carries.
+     * Placement uses the type, slot, name and icon. The renderer observes wantsKeys through
+     * capability callbacks, and emit enforces it against this immutable receiving registration.
      */
     val descriptor: RemoteUiSurfaceDescriptor = RemoteUiSurfaceDescriptor(),
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -166,6 +166,7 @@ class RemoteUiSurface internal constructor(
      */
     internal fun replayTo(host: RemoteUiSurfaceHost) {
         synchronized(publishLock) {
+            host.onKeyCapabilityChanged(descriptor.wantsKeys)
             host.onConnectionChanged(streaming)
             tree?.let(host::onTreeUpdated)
         }
@@ -197,8 +198,7 @@ class RemoteUiSurface internal constructor(
     internal fun emit(event: UIEvent): Boolean {
         // A composed renderer can still hold the previous registration's capability until its next
         // callback/recomposition. Enforce the receiving registration's immutable policy at enqueue.
-        if (event.hasKey() && !descriptor.wantsKeys) return false
-        if (outgoing.trySend(event).isFailure) return false
+        if ((event.hasKey() && !descriptor.wantsKeys) || outgoing.trySend(event).isFailure) return false
         // DROP_OLDEST evicts inside the channel, so overflow has to be inferred from outside it: the
         // buffer cannot hold more than its capacity, so a count above it means this send probably
         // evicted. "Probably" because the collector decrements just after its receive — see

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -38,6 +38,13 @@ data class RemoteUiSurfaceDescriptor(
     val displayName: String = "",
     val iconName: String = "",
     val defaultSlot: String = "",
+    /**
+     * Whether the plugin declared it wants unclaimed [ai.rever.boss.ipc.proto.KeyEvent]s
+     * (the security note in docs/KEYBOARD_SHORTCUTS.md). False by default and for
+     * every plugin built against a proto before this field existed - the renderer that reads it
+     * must fail closed on a plugin that never sends it.
+     */
+    val wantsKeys: Boolean = false,
 )
 
 /** Outcome of a plugin's `RegisterUI`. */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -9,8 +9,8 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * The host-side renderer of one remote surface, as the transport sees it.
  *
- * Implemented by `RemotePanelComponent` / `RemoteTabComponent`. Both callbacks arrive on whichever thread
- * gRPC delivered the message on, never the UI thread, and both are invoked **while the surface's publish
+ * Implemented by `RemotePanelComponent` / `RemoteTabComponent`. Callbacks arrive on whichever thread
+ * gRPC delivered the message on, never the UI thread, and are invoked **while the surface's publish
  * lock is held** — which is what makes the sequence a host observes monotonic. So an implementation must:
  *
  * - touch only thread-safe state (Compose snapshot state is — writing it from any thread is fine);
@@ -20,6 +20,9 @@ import java.util.concurrent.ConcurrentHashMap
  * Anything heavier belongs on the far side of a state write the UI observes.
  */
 interface RemoteUiSurfaceHost {
+    /** The publishing surface's key declaration, delivered without a registry lookup by the host. */
+    fun onKeyCapabilityChanged(wantsKeys: Boolean) {}
+
     /** A new widget tree to render. */
     fun onTreeUpdated(tree: WidgetTree)
 
@@ -182,10 +185,20 @@ class RemoteUiSurfaceRegistry {
                 processId = processId,
                 descriptor = descriptor,
                 publishTree = { from, tree ->
-                    if (surfaces.stillOwnedBy(from)) hosts[surfaceId]?.onTreeUpdated(tree)
+                    if (surfaces.stillOwnedBy(from)) {
+                        hosts[surfaceId]?.apply {
+                            onKeyCapabilityChanged(from.descriptor.wantsKeys)
+                            onTreeUpdated(tree)
+                        }
+                    }
                 },
                 publishConnected = { from, connected ->
-                    if (surfaces.stillOwnedBy(from)) hosts[surfaceId]?.onConnectionChanged(connected)
+                    if (surfaces.stillOwnedBy(from)) {
+                        hosts[surfaceId]?.apply {
+                            onKeyCapabilityChanged(connected && from.descriptor.wantsKeys)
+                            onConnectionChanged(connected)
+                        }
+                    }
                 },
             )
         val stale = claim(surfaceId, created)
@@ -340,10 +353,12 @@ class RemoteUiSurfaceRegistry {
                 "A second component attached to a surface already being rendered - the first is detached",
                 mapOf("surfaceId" to surfaceId),
             )
+            displaced.onKeyCapabilityChanged(false)
             displaced.onConnectionChanged(false)
         }
         val surface = surfaces[surfaceId]
         if (surface == null) {
+            host.onKeyCapabilityChanged(false)
             host.onConnectionChanged(false)
         } else {
             surface.replayTo(host)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -33,8 +33,8 @@ interface RemoteUiSurfaceHost {
 /**
  * What a plugin declared about a surface when it registered it.
  *
- * Carried, not acted on: placing a remote surface in the window is the follow-up this transport unblocks,
- * and it is what will read these. Mirrors the corresponding `UIRegistration` fields.
+ * Mirrors `UIRegistration`: placement consumes the type/name/icon/slot, and the renderer and
+ * receiving event queue enforce the key declaration.
  */
 data class RemoteUiSurfaceDescriptor(
     val surfaceType: String = "",
@@ -195,6 +195,7 @@ class RemoteUiSurfaceRegistry {
                 publishConnected = { from, connected ->
                     if (surfaces.stillOwnedBy(from)) {
                         hosts[surfaceId]?.apply {
+                            // A false publication comes from close(); reset the tap on teardown.
                             onKeyCapabilityChanged(connected && from.descriptor.wantsKeys)
                             onConnectionChanged(connected)
                         }
@@ -393,8 +394,8 @@ class RemoteUiSurfaceRegistry {
     /**
      * Queue a user event for the plugin behind [surfaceId].
      *
-     * @return `false` when there is nothing to deliver to — no registered surface, or one already closed.
-     *   Callers log and move on; a click that lands during teardown is not an error condition.
+     * @return `false` when no surface is registered, the receiving surface is closed, or a key
+     *   was not requested by its declaration. Callers drop the event rather than retry a policy refusal.
      */
     fun emit(
         surfaceId: String,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
@@ -123,6 +123,28 @@ class RemoteSurfaceInputComposeTest {
     }
 
     @Test
+    fun `an opted out replacement rejects keys from the still composed opted in renderer`() {
+        val registry = RemoteUiSurfaceRegistry()
+        val original = registry.accept(PANEL, wantsKeys = true)
+        val panel = RemotePanelComponent(PANEL, "Test Panel", PROCESS, registry)
+        original.pushTree(textFieldTree())
+        panel.attach()
+        assertUnboundInLiveKeymap()
+        compose.setContent { panel.Content() }
+        compose.onNode(hasSetTextAction()).requestFocus()
+
+        // Reclaim a registration that has not opened its stream. No tree or connection callback
+        // has refreshed the existing composition, but events now route to the replacement queue.
+        val replacement = registry.accept(PANEL)
+        compose.onRoot().performKeyInput {
+            withKeyDown(Key.AltLeft) { withKeyDown(Key.ShiftLeft) { pressKey(Key.F7) } }
+        }
+        compose.waitForIdle()
+        assertNoKeyReachesThePlugin(replacement)
+        panel.dispose()
+    }
+
+    @Test
     fun `a key the focused widget consumes never reaches the plugin`() {
         // "The focused widget gets first refusal" is the property that keeps ordinary typing off the
         // wire — a text field consumes its character keys, so a plugin sees one TextChange per edit

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.plugin.remote
 
 import ai.rever.boss.ipc.proto.UIEvent
 import ai.rever.boss.kernel.ui.RemoteUiSurface
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceDescriptor
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.kernel.ui.SurfaceRegistration
 import ai.rever.boss.keymap.KeymapSettingsManager
@@ -39,6 +40,7 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -67,7 +69,10 @@ class RemoteSurfaceInputComposeTest {
     @Test
     fun `a key the host does not claim reaches the plugin with its payload intact`() {
         val registry = RemoteUiSurfaceRegistry()
-        val surface = registry.accept(PANEL)
+        // wantsKeys = true: this test is about the routing rule end to end, not about the gate
+        // The gate added in front of it - RemoteSurfaceKeyRoutingTest and the wantsKeys-specific
+        // tests in this file cover that the gate itself defaults closed and is enforced.
+        val surface = registry.accept(PANEL, wantsKeys = true)
         val panel = RemotePanelComponent(PANEL, "Test Panel", PROCESS, registry)
         surface.pushTree(textFieldTree())
         panel.attach()
@@ -90,6 +95,30 @@ class RemoteSurfaceInputComposeTest {
         assertEquals(AwtKeyEvent.VK_F7, queued.key.keyCode)
         assertTrue(queued.key.alt, "the alt modifier must survive the crossing")
         assertTrue(queued.key.shift, "the shift modifier must survive the crossing")
+        panel.dispose()
+    }
+
+    @Test
+    fun `wants_keys defaults to false, and no key reaches a plugin that never declared it`() {
+        // The mirror of the test above, with the one thing changed being whether the
+        // surface declared wants_keys - not the widget tree, not the key, not the routing rule. Same
+        // interactive field, same focus, same unbound chord; the only difference from the passing case
+        // is the registration this test does NOT opt into.
+        val registry = RemoteUiSurfaceRegistry()
+        val surface = registry.accept(PANEL) // wantsKeys defaults to false - the point of this test.
+        val panel = RemotePanelComponent(PANEL, "Test Panel", PROCESS, registry)
+        surface.pushTree(textFieldTree())
+        panel.attach()
+        assertUnboundInLiveKeymap()
+
+        compose.setContent { panel.Content() }
+        compose.onNode(hasSetTextAction()).requestFocus()
+        compose.onRoot().performKeyInput {
+            withKeyDown(Key.AltLeft) { withKeyDown(Key.ShiftLeft) { pressKey(Key.F7) } }
+        }
+        compose.waitForIdle()
+
+        assertNoKeyReachesThePlugin(surface)
         panel.dispose()
     }
 
@@ -234,8 +263,14 @@ class RemoteSurfaceInputComposeTest {
         return KeymapSettings(shortcuts = mapOf(binding.actionId to binding))
     }
 
-    private fun RemoteUiSurfaceRegistry.accept(surfaceId: String): RemoteUiSurface =
-        (register(surfaceId, PROCESS) as SurfaceRegistration.Accepted).surface
+    private fun RemoteUiSurfaceRegistry.accept(
+        surfaceId: String,
+        wantsKeys: Boolean = false,
+    ): RemoteUiSurface =
+        (
+            register(surfaceId, PROCESS, RemoteUiSurfaceDescriptor(wantsKeys = wantsKeys))
+                as SurfaceRegistration.Accepted
+        ).surface
 
     /** Bounded, so a regression fails the build instead of hanging it. Mirrors RemoteWidgetRendererComposeTest. */
     private fun RemoteUiSurface.firstEvent(): UIEvent = firstEventWhere { true }
@@ -250,6 +285,25 @@ class RemoteSurfaceInputComposeTest {
         runBlocking {
             withTimeout(WAIT_TIMEOUT_MS) { events().filter(predicate).take(1).toList() }.single()
         }
+
+    /**
+     * Bounded wait proving a Key event never arrives - a much shorter budget than
+     * [WAIT_TIMEOUT_MS], since this test asserts an absence rather than waiting out a real event,
+     * and a slow negative test is still a real one to keep the suite fast.
+     */
+    private fun assertNoKeyReachesThePlugin(surface: RemoteUiSurface) {
+        runBlocking {
+            val arrived =
+                withTimeoutOrNull(NEGATIVE_WAIT_TIMEOUT_MS) {
+                    surface
+                        .events()
+                        .filter { it.hasKey() }
+                        .take(1)
+                        .toList()
+                }
+            assertNull(arrived, "no Key event should reach a plugin that never declared wants_keys")
+        }
+    }
 
     private fun textFieldTree(): WidgetTree =
         WidgetTree(
@@ -280,5 +334,6 @@ class RemoteSurfaceInputComposeTest {
         const val ROWS = 20
         const val VIEWPORT_DP = 40
         const val WAIT_TIMEOUT_MS = 10_000L
+        const val NEGATIVE_WAIT_TIMEOUT_MS = 500L
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
@@ -145,6 +145,31 @@ class RemoteSurfaceInputComposeTest {
     }
 
     @Test
+    fun `a component attached before registration follows an opted in reconnect`() {
+        val registry = RemoteUiSurfaceRegistry()
+        val panel = RemotePanelComponent(PANEL, "Test Panel", PROCESS, registry)
+        panel.attach()
+        compose.setContent { panel.Content() }
+        val original = registry.accept(PANEL)
+        original.pushTree(textFieldTree())
+        registry.openStream(PANEL, PROCESS)
+        registry.closeStream(original)
+
+        val replacement = registry.accept(PANEL, wantsKeys = true)
+        replacement.pushTree(textFieldTree())
+        registry.openStream(PANEL, PROCESS)
+        compose.waitForIdle()
+        assertUnboundInLiveKeymap()
+        compose.onNode(hasSetTextAction()).requestFocus()
+        compose.onRoot().performKeyInput {
+            withKeyDown(Key.AltLeft) { withKeyDown(Key.ShiftLeft) { pressKey(Key.F7) } }
+        }
+        compose.waitForIdle()
+        assertEquals(AwtKeyEvent.VK_F7, replacement.firstEventWhere { it.hasKey() }.key.keyCode)
+        panel.dispose()
+    }
+
+    @Test
     fun `a key the focused widget consumes never reaches the plugin`() {
         // "The focused widget gets first refusal" is the property that keeps ordinary typing off the
         // wire — a text field consumes its character keys, so a plugin sees one TextChange per edit

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
@@ -148,6 +148,16 @@ class PluginUIServiceBridgeTest {
     }
 
     @Test
+    fun `wire registration preserves key opt in and defaults older registrations closed`() =
+        runBlocking {
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            assertFalse(assertNotNull(registry.surfaceOf(PANEL)).descriptor.wantsKeys)
+            val optedIn = registration(PANEL).toBuilder().setWantsKeys(true).build()
+            assertTrue(plugin.registerUI(optedIn).success)
+            assertTrue(assertNotNull(registry.surfaceOf(PANEL)).descriptor.wantsKeys)
+        }
+
+    @Test
     fun `a widget tree streamed by a plugin reaches the attached host component`() =
         runBlocking {
             val host = RecordingHost()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -242,6 +242,7 @@ class RemoteUiSurfaceRegistryTest {
                 displayName = "Inbox",
                 iconName = "mail",
                 defaultSlot = "left.top.top",
+                wantsKeys = true,
             )
 
         val surface = registry.register(SURFACE, PROCESS, descriptor).accepted()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -43,6 +43,23 @@ class RemoteUiSurfaceRegistryTest {
     private val registry = RemoteUiSurfaceRegistry()
 
     @Test
+    fun `capabilities replay before streaming and reset for absent displaced and closed surfaces`() {
+        val originalHost = RecordingHost()
+        registry.attach(SURFACE, originalHost)
+        assertEquals(listOf(false), originalHost.capabilities)
+
+        val surface = registry.register(SURFACE, PROCESS, RemoteUiSurfaceDescriptor(wantsKeys = true)).accepted()
+        val replacementHost = RecordingHost()
+        registry.attach(SURFACE, replacementHost)
+        assertEquals(listOf(false, false), originalHost.capabilities, "displacement resets the old host")
+        assertEquals(listOf(true), replacementHost.capabilities, "replay grants before a stream exists")
+
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE, PROCESS))
+        registry.closeStream(surface)
+        assertEquals(listOf(true, true, false), replacementHost.capabilities, "closing revokes the tap")
+    }
+
+    @Test
     fun `unregister and kernel reset retain ownership while old host compositions can remain`() {
         registry.register(SURFACE, PROCESS).accepted()
         registry.unregister(SURFACE)
@@ -556,6 +573,11 @@ class RemoteUiSurfaceRegistryTest {
     private class RecordingHost : RemoteUiSurfaceHost {
         val trees = CopyOnWriteArrayList<WidgetTree>()
         val connections = CopyOnWriteArrayList<Boolean>()
+        val capabilities = CopyOnWriteArrayList<Boolean>()
+
+        override fun onKeyCapabilityChanged(wantsKeys: Boolean) {
+            capabilities += wantsKeys
+        }
 
         override fun onTreeUpdated(tree: WidgetTree) {
             trees += tree

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -407,10 +407,12 @@ Common issues:
 - **Conflicts**: Settings UI shows visual warnings for conflicting shortcuts
 - **Focus mode**: Settings window and shortcuts work in focus mode (fixed in Issue #74)
 
-## Remote plugin surfaces are keystroke sinks while focused
+## Remote plugin surfaces declare raw key delivery
 
 A remote (out-of-process) plugin surface taps keys the host did not claim and forwards them to the
-plugin as `UIEvent.key`. Three things bound that, and one thing does not:
+plugin as `UIEvent.key` only when its registration declares `wants_keys = true`.
+Omitted or false declarations disable the tap and reject key events at the outgoing queue,
+including while a renderer still holds state from a previous registration. Three routing rules apply:
 
 - **The host keymap wins.** `AWTKeyboardInterceptor` runs at the `KeyboardFocusManager`, upstream of
   Compose, and consumes what it dispatches - so a bound shortcut never reaches a plugin surface. The
@@ -424,9 +426,11 @@ plugin as `UIEvent.key`. Three things bound that, and one thing does not:
 - **The tap never consumes.** It always returns `false`, so a plugin cannot swallow a shortcut or trap
   the user in a panel.
 
-**What is not bounded is which plugin may listen.** `Modifier.forwardUnclaimedKeys` ends in
-`.focusable()`, so a remote surface is a focus target in its own right - a surface made only of labels
-can still take focus and receive every unclaimed key-down, including plain typing when no widget inside
-it holds focus. There is no plugin capability model gating that today. The intended fix is a declared
-opt-in (a `wants_keys` flag on `UIRegistration`), which makes both the focus stop and the tap something
-a plugin asks for; it needs the same per-connection plugin identity as attributing `UnregisterUI`.
+The surface root is never a focus target of its own, even with `wants_keys = true`; an interactive
+child must hold focus. Text changes, clicks, scrolls and lifecycle events do not require this flag.
+
+The field is additive on the wire but changes behavior for older plugins: an omitted declaration
+now disables previously implicit raw key delivery. Plugin authors who need it must opt in.
+This is a declaration, not user consent: there is no prompt or user-managed permission, and a
+plugin can declare the flag itself. The existing authenticated process identity still determines
+which process may register and stream the surface.

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -76,15 +76,12 @@ message UIRegistration {
   // For panels: default slot position
   string default_slot = 7;     // e.g., "left.top.top", "right.top.bottom"
 
-  // Whether this surface may receive KeyEvent (unclaimed keys - see KeyEvent's own doc for what
-  // "unclaimed" means). False (the default, and every existing plugin's unset value) means the
-  // surface never becomes a focus target of its own and never receives one, matching the behavior
-  // every remote surface had before this field existed - additive, not a behavior change for a
-  // plugin built against an older host. A plugin whose widget tree has no interactive content and
-  // no reason to see raw key presses should leave this false even if it could set it: fewer
-  // capabilities declared is less for a reviewer, and a future host security prompt, to reason
-  // about. See KeyEvent and the host's Modifier.forwardUnclaimedKeys for the full policy this
-  // gates.
+  // Opt in to unclaimed KeyEvent delivery while an interactive child holds focus.
+  // False by default, including registrations from older plugins that omit this field.
+  // This is wire-compatible but changes behavior: older plugins must opt in to retain raw
+  // key delivery. Neither value makes the surface root a focus target. Widget events such as
+  // TextChange still work without this flag. This is a plugin declaration, not user consent;
+  // it does not add a permission prompt or protect against a plugin deliberately opting in.
   bool wants_keys = 8;
 }
 

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -75,6 +75,17 @@ message UIRegistration {
   WidgetTree initial_tree = 6;
   // For panels: default slot position
   string default_slot = 7;     // e.g., "left.top.top", "right.top.bottom"
+
+  // Whether this surface may receive KeyEvent (unclaimed keys - see KeyEvent's own doc for what
+  // "unclaimed" means). False (the default, and every existing plugin's unset value) means the
+  // surface never becomes a focus target of its own and never receives one, matching the behavior
+  // every remote surface had before this field existed - additive, not a behavior change for a
+  // plugin built against an older host. A plugin whose widget tree has no interactive content and
+  // no reason to see raw key presses should leave this false even if it could set it: fewer
+  // capabilities declared is less for a reviewer, and a future host security prompt, to reason
+  // about. See KeyEvent and the host's Modifier.forwardUnclaimedKeys for the full policy this
+  // gates.
+  bool wants_keys = 8;
 }
 
 message UIRegistrationResponse {


### PR DESCRIPTION
A focused remote plugin previously received unclaimed raw keys implicitly. Its UIRegistration must now declare `wants_keys = true`; omitted/false declarations disable forwarding. Text changes, clicks, scroll and lifecycle events still work, and the surface root does not become an extra focus target.

The renderer omits the key tap when the capability is false. The receiving surface also checks its immutable descriptor before enqueueing a key, covering same-owner re-registration while an existing composition still holds the old capability.

The protobuf field is additive and defaults false. This is wire-compatible but changes behavior for older plugins that previously received raw keys implicitly: they must opt in. The flag is a plugin declaration, not a user consent prompt.

### Contributor provenance

- @Antriksh1984 supplied the original additive protocol field, registration/descriptor/renderer wiring, and initial positive/negative Compose tests in `88eb512f0`.
- Review-agent follow-up by @kshivang integrated current dev, added the receiving-queue guard for stale compositions, a same-owner replacement Compose regression and real gRPC default/true registration test, corrected compatibility/security documentation, and replaced callback registry reads with direct capability delivery in `261bee2ef` and `23abda55e`. Added reconnect coverage in the latter commit. These repairs are separate from the original contribution.
- Earlier identity/placement work from #348 is already merged via #430 and is prerequisite provenance, not new work in this PR. No consolidation or closure is needed.

### Validation and review

Current head: 2fd22e6882d65e4603c2f6db0534f35645c0943a. The last commit corrects KDoc and adds direct capability callback coverage; production behavior is unchanged from 23abda55e.

- Final-head local validation passed: 37 registry tests, zero failures/errors/skips, plus repository-wide ktlintCheck and detekt under the shared build lock.
- [Claude current-head review](https://github.com/risa-labs-inc/BossConsole/pull/441#issuecomment-5610035760) found no further actionable correctness/regression issue. This follows the [23abda55e review](https://github.com/risa-labs-inc/BossConsole/pull/441#issuecomment-5609961725); its documentation/test suggestions are addressed in 2fd22e688.
- Previous behavior-identical head passed all nine CI checks; downloaded Ubuntu/Windows/macOS XML confirms 169 selected remote-UI/IPC tests passed on each with no skips/failures/errors. All nine current-head CI checks pass in [run 34416088167](https://github.com/risa-labs-inc/BossConsole/actions/runs/34416088167), including all three platforms, quality and aggregate summary. Final-head macOS XML confirms 170 selected remote-UI/IPC tests with no skips/failures/errors.
- External runtime helper/version-negotiation rollout is a separate follow-up, not included in this PR. No app instance was launched/stopped or live database migration applied.

### Operator checks pending

- With a remote text field/button focused, omitted/false declaration must send no raw key for unbound Alt+Shift+F7; true must send the intact payload.
- Text edits/clicks/scroll still work with false; host shortcuts still work with true; labels-only surfaces add no Tab stop.
- Re-register/reconnect with true to false and false to true and verify the new declaration is enforced.

Prepared against dev with current-head review and automated checks complete. Operator checks above remain pending. Do not merge or enable auto-merge as part of this review.
