### PR TITLE
refactor(plugins): split two self-contained pieces out of PluginStoreSetup.kt (#447)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -480,9 +480,9 @@ val downloadBundledPlugins =
                     // contains `boss-plugin-fluck-browser-1.2.24-thin.jar`,
                     // 1 MB of a 4 MB plugin, missing everything it needs to run.
                     //
-                    // This is exactly PluginStoreSetup.pickPluginJarUrl, which
+                    // This is exactly PluginVersionComparator.pickPluginJarUrl, which
                     // the host uses for the same decision and which
-                    // PluginStoreSetupMinVersionGateTest already guards against
+                    // PluginVersionComparatorTest already guards against
                     // picking a thin JAR. The two pickers must not disagree.
                     val jarUrl =
                         Regex(""""browser_download_url"\s*:\s*"([^"]+${Regex.escape(artifactPrefix)}[^"]*\.jar)"""")

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -1158,11 +1158,11 @@
     <ID>ReturnCount:PluginInstallService.kt$PluginInstallService$private fun downloadFromGitHubRelease( owner: String, repo: String, pluginDir: File, ): String?</ID>
     <ID>ReturnCount:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl$private fun isMicrokernelRuntimeJar(jarPath: String): Boolean</ID>
     <ID>ReturnCount:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl$private suspend fun doReloadPlugin(pluginId: String): LoadedPluginInfo?</ID>
-    <ID>ReturnCount:PluginStoreSetup.kt$PluginStoreSetup$internal fun isNewerVersion( version1: String, version2: String, ): Boolean</ID>
     <ID>ReturnCount:PluginStoreSetup.kt$PluginStoreSetup$private fun copyBundledPluginsToPluginDir(dynamicPluginManager: ai.rever.boss.components.plugin.DynamicPluginManager)</ID>
     <ID>ReturnCount:PluginStoreVersionBridge.kt$PluginStoreVersionBridge$actual suspend fun lookup(pluginId: String): StoreVersionLookup</ID>
     <ID>ReturnCount:PluginUpdateBridge.kt$PluginUpdateBridge$actual suspend fun performUpdate( pluginId: String, manager: DynamicPluginManager, ): Result&lt;String&gt;</ID>
     <ID>ReturnCount:PluginUpdateBridge.kt$PluginUpdateBridge$actual suspend fun refreshAll(installed: List&lt;InstalledPluginRef&gt;)</ID>
+    <ID>ReturnCount:PluginVersionComparator.kt$PluginVersionComparator$fun isNewerVersion( version1: String, version2: String, ): Boolean</ID>
     <ID>ReturnCount:RoleService.kt$RoleService$suspend fun canPerformAction( userId: String, permissionName: String, ): Result&lt;Boolean&gt;</ID>
     <ID>ReturnCount:SecretModels.kt$CreateSecretRequest$fun validate(): Result&lt;Unit&gt;</ID>
     <ID>ReturnCount:SecretModels.kt$ShareSecretRequest$fun validate(): Result&lt;Unit&gt;</ID>

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -1698,10 +1698,9 @@ object PluginStoreSetup {
                     val existingJar = File(existingPlugin.jarPath)
                     if (existingJar.exists()) {
                         val existingManifest = readPluginManifest(existingJar)
-                        val bundledIsNotNewer =
-                            existingManifest != null &&
-                                !PluginVersionComparator.isNewerVersion(bundledVersion, existingManifest.version)
-                        if (existingManifest != null && bundledIsNotNewer) {
+                        if (existingManifest != null &&
+                            !PluginVersionComparator.isNewerVersion(bundledVersion, existingManifest.version)
+                        ) {
                             logger.info(
                                 LogCategory.SYSTEM,
                                 "Bundled plugin already installed with same/newer version - skipping",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -26,13 +26,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.net.URL
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Information about a system plugin that should always be installed.
@@ -502,7 +498,10 @@ object PluginStoreSetup {
                     if (installedIds.contains(systemPlugin.pluginId) && jarExists) {
                         val jarFile = File(existingEntry.jarPath)
                         val installedVersion =
-                            extractVersionFromJarFileName(jarFile.name, systemPlugin.artifactPrefix)
+                            PluginVersionComparator.extractVersionFromJarFileName(
+                                jarFile.name,
+                                systemPlugin.artifactPrefix,
+                            )
                                 ?: runCatching { readPluginManifest(jarFile)?.version }.getOrNull()
                         // Installed JAR is older than this host requires (or its
                         // version is unreadable, which only very old JARs are):
@@ -510,7 +509,8 @@ object PluginStoreSetup {
                         // contract-breaking version is never loaded. If the
                         // download fails (offline), the old JAR still loads and
                         // the update is retried next launch.
-                        val tooOldForHost = isTooOldForHost(installedVersion, systemPlugin.minVersion)
+                        val tooOldForHost =
+                            PluginVersionComparator.isTooOldForHost(installedVersion, systemPlugin.minVersion)
                         if (!tooOldForHost) {
                             // Plugin is on disk — proceed with startup using the
                             // current JAR. Kick off a background update check so
@@ -627,7 +627,7 @@ object PluginStoreSetup {
                 // every startup even though the fallback handles it. Manifest
                 // read is therefore only used when the filename lacks a version.
                 val installedVersion =
-                    extractVersionFromJarFileName(existingJar.name, systemPlugin.artifactPrefix)
+                    PluginVersionComparator.extractVersionFromJarFileName(existingJar.name, systemPlugin.artifactPrefix)
                         ?: runCatching { readPluginManifest(existingJar)?.version }.getOrNull()
                 val latestVersion = fetchLatestReleaseVersion(systemPlugin.githubRepo)
                 when {
@@ -665,7 +665,7 @@ object PluginStoreSetup {
                         )
                     }
 
-                    !isNewerVersion(latestVersion, installedVersion) -> {
+                    !PluginVersionComparator.isNewerVersion(latestVersion, installedVersion) -> {
                         // Installed version is NEWER than the latest published release —
                         // e.g. a local dev build ahead of the store. Do NOT downgrade:
                         // a download-only runtime update removes older versions, while a
@@ -798,24 +798,6 @@ object PluginStoreSetup {
                 connection?.disconnect()
             }
         }
-    }
-
-    /**
-     * Extract the semver component from a plugin JAR filename.
-     * Handles the `{prefix}-{version}.jar` and `{prefix}-{version}-all.jar`
-     * patterns produced by Gradle. Returns null if the filename doesn't match.
-     */
-    internal fun extractVersionFromJarFileName(
-        fileName: String,
-        artifactPrefix: String,
-    ): String? {
-        val withoutPrefix = fileName.removePrefix("$artifactPrefix-")
-        if (withoutPrefix == fileName) return null
-        val version =
-            withoutPrefix
-                .removeSuffix(".jar")
-                .removeSuffix("-all")
-        return version.takeIf { it.matches(Regex("""\d+\.\d+\.\d+(?:[-+.][A-Za-z0-9.]+)*""")) }
     }
 
     /**
@@ -1136,7 +1118,10 @@ object PluginStoreSetup {
                 // contract-breaking JAR the gate exists to prevent. Keep
                 // whatever is on disk and retry next launch instead.
                 val requiredMin = plugin.minVersion
-                if (requiredMin != null && isTooOldForHost(tagName.removePrefix("v"), requiredMin)) {
+                val tooOldRelease =
+                    requiredMin != null &&
+                        PluginVersionComparator.isTooOldForHost(tagName.removePrefix("v"), requiredMin)
+                if (tooOldRelease) {
                     logger.error(
                         LogCategory.SYSTEM,
                         "Latest GitHub release is older than this host requires - not installing",
@@ -1152,7 +1137,7 @@ object PluginStoreSetup {
 
                 // Find the JAR download URL (skips "-thin.jar" assets — see
                 // pickPluginJarUrl).
-                val jarUrl = pickPluginJarUrl(responseText, plugin.artifactPrefix)
+                val jarUrl = PluginVersionComparator.pickPluginJarUrl(responseText, plugin.artifactPrefix)
 
                 if (jarUrl == null) {
                     logger.warn(
@@ -1679,10 +1664,12 @@ object PluginStoreSetup {
                     val existingManifest = readPluginManifest(existingJar)
                     if (existingManifest != null) {
                         val existingVersion = existingManifest.version
-                        if (highestExistingVersion == null || isNewerVersion(existingVersion, highestExistingVersion)) {
+                        if (highestExistingVersion == null ||
+                            PluginVersionComparator.isNewerVersion(existingVersion, highestExistingVersion)
+                        ) {
                             highestExistingVersion = existingVersion
                         }
-                        if (!isNewerVersion(bundledVersion, existingVersion)) {
+                        if (!PluginVersionComparator.isNewerVersion(bundledVersion, existingVersion)) {
                             logger.info(
                                 LogCategory.SYSTEM,
                                 "Found existing JAR with same/newer version - skipping",
@@ -1708,7 +1695,10 @@ object PluginStoreSetup {
                     val existingJar = File(existingPlugin.jarPath)
                     if (existingJar.exists()) {
                         val existingManifest = readPluginManifest(existingJar)
-                        if (existingManifest != null && !isNewerVersion(bundledVersion, existingManifest.version)) {
+                        val bundledIsNotNewer =
+                            existingManifest != null &&
+                                !PluginVersionComparator.isNewerVersion(bundledVersion, existingManifest.version)
+                        if (existingManifest != null && bundledIsNotNewer) {
                             logger.info(
                                 LogCategory.SYSTEM,
                                 "Bundled plugin already installed with same/newer version - skipping",
@@ -1912,178 +1902,5 @@ object PluginStoreSetup {
             )
             null
         }
-    }
-
-    /**
-     * Check if version1 is newer than version2.
-     *
-     * Numeric major.minor.patch comparison; a segment's non-numeric suffix
-     * counts only as its numeric prefix ("0-rc1" -> 0). On a numeric tie, a
-     * version WITH a pre-release suffix is OLDER than one without
-     * (1.4.0-rc1 < 1.4.0) — this comparator gates whether a system plugin
-     * satisfies the host's [SystemPluginInfo.minVersion], and a pre-release
-     * must not pass for its release. Internal for test access.
-     */
-    internal fun isNewerVersion(
-        version1: String,
-        version2: String,
-    ): Boolean {
-        fun numericParts(v: String) = v.split(".").map { seg -> seg.takeWhile { it.isDigit() }.toIntOrNull() ?: 0 }
-
-        fun hasPreReleaseSuffix(v: String) = v.split(".").any { seg -> seg.any { !it.isDigit() } }
-
-        val v1Parts = numericParts(version1)
-        val v2Parts = numericParts(version2)
-
-        for (i in 0 until maxOf(v1Parts.size, v2Parts.size)) {
-            val v1 = v1Parts.getOrElse(i) { 0 }
-            val v2 = v2Parts.getOrElse(i) { 0 }
-            if (v1 > v2) return true
-            if (v1 < v2) return false
-        }
-        // Numeric tie: a release is newer than its own pre-release.
-        return hasPreReleaseSuffix(version2) && !hasPreReleaseSuffix(version1)
-    }
-
-    /**
-     * True when the host mandates a minimum plugin version and the installed
-     * version is below it — or can't be determined at all (only very old JARs
-     * lack a readable version). Internal for test access.
-     */
-    internal fun isTooOldForHost(
-        installedVersion: String?,
-        minVersion: String?,
-    ): Boolean {
-        if (minVersion == null) return false
-        return installedVersion == null || isNewerVersion(minVersion, installedVersion)
-    }
-
-    /**
-     * Pick the plugin JAR asset URL from a GitHub release JSON payload.
-     * Skips "-thin.jar" assets — a module's default :jar output, missing
-     * everything buildPluginJar bundles (editor-tab's BossEditor,
-     * fluck-browser's tunnel deps, …) — which GitHub can list first.
-     * Internal for test access.
-     */
-    internal fun pickPluginJarUrl(
-        releaseJson: String,
-        artifactPrefix: String,
-    ): String? =
-        Regex(""""browser_download_url"\s*:\s*"([^"]+${Regex.escape(artifactPrefix)}[^"]*\.jar)"""")
-            .findAll(releaseJson)
-            .map { it.groupValues[1] }
-            .firstOrNull { !it.endsWith("-thin.jar") }
-}
-
-/**
- * Coordinates authenticated signature backfill for installed system-plugin JARs.
- * Authentication avoids the store permission gate; update completion wakes deferred JARs.
- * Each completed attempt is counted even when unsigned: getDownloadUrl records a download,
- * so ordinary failures must not create a retry loop. A signature-only store route would
- * remove that cost (see #108). Cancellation and lost authentication may retry.
- * The supplied scope must dispatch file probes and persistence onto an I/O dispatcher.
- */
-internal class SidecarBackfillCoordinator(
-    private val scope: CoroutineScope,
-    private val sidecarExists: (File) -> Boolean,
-    private val updateInFlight: (String) -> Boolean,
-    private val persist: suspend (File) -> Unit,
-) {
-    private data class JarStamp(
-        val path: String,
-        val length: Long,
-        val modifiedAt: Long,
-    )
-
-    private data class PendingJar(
-        val pluginId: String,
-        val jarFile: File,
-        val stamp: JarStamp,
-    )
-
-    private data class AttemptKey(
-        val pluginId: String,
-        val stamp: JarStamp,
-    )
-
-    private val pending = ConcurrentHashMap<String, PendingJar>()
-    private val attempted = ConcurrentHashMap.newKeySet<AttemptKey>()
-    private val drainMutex = Mutex()
-    private val authenticationLosses = AtomicLong()
-
-    @Volatile
-    private var authenticated = false
-
-    fun setAuthenticated(available: Boolean) {
-        if (!available) authenticationLosses.incrementAndGet()
-        authenticated = available
-        if (available) requestDrain()
-    }
-
-    fun enqueue(
-        pluginId: String,
-        jarFile: File,
-    ) {
-        if (sidecarExists(jarFile)) return
-        val stamp = stampOf(jarFile) ?: return
-        pending[pluginId] = PendingJar(pluginId, jarFile, stamp)
-        requestDrain()
-    }
-
-    fun onUpdateCheckCompleted(pluginId: String) {
-        if (pending.containsKey(pluginId)) requestDrain()
-    }
-
-    private fun requestDrain() {
-        if (!authenticated) return
-        scope.launch {
-            drainMutex.withLock { drainOnce() }
-        }
-    }
-
-    private suspend fun drainOnce() {
-        if (!authenticated) return
-
-        pending.entries.toList().forEach { (_, entry) ->
-            if (!authenticated) return
-            if (!isCurrentAndUnsigned(entry)) {
-                pending.remove(entry.pluginId, entry)
-                return@forEach
-            }
-            if (updateInFlight(entry.pluginId)) return@forEach
-
-            val attemptKey = AttemptKey(entry.pluginId, entry.stamp)
-            if (!attempted.add(attemptKey)) {
-                pending.remove(entry.pluginId, entry)
-                return@forEach
-            }
-            if (!pending.remove(entry.pluginId, entry)) return@forEach
-
-            val authenticationGeneration = authenticationLosses.get()
-            try {
-                persist(entry.jarFile)
-                val lostAuthentication = !authenticated || authenticationGeneration != authenticationLosses.get()
-                if (lostAuthentication && !sidecarExists(entry.jarFile)) {
-                    attempted.remove(attemptKey)
-                    pending.putIfAbsent(entry.pluginId, entry)
-                }
-            } catch (cancelled: kotlinx.coroutines.CancellationException) {
-                attempted.remove(attemptKey)
-                pending.putIfAbsent(entry.pluginId, entry)
-                throw cancelled
-            } catch (_: Exception) {
-                // Unexpected failures also consume the attempt, preventing wakeup-driven retries.
-            }
-        }
-    }
-
-    private fun isCurrentAndUnsigned(entry: PendingJar): Boolean {
-        val currentStamp = stampOf(entry.jarFile)
-        return currentStamp == entry.stamp && !sidecarExists(entry.jarFile)
-    }
-
-    private fun stampOf(jarFile: File): JarStamp? {
-        if (!jarFile.exists()) return null
-        return JarStamp(jarFile.absolutePath, jarFile.length(), jarFile.lastModified())
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginVersionComparator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginVersionComparator.kt
@@ -1,0 +1,87 @@
+package ai.rever.boss.plugin
+
+/**
+ * Pure version/asset-selection helpers used to decide whether a system plugin JAR
+ * needs installing or updating. Split out of [PluginStoreSetup] (BossConsole#447
+ * step 6): each function is stateless and was already `internal` for test access,
+ * so extracting them changes nothing about behavior - only where the logic lives.
+ */
+internal object PluginVersionComparator {
+    /**
+     * Check if version1 is newer than version2.
+     *
+     * Numeric major.minor.patch comparison; a segment's non-numeric suffix
+     * counts only as its numeric prefix ("0-rc1" -> 0). On a numeric tie, a
+     * version WITH a pre-release suffix is OLDER than one without
+     * (1.4.0-rc1 < 1.4.0) — this comparator gates whether a system plugin
+     * satisfies the host's [SystemPluginInfo.minVersion], and a pre-release
+     * must not pass for its release. Internal for test access.
+     */
+    fun isNewerVersion(
+        version1: String,
+        version2: String,
+    ): Boolean {
+        fun numericParts(v: String) = v.split(".").map { seg -> seg.takeWhile { it.isDigit() }.toIntOrNull() ?: 0 }
+
+        fun hasPreReleaseSuffix(v: String) = v.split(".").any { seg -> seg.any { !it.isDigit() } }
+
+        val v1Parts = numericParts(version1)
+        val v2Parts = numericParts(version2)
+
+        for (i in 0 until maxOf(v1Parts.size, v2Parts.size)) {
+            val v1 = v1Parts.getOrElse(i) { 0 }
+            val v2 = v2Parts.getOrElse(i) { 0 }
+            if (v1 > v2) return true
+            if (v1 < v2) return false
+        }
+        // Numeric tie: a release is newer than its own pre-release.
+        return hasPreReleaseSuffix(version2) && !hasPreReleaseSuffix(version1)
+    }
+
+    /**
+     * True when the host mandates a minimum plugin version and the installed
+     * version is below it — or can't be determined at all (only very old JARs
+     * lack a readable version). Internal for test access.
+     */
+    fun isTooOldForHost(
+        installedVersion: String?,
+        minVersion: String?,
+    ): Boolean {
+        if (minVersion == null) return false
+        return installedVersion == null || isNewerVersion(minVersion, installedVersion)
+    }
+
+    /**
+     * Pick the plugin JAR asset URL from a GitHub release JSON payload.
+     * Skips "-thin.jar" assets — a module's default :jar output, missing
+     * everything buildPluginJar bundles (editor-tab's BossEditor,
+     * fluck-browser's tunnel deps, …) — which GitHub can list first.
+     * Internal for test access.
+     */
+    fun pickPluginJarUrl(
+        releaseJson: String,
+        artifactPrefix: String,
+    ): String? =
+        Regex(""""browser_download_url"\s*:\s*"([^"]+${Regex.escape(artifactPrefix)}[^"]*\.jar)"""")
+            .findAll(releaseJson)
+            .map { it.groupValues[1] }
+            .firstOrNull { !it.endsWith("-thin.jar") }
+
+    /**
+     * Extract the semver component from a plugin JAR filename.
+     * Handles the `{prefix}-{version}.jar` and `{prefix}-{version}-all.jar`
+     * patterns produced by Gradle. Returns null if the filename doesn't match.
+     */
+    fun extractVersionFromJarFileName(
+        fileName: String,
+        artifactPrefix: String,
+    ): String? {
+        val withoutPrefix = fileName.removePrefix("$artifactPrefix-")
+        if (withoutPrefix == fileName) return null
+        val version =
+            withoutPrefix
+                .removeSuffix(".jar")
+                .removeSuffix("-all")
+        return version.takeIf { it.matches(Regex("""\d+\.\d+\.\d+(?:[-+.][A-Za-z0-9.]+)*""")) }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/SidecarBackfillCoordinator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/SidecarBackfillCoordinator.kt
@@ -1,0 +1,127 @@
+package ai.rever.boss.plugin
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Coordinates authenticated signature backfill for installed system-plugin JARs.
+ * Authentication avoids the store permission gate; update completion wakes deferred JARs.
+ * Each completed attempt is counted even when unsigned: getDownloadUrl records a download,
+ * so ordinary failures must not create a retry loop. A signature-only store route would
+ * remove that cost (see #108). Cancellation and lost authentication may retry.
+ * The supplied scope must dispatch file probes and persistence onto an I/O dispatcher.
+ *
+ * Split out of [PluginStoreSetup] (BossConsole#447 step 7): already a standalone class
+ * with its own state and lifecycle, driven entirely by the constructor lambdas below -
+ * being nested at the bottom of a 2,000-line file was purely accidental. Same package as
+ * before, so no caller or test needed to change.
+ */
+internal class SidecarBackfillCoordinator(
+    private val scope: CoroutineScope,
+    private val sidecarExists: (File) -> Boolean,
+    private val updateInFlight: (String) -> Boolean,
+    private val persist: suspend (File) -> Unit,
+) {
+    private data class JarStamp(
+        val path: String,
+        val length: Long,
+        val modifiedAt: Long,
+    )
+
+    private data class PendingJar(
+        val pluginId: String,
+        val jarFile: File,
+        val stamp: JarStamp,
+    )
+
+    private data class AttemptKey(
+        val pluginId: String,
+        val stamp: JarStamp,
+    )
+
+    private val pending = ConcurrentHashMap<String, PendingJar>()
+    private val attempted = ConcurrentHashMap.newKeySet<AttemptKey>()
+    private val drainMutex = Mutex()
+    private val authenticationLosses = AtomicLong()
+
+    @Volatile
+    private var authenticated = false
+
+    fun setAuthenticated(available: Boolean) {
+        if (!available) authenticationLosses.incrementAndGet()
+        authenticated = available
+        if (available) requestDrain()
+    }
+
+    fun enqueue(
+        pluginId: String,
+        jarFile: File,
+    ) {
+        if (sidecarExists(jarFile)) return
+        val stamp = stampOf(jarFile) ?: return
+        pending[pluginId] = PendingJar(pluginId, jarFile, stamp)
+        requestDrain()
+    }
+
+    fun onUpdateCheckCompleted(pluginId: String) {
+        if (pending.containsKey(pluginId)) requestDrain()
+    }
+
+    private fun requestDrain() {
+        if (!authenticated) return
+        scope.launch {
+            drainMutex.withLock { drainOnce() }
+        }
+    }
+
+    private suspend fun drainOnce() {
+        if (!authenticated) return
+
+        pending.entries.toList().forEach { (_, entry) ->
+            if (!authenticated) return
+            if (!isCurrentAndUnsigned(entry)) {
+                pending.remove(entry.pluginId, entry)
+                return@forEach
+            }
+            if (updateInFlight(entry.pluginId)) return@forEach
+
+            val attemptKey = AttemptKey(entry.pluginId, entry.stamp)
+            if (!attempted.add(attemptKey)) {
+                pending.remove(entry.pluginId, entry)
+                return@forEach
+            }
+            if (!pending.remove(entry.pluginId, entry)) return@forEach
+
+            val authenticationGeneration = authenticationLosses.get()
+            try {
+                persist(entry.jarFile)
+                val lostAuthentication = !authenticated || authenticationGeneration != authenticationLosses.get()
+                if (lostAuthentication && !sidecarExists(entry.jarFile)) {
+                    attempted.remove(attemptKey)
+                    pending.putIfAbsent(entry.pluginId, entry)
+                }
+            } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                attempted.remove(attemptKey)
+                pending.putIfAbsent(entry.pluginId, entry)
+                throw cancelled
+            } catch (_: Exception) {
+                // Unexpected failures also consume the attempt, preventing wakeup-driven retries.
+            }
+        }
+    }
+
+    private fun isCurrentAndUnsigned(entry: PendingJar): Boolean {
+        val currentStamp = stampOf(entry.jarFile)
+        return currentStamp == entry.stamp && !sidecarExists(entry.jarFile)
+    }
+
+    private fun stampOf(jarFile: File): JarStamp? {
+        if (!jarFile.exists()) return null
+        return JarStamp(jarFile.absolutePath, jarFile.length(), jarFile.lastModified())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/PluginVersionComparatorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/PluginVersionComparatorTest.kt
@@ -8,75 +8,79 @@ import kotlin.test.assertTrue
 
 /**
  * Guards the system-plugin minVersion gate (editor-tab 1.4.0 bundling
- * BossEditor after the host dropped it): [PluginStoreSetup.isTooOldForHost]
+ * BossEditor after the host dropped it): [PluginVersionComparator.isTooOldForHost]
  * decides whether the installed JAR must be replaced before load,
- * [PluginStoreSetup.isNewerVersion] is the comparator behind it (including
- * the release-vs-pre-release tiebreak), and [PluginStoreSetup.pickPluginJarUrl]
+ * [PluginVersionComparator.isNewerVersion] is the comparator behind it (including
+ * the release-vs-pre-release tiebreak), and [PluginVersionComparator.pickPluginJarUrl]
  * must never select a "-thin.jar" release asset (a module's default :jar
  * output, missing everything buildPluginJar bundles).
+ *
+ * Relocated from PluginStoreSetupMinVersionGateTest (BossConsole#447 step 6) when
+ * the four functions it exercises moved into their own file - same assertions,
+ * new home.
  */
-class PluginStoreSetupMinVersionGateTest {
+class PluginVersionComparatorTest {
     // ---- isTooOldForHost: the load/update decision ----
 
     @Test
     fun `no minimum means never too old`() {
-        assertFalse(PluginStoreSetup.isTooOldForHost("0.0.1", null))
-        assertFalse(PluginStoreSetup.isTooOldForHost(null, null))
+        assertFalse(PluginVersionComparator.isTooOldForHost("0.0.1", null))
+        assertFalse(PluginVersionComparator.isTooOldForHost(null, null))
     }
 
     @Test
     fun `version equal to minimum loads`() {
-        assertFalse(PluginStoreSetup.isTooOldForHost("1.4.0", "1.4.0"))
+        assertFalse(PluginVersionComparator.isTooOldForHost("1.4.0", "1.4.0"))
     }
 
     @Test
     fun `version above minimum loads`() {
-        assertFalse(PluginStoreSetup.isTooOldForHost("1.4.1", "1.4.0"))
-        assertFalse(PluginStoreSetup.isTooOldForHost("2.0.0", "1.4.0"))
+        assertFalse(PluginVersionComparator.isTooOldForHost("1.4.1", "1.4.0"))
+        assertFalse(PluginVersionComparator.isTooOldForHost("2.0.0", "1.4.0"))
     }
 
     @Test
     fun `version below minimum forces update`() {
-        assertTrue(PluginStoreSetup.isTooOldForHost("1.3.2", "1.4.0"))
+        assertTrue(PluginVersionComparator.isTooOldForHost("1.3.2", "1.4.0"))
     }
 
     @Test
     fun `unreadable installed version forces update`() {
         // Only very old JARs lack a readable version — conservatively too old.
-        assertTrue(PluginStoreSetup.isTooOldForHost(null, "1.4.0"))
+        assertTrue(PluginVersionComparator.isTooOldForHost(null, "1.4.0"))
     }
 
     @Test
     fun `pre-release of the minimum forces update`() {
         // 1.4.0-rc1 predates 1.4.0 and may lack the final contract.
-        assertTrue(PluginStoreSetup.isTooOldForHost("1.4.0-rc1", "1.4.0"))
+        assertTrue(PluginVersionComparator.isTooOldForHost("1.4.0-rc1", "1.4.0"))
     }
 
     // ---- isNewerVersion: comparator edges ----
 
     @Test
     fun `basic semver ordering`() {
-        assertTrue(PluginStoreSetup.isNewerVersion("1.4.0", "1.3.9"))
-        assertFalse(PluginStoreSetup.isNewerVersion("1.3.9", "1.4.0"))
-        assertFalse(PluginStoreSetup.isNewerVersion("1.4.0", "1.4.0"))
+        assertTrue(PluginVersionComparator.isNewerVersion("1.4.0", "1.3.9"))
+        assertFalse(PluginVersionComparator.isNewerVersion("1.3.9", "1.4.0"))
+        assertFalse(PluginVersionComparator.isNewerVersion("1.4.0", "1.4.0"))
     }
 
     @Test
     fun `multi-digit segments compare numerically not lexically`() {
-        assertTrue(PluginStoreSetup.isNewerVersion("1.4.10", "1.4.2"))
-        assertFalse(PluginStoreSetup.isNewerVersion("1.4.2", "1.4.10"))
+        assertTrue(PluginVersionComparator.isNewerVersion("1.4.10", "1.4.2"))
+        assertFalse(PluginVersionComparator.isNewerVersion("1.4.2", "1.4.10"))
     }
 
     @Test
     fun `release is newer than its own pre-release`() {
-        assertTrue(PluginStoreSetup.isNewerVersion("1.4.0", "1.4.0-rc1"))
-        assertFalse(PluginStoreSetup.isNewerVersion("1.4.0-rc1", "1.4.0"))
+        assertTrue(PluginVersionComparator.isNewerVersion("1.4.0", "1.4.0-rc1"))
+        assertFalse(PluginVersionComparator.isNewerVersion("1.4.0-rc1", "1.4.0"))
     }
 
     @Test
     fun `suffixed segment counts as its numeric prefix`() {
         // 1.4.10-beta is numerically 1.4.10, which beats 1.4.2.
-        assertTrue(PluginStoreSetup.isNewerVersion("1.4.10-beta", "1.4.2"))
+        assertTrue(PluginVersionComparator.isNewerVersion("1.4.10-beta", "1.4.2"))
     }
 
     // ---- pickPluginJarUrl: release-asset selection ----
@@ -95,20 +99,20 @@ class PluginStoreSetupMinVersionGateTest {
             )
         assertEquals(
             "https://github.example/boss-plugin-editor-tab-1.4.3.jar",
-            PluginStoreSetup.pickPluginJarUrl(json, "boss-plugin-editor-tab"),
+            PluginVersionComparator.pickPluginJarUrl(json, "boss-plugin-editor-tab"),
         )
     }
 
     @Test
     fun `release with only a thin jar yields null`() {
         val json = releaseJson("https://github.example/boss-plugin-editor-tab-1.4.3-thin.jar")
-        assertNull(PluginStoreSetup.pickPluginJarUrl(json, "boss-plugin-editor-tab"))
+        assertNull(PluginVersionComparator.pickPluginJarUrl(json, "boss-plugin-editor-tab"))
     }
 
     @Test
     fun `release without matching assets yields null`() {
         val json = releaseJson("https://github.example/some-other-plugin-1.0.0.jar")
-        assertNull(PluginStoreSetup.pickPluginJarUrl(json, "boss-plugin-editor-tab"))
+        assertNull(PluginVersionComparator.pickPluginJarUrl(json, "boss-plugin-editor-tab"))
     }
 
     // ---- extractVersionFromJarFileName: version source for the gate ----
@@ -117,7 +121,7 @@ class PluginStoreSetupMinVersionGateTest {
     fun `version extracted from standard jar filename`() {
         assertEquals(
             "1.4.0",
-            PluginStoreSetup.extractVersionFromJarFileName(
+            PluginVersionComparator.extractVersionFromJarFileName(
                 "boss-plugin-editor-tab-1.4.0.jar",
                 "boss-plugin-editor-tab",
             ),
@@ -127,7 +131,7 @@ class PluginStoreSetupMinVersionGateTest {
     @Test
     fun `non-matching filename yields null`() {
         assertNull(
-            PluginStoreSetup.extractVersionFromJarFileName(
+            PluginVersionComparator.extractVersionFromJarFileName(
                 "other-plugin-1.4.0.jar",
                 "boss-plugin-editor-tab",
             ),


### PR DESCRIPTION
Current integration status: conflict resolution against dev `5ba3da7cf` pushed as `7c1350bdf`. All 39 affected local tests plus root ktlintCheck/detekt pass through the shared build lock, including bundled-trust regressions. GitHub reports MERGEABLE. [Current-head CI](https://github.com/risa-labs-inc/BossConsole/actions/runs/34420436160) passes all checks and platforms. [Completed current-head Claude review](https://github.com/risa-labs-inc/BossConsole/pull/448#issuecomment-5610622714) confirms the extraction and bundled-trust integration are preserved with no correctness issue or regression. Validation below describes the preceding reviewed head.

PluginStoreSetup.kt holds unrelated startup, download and signature responsibilities in one large file. This PR moves its standalone SidecarBackfillCoordinator and four pure version/asset-selection helpers into separate files, leaving their behavior unchanged and updating all callers and existing tests to the new helper location.

This is a partial implementation of #447: the coordinator and utility extractions only. PluginStoreSetup remains about 1,900 lines; the remaining decomposition and the issue's under-400-line target are follow-up work, so #447 remains open.

Contributor provenance: @Antriksh1984 supplied both extractions, relocated the existing assertions and moved the existing detekt baseline entry. The review agent merged current dev into the feature branch and checked all callers and exact coordinator-body equivalence against current dev; the agent also corrected stale build-script references and simplified an equivalent condition identified by Claude. #420 changes recovery behavior and remains a separate PR.

Validation: final-head Build & Test run [34408018039](https://github.com/risa-labs-inc/BossConsole/actions/runs/34408018039) passed Linux, macOS, Windows, root ktlint/detekt, compatibility, database, shell, version and summary checks. Downloaded macOS XML confirms all 27 relevant tests passed (15 PluginVersionComparatorTest + 12 SidecarBackfillCoordinatorTest), zero failures/errors/skips. [Claude reviewed the final head 289abe74d](https://github.com/risa-labs-inc/BossConsole/pull/448#issuecomment-5609963171), confirmed behavior preservation and all previous findings addressed, and found no correctness issue or regression. The redundant local queue entry was stopped after final-head hosted verification passed; no local pass is claimed.

Manual check still required: restart manually with an existing workspace, confirm system plugins and Toolbox load, open Terminal/Browser/Editor, then sign in and confirm no new signature errors. No visual or behavior change is intended. No application was launched or stopped by the review agent.
