### PR TITLE
fix(chromium): validate macOS framework version before startup

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
@@ -185,20 +185,27 @@ object ChromiumAutoDownloader {
         executableNameFile: java.io.File,
         requiredChromium: String,
         installedVersion: String,
-        isMacOverride: Boolean? = null
+        isMacOverride: Boolean? = null,
     ): Boolean {
-        val isMac = isMacOverride ?: System.getProperty("os.name").orEmpty().lowercase().contains("mac")
+        val isMac =
+            isMacOverride ?: System
+                .getProperty("os.name")
+                .orEmpty()
+                .lowercase()
+                .contains("mac")
         if (!isMac) return false
         val execName = executableNameFile.readText().trim()
 
         var isMismatch = false
         if (execName.isNotEmpty()) {
-            val versionsDir = dir.resolve("$execName.app")
-                .resolve("Contents")
-                .resolve("Frameworks")
-                .resolve("Chromium Framework.framework")
-                .resolve("Versions")
-                .toFile()
+            val versionsDir =
+                dir
+                    .resolve("$execName.app")
+                    .resolve("Contents")
+                    .resolve("Frameworks")
+                    .resolve("Chromium Framework.framework")
+                    .resolve("Versions")
+                    .toFile()
 
             if (versionsDir.exists() && !versionsDir.resolve(requiredChromium).isDirectory) {
                 logger.info(
@@ -206,8 +213,8 @@ object ChromiumAutoDownloader {
                     "Chromium build mismatch",
                     mapOf(
                         "required" to requiredChromium,
-                        "installed_engine" to installedVersion
-                    )
+                        "installed_engine" to installedVersion,
+                    ),
                 )
                 isMismatch = true
             }
@@ -241,13 +248,15 @@ object ChromiumAutoDownloader {
                 "Chromium version mismatch",
                 mapOf(
                     "expected" to effectiveVersion,
-                    "installed" to installedVersion
-                )
+                    "installed" to installedVersion,
+                ),
             )
             return false
         }
 
-        val requiredChromium = com.teamdev.jxbrowser.VersionInfo.chromiumVersion()
+        val requiredChromium =
+            com.teamdev.jxbrowser.VersionInfo
+                .chromiumVersion()
         if (isMacFrameworkMismatch(dir, executableNameFile, requiredChromium, installedVersion)) {
             return false
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
@@ -180,6 +180,41 @@ object ChromiumAutoDownloader {
         }
     }
 
+    internal fun isMacFrameworkMismatch(
+        dir: java.nio.file.Path,
+        executableNameFile: java.io.File,
+        requiredChromium: String,
+        installedVersion: String,
+        isMacOverride: Boolean? = null
+    ): Boolean {
+        val isMac = isMacOverride ?: System.getProperty("os.name").orEmpty().lowercase().contains("mac")
+        if (!isMac) return false
+        val execName = executableNameFile.readText().trim()
+
+        var isMismatch = false
+        if (execName.isNotEmpty()) {
+            val versionsDir = dir.resolve("$execName.app")
+                .resolve("Contents")
+                .resolve("Frameworks")
+                .resolve("Chromium Framework.framework")
+                .resolve("Versions")
+                .toFile()
+
+            if (versionsDir.exists() && !versionsDir.resolve(requiredChromium).isDirectory) {
+                logger.info(
+                    LogCategory.BROWSER,
+                    "Chromium build mismatch",
+                    mapOf(
+                        "required" to requiredChromium,
+                        "installed_engine" to installedVersion
+                    )
+                )
+                isMismatch = true
+            }
+        }
+        return isMismatch
+    }
+
     /**
      * Check if Chromium is already installed, valid, and matches the effective
      * engine version (Settings pin, else the bundled JxBrowser version).
@@ -205,10 +240,15 @@ object ChromiumAutoDownloader {
                 LogCategory.BROWSER,
                 "Chromium version mismatch",
                 mapOf(
-                    "installed" to installedVersion,
-                    "required" to effectiveVersion,
-                ),
+                    "expected" to effectiveVersion,
+                    "installed" to installedVersion
+                )
             )
+            return false
+        }
+
+        val requiredChromium = com.teamdev.jxbrowser.VersionInfo.chromiumVersion()
+        if (isMacFrameworkMismatch(dir, executableNameFile, requiredChromium, installedVersion)) {
             return false
         }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumAutoDownloaderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumAutoDownloaderTest.kt
@@ -261,17 +261,18 @@ class ChromiumAutoDownloaderTest {
                 executableNameFile = File(target, "executable.name"),
                 requiredChromium = "151.0.7922.72",
                 installedVersion = "9.4.0",
-                isMacOverride = false
-            )
+                isMacOverride = false,
+            ),
         )
     }
 
     @Test
     fun `isMacFrameworkMismatch returns true when framework exists but required version is missing`() {
-        val execFile = File(target, "executable.name").apply {
-            parentFile.mkdirs()
-            writeText("BOSS")
-        }
+        val execFile =
+            File(target, "executable.name").apply {
+                parentFile.mkdirs()
+                writeText("BOSS")
+            }
 
         // Setup the framework directory with a DIFFERENT version than required
         val versionsDir = File(target, "BOSS.app/Contents/Frameworks/Chromium Framework.framework/Versions")
@@ -284,18 +285,19 @@ class ChromiumAutoDownloaderTest {
                 executableNameFile = execFile,
                 requiredChromium = "151.0.7922.72",
                 installedVersion = "pinned-version",
-                isMacOverride = true
+                isMacOverride = true,
             ),
-            "Should reject when framework exists but required version is absent"
+            "Should reject when framework exists but required version is absent",
         )
     }
 
     @Test
     fun `isMacFrameworkMismatch returns false when required framework version exists`() {
-        val execFile = File(target, "executable.name").apply {
-            parentFile.mkdirs()
-            writeText("BOSS")
-        }
+        val execFile =
+            File(target, "executable.name").apply {
+                parentFile.mkdirs()
+                writeText("BOSS")
+            }
 
         val requiredChromium = "151.0.7922.72"
         val versionsDir = File(target, "BOSS.app/Contents/Frameworks/Chromium Framework.framework/Versions")
@@ -308,9 +310,9 @@ class ChromiumAutoDownloaderTest {
                 executableNameFile = execFile,
                 requiredChromium = requiredChromium,
                 installedVersion = "9.4.0",
-                isMacOverride = true
+                isMacOverride = true,
             ),
-            "Should accept when the required version directory exists"
+            "Should accept when the required version directory exists",
         )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumAutoDownloaderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumAutoDownloaderTest.kt
@@ -250,4 +250,67 @@ class ChromiumAutoDownloaderTest {
             assertEquals("network down", reportedError)
             assertFalse(File(target, "version.txt").exists())
         }
+
+    // ---- isMacFrameworkMismatch: preflight rejection of broken pins ----
+
+    @Test
+    fun `isMacFrameworkMismatch returns false on non-macOS platforms`() {
+        assertFalse(
+            ChromiumAutoDownloader.isMacFrameworkMismatch(
+                dir = target.toPath(),
+                executableNameFile = File(target, "executable.name"),
+                requiredChromium = "151.0.7922.72",
+                installedVersion = "9.4.0",
+                isMacOverride = false
+            )
+        )
+    }
+
+    @Test
+    fun `isMacFrameworkMismatch returns true when framework exists but required version is missing`() {
+        val execFile = File(target, "executable.name").apply {
+            parentFile.mkdirs()
+            writeText("BOSS")
+        }
+
+        // Setup the framework directory with a DIFFERENT version than required
+        val versionsDir = File(target, "BOSS.app/Contents/Frameworks/Chromium Framework.framework/Versions")
+        versionsDir.mkdirs()
+        File(versionsDir, "150.0.7871.47").mkdirs() // Not the required one
+
+        assertTrue(
+            ChromiumAutoDownloader.isMacFrameworkMismatch(
+                dir = target.toPath(),
+                executableNameFile = execFile,
+                requiredChromium = "151.0.7922.72",
+                installedVersion = "pinned-version",
+                isMacOverride = true
+            ),
+            "Should reject when framework exists but required version is absent"
+        )
+    }
+
+    @Test
+    fun `isMacFrameworkMismatch returns false when required framework version exists`() {
+        val execFile = File(target, "executable.name").apply {
+            parentFile.mkdirs()
+            writeText("BOSS")
+        }
+
+        val requiredChromium = "151.0.7922.72"
+        val versionsDir = File(target, "BOSS.app/Contents/Frameworks/Chromium Framework.framework/Versions")
+        versionsDir.mkdirs()
+        File(versionsDir, requiredChromium).mkdirs() // The required one exists
+
+        assertFalse(
+            ChromiumAutoDownloader.isMacFrameworkMismatch(
+                dir = target.toPath(),
+                executableNameFile = execFile,
+                requiredChromium = requiredChromium,
+                installedVersion = "9.4.0",
+                isMacOverride = true
+            ),
+            "Should accept when the required version directory exists"
+        )
+    }
 }


### PR DESCRIPTION
Issue #118 is still open and currently reproducible.

`isChromiumInstalled()` previously trusted `version.txt` without validating the bundled macOS Chromium Framework version. A pinned engine can therefore pass preflight while JxBrowser later crashes with `UnsatisfiedLinkError`.

The fix adds a macOS-only preflight validation against `VersionInfo.chromiumVersion()`. A mismatch now fails the installation check and lets the existing recovery/download flow handle it safely before startup.

Three deterministic unit tests cover non-macOS behavior, missing required framework version, and valid required framework version.

Validation completed: focused desktop tests, ktlint, detekt for changed files, and `git diff --check`.

Fixes #118