### PR TITLE
fix(plugins): scope OOP process IDs by window

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1087,6 +1087,8 @@ kotlin {
                 "**/plugin/IpcCompatibilityTest.kt",
                 "**/plugin/PluginStoreSetupIpcGateTest.kt",
                 "**/plugin/PluginStateDeltaTest.kt",
+                // Its process registry and production ID helper belong to the excluded OOP runtime.
+                "**/plugin/PluginProcessIdTest.kt",
             )
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
@@ -160,8 +160,10 @@ class OutOfProcessPluginSpawnerImpl(
                     )
 
                 logger.info(
-                    "Spawning out-of-process plugin: id={}, jar={}, runtime={}",
+                    "Spawning out-of-process plugin: id={}, processId={}, windowId={}, jar={}, runtime={}",
                     pluginId,
+                    config.processId,
+                    windowId,
                     jarPath,
                     runtimeClasspath,
                 )

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -153,7 +154,7 @@ class OutOfProcessPluginSpawnerImpl(
                         workDir = File(projectPath.ifEmpty { System.getProperty("user.dir") }),
                         restartPolicy = RestartPolicy.ON_FAILURE,
                         maxRestarts = manifest.sandbox.maxRestartAttempts,
-                        environment = buildEnvironment(jarPath),
+                        environment = buildEnvironment(jarPath) + ("BOSS_PLUGIN_ID" to pluginId),
                         startupTimeoutMs = manifest.healthContract?.startupTimeoutMs ?: 30_000,
                         heartbeatIntervalMs = manifest.healthContract?.heartbeatIntervalMs ?: 5_000,
                     )
@@ -228,7 +229,7 @@ class OutOfProcessPluginSpawnerImpl(
         // is the only thing that would let a host exit reap it.
         val process = managedProcesses.remove(pluginId)
         runCatching { process?.destroyForcibly() }
-        process?.let { kernelRegistry()?.unregisterIfSame(pluginProcessId(windowId, pluginId), it) }
+        process?.let { kernelRegistry()?.unregisterIfSame(it.config.processId, it) }
     }
 
     override suspend fun terminate(pluginId: String): Result<Unit> =
@@ -273,7 +274,7 @@ class OutOfProcessPluginSpawnerImpl(
                 // implies reapable" has to hold for as long as the child is alive, so a host exit
                 // part-way through an unload still reaps it; and removing by id alone could evict
                 // a replacement that a concurrent respawn had already registered.
-                process?.let { kernelRegistry()?.unregisterIfSame(pluginProcessId(windowId, pluginId), it) }
+                process?.let { kernelRegistry()?.unregisterIfSame(it.config.processId, it) }
             }
         }
 
@@ -316,7 +317,7 @@ class OutOfProcessPluginSpawnerImpl(
     private fun buildEnvironment(jarPath: String): Map<String, String> =
         buildMap {
             put("BOSS_PLUGIN_CLASSPATH", jarPath)
-            if (windowId.isNotEmpty()) put("BOSS_WINDOW_ID", windowId)
+            if (windowId.isNotBlank()) put("BOSS_WINDOW_ID", windowId)
             if (projectPath.isNotEmpty()) put("BOSS_PROJECT_PATH", projectPath)
         }
 
@@ -329,7 +330,7 @@ class OutOfProcessPluginSpawnerImpl(
         timeoutMs: Long,
     ) {
         withTimeout(timeoutMs) {
-            val processId = pluginProcessId(windowId, pluginId)
+            val processId = process.config.processId
             val registry = kernelRegistry()
 
             while (true) {
@@ -379,7 +380,7 @@ class OutOfProcessPluginSpawnerImpl(
  * Kernel-side process ID for a plugin.
  *
  * The registry is process-wide, so window-owned spawners include [windowId]. This prevents the
- * same plugin in two windows from evicting the other live process. An empty window ID preserves
+ * same plugin in two windows from evicting the other live process. A blank window ID preserves
  * the legacy identity for non-window and test contexts.
  */
 internal fun pluginProcessId(
@@ -389,7 +390,11 @@ internal fun pluginProcessId(
     if (windowId.isBlank()) {
         "plugin-$pluginId"
     } else {
-        "plugin-$windowId-$pluginId"
+        // IPC uses this as a socket filename. Full window UUIDs plus manifest IDs exceed
+        // Unix socket path limits, so keep the identity bounded without ambiguous separators.
+        val identity = "${windowId.length}:$windowId$pluginId"
+        val digest = MessageDigest.getInstance("SHA-256").digest(identity.toByteArray(Charsets.UTF_8))
+        "plugin-" + digest.take(16).joinToString("") { "%02x".format(it) }
     }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
@@ -143,7 +143,7 @@ class OutOfProcessPluginSpawnerImpl(
 
                 val config =
                     ProcessConfig(
-                        processId = processIdOf(pluginId),
+                        processId = pluginProcessId(windowId, pluginId),
                         processType = ProcessType.PLUGIN,
                         displayName = manifest.displayName,
                         mainClass = "ai.rever.boss.plugin.runtime.PluginProcessMainKt",
@@ -186,7 +186,7 @@ class OutOfProcessPluginSpawnerImpl(
                 val bridge =
                     PluginStateBridge(
                         pluginId = pluginId,
-                        instanceId = "plugin-$pluginId",
+                        instanceId = config.processId,
                         channel = channel,
                     )
                 bridge.start()
@@ -228,7 +228,7 @@ class OutOfProcessPluginSpawnerImpl(
         // is the only thing that would let a host exit reap it.
         val process = managedProcesses.remove(pluginId)
         runCatching { process?.destroyForcibly() }
-        process?.let { kernelRegistry()?.unregisterIfSame(processIdOf(pluginId), it) }
+        process?.let { kernelRegistry()?.unregisterIfSame(pluginProcessId(windowId, pluginId), it) }
     }
 
     override suspend fun terminate(pluginId: String): Result<Unit> =
@@ -273,7 +273,7 @@ class OutOfProcessPluginSpawnerImpl(
                 // implies reapable" has to hold for as long as the child is alive, so a host exit
                 // part-way through an unload still reaps it; and removing by id alone could evict
                 // a replacement that a concurrent respawn had already registered.
-                process?.let { kernelRegistry()?.unregisterIfSame(processIdOf(pluginId), it) }
+                process?.let { kernelRegistry()?.unregisterIfSame(pluginProcessId(windowId, pluginId), it) }
             }
         }
 
@@ -329,7 +329,7 @@ class OutOfProcessPluginSpawnerImpl(
         timeoutMs: Long,
     ) {
         withTimeout(timeoutMs) {
-            val processId = processIdOf(pluginId)
+            val processId = pluginProcessId(windowId, pluginId)
             val registry = kernelRegistry()
 
             while (true) {
@@ -376,17 +376,21 @@ class OutOfProcessPluginSpawnerImpl(
 }
 
 /**
- * Kernel-side process id for a plugin. The kernel registry is keyed by it.
+ * Kernel-side process ID for a plugin.
  *
- * **Not window-scoped.** This spawner is per-window but the registry is process-wide, so two windows
- * running the same out-of-process plugin produce the same id and the second registration evicts the
- * first while its child is still alive - leaving that child unreapable on host exit. `terminate()` is
- * unaffected (each spawner keeps its own [managedProcesses]), so this only bites at exit.
- * [ProcessRegistry.register] logs a warning when it evicts a live handle, which is how this shows up.
- * Putting the window id in here is the real fix and needs the child side to agree, since the runtime
- * reports state under the process id it was given.
+ * The registry is process-wide, so window-owned spawners include [windowId]. This prevents the
+ * same plugin in two windows from evicting the other live process. An empty window ID preserves
+ * the legacy identity for non-window and test contexts.
  */
-private fun processIdOf(pluginId: String): String = "plugin-$pluginId"
+internal fun pluginProcessId(
+    windowId: String,
+    pluginId: String,
+): String =
+    if (windowId.isBlank()) {
+        "plugin-$pluginId"
+    } else {
+        "plugin-$windowId-$pluginId"
+    }
 
 /**
  * The kernel's process registry, or null when the kernel is not up.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceDataProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceDataProviderImpl.kt
@@ -154,7 +154,8 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
             return cachedChildProcesses.map { it.copy(uptimeMs = it.uptimeMs + (now - childProcessCacheTime)) }
         }
 
-        val result = collectViaProcessHandle().ifEmpty { collectViaKernelRegistry() }
+        val registered = collectViaKernelRegistry()
+        val result = collectViaProcessHandle(registered).ifEmpty { registered }
         cachedChildProcesses = result
         childProcessCacheTime = now
         return result
@@ -165,33 +166,27 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
      * Searches all descendants of the current process for PluginProcessMainKt.
      * Enriches with uptime from startInstant() and RSS memory from OS query.
      */
-    private fun collectViaProcessHandle(): List<ChildProcessData> {
-        return try {
+    private fun collectViaProcessHandle(registeredProcesses: List<ChildProcessData>): List<ChildProcessData> =
+        try {
             val current = ProcessHandle.current()
-            val descendants = current.descendants().toList()
-            val registered = collectViaKernelRegistry().associateBy { it.pid }
+            val descendants =
+                current.descendants().toList().filter {
+                    it
+                        .info()
+                        .commandLine()
+                        .orElse("")
+                        .contains("PluginProcessMainKt")
+                }
+            val registered = registeredProcesses.associateBy { it.pid }
             val now = Instant.now()
 
             // Batch query RSS and thread counts for all PIDs via ps
-            val pids =
-                descendants.mapNotNull { h ->
-                    if (h
-                            .info()
-                            .commandLine()
-                            .orElse("")
-                            .contains("PluginProcessMainKt")
-                    ) {
-                        h.pid()
-                    } else {
-                        null
-                    }
-                }
+            val pids = descendants.map { it.pid() }
             val processMetrics = if (pids.isNotEmpty()) queryProcessMetrics(pids) else emptyMap()
 
             descendants.mapNotNull { handle ->
                 try {
                     val cmdLine = handle.info().commandLine().orElse("")
-                    if (!cmdLine.contains("PluginProcessMainKt")) return@mapNotNull null
 
                     // Extract plugin ID from classpath: ...boss-plugin-{name}-{version}.jar
                     val pluginJarRegex = Regex("""boss-plugin-([a-z\-]+)-\d+""")
@@ -239,7 +234,6 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
             logger.warn("ProcessHandle approach failed: {}", e.message)
             emptyList()
         }
-    }
 
     private data class OsProcessMetrics(
         val rssBytes: Long,
@@ -355,7 +349,7 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
 
                     val processId = configCls.getMethod("getProcessId").invoke(config) as String
                     val displayName = configCls.getMethod("getDisplayName").invoke(config) as String
-                    val environment = configCls.getMethod("getEnvironment").invoke(config) as? Map<*, *>
+                    val environment = processEnvironmentOrNull(config)
                     val pluginId = pluginIdFromProcessMetadata(processId, environment)
                     val pid =
                         try {
@@ -414,4 +408,10 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
 internal fun pluginIdFromProcessMetadata(
     processId: String,
     environment: Map<*, *>?,
-): String = environment?.get("BOSS_PLUGIN_ID") as? String ?: processId.removePrefix("plugin-")
+): String =
+    (environment?.get("BOSS_PLUGIN_ID") as? String)?.takeIf { it.isNotBlank() }
+        ?: processId.removePrefix("plugin-")
+
+/** Optional metadata must never hide the entire process when a reflected getter is unavailable. */
+internal fun processEnvironmentOrNull(config: Any): Map<*, *>? =
+    runCatching { config.javaClass.getMethod("getEnvironment").invoke(config) as? Map<*, *> }.getOrNull()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceDataProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceDataProviderImpl.kt
@@ -169,6 +169,7 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
         return try {
             val current = ProcessHandle.current()
             val descendants = current.descendants().toList()
+            val registered = collectViaKernelRegistry().associateBy { it.pid }
             val now = Instant.now()
 
             // Batch query RSS and thread counts for all PIDs via ps
@@ -195,9 +196,10 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
                     // Extract plugin ID from classpath: ...boss-plugin-{name}-{version}.jar
                     val pluginJarRegex = Regex("""boss-plugin-([a-z\-]+)-\d+""")
                     val match = pluginJarRegex.find(cmdLine)
-                    val pluginId = match?.groupValues?.get(1) ?: "unknown-${handle.pid()}"
+                    val known = registered[handle.pid()]
+                    val pluginId = known?.pluginId ?: match?.groupValues?.get(1) ?: "unknown-${handle.pid()}"
                     val displayName =
-                        pluginId.split("-").joinToString(" ") { part ->
+                        known?.displayName ?: pluginId.split("-").joinToString(" ") { part ->
                             part.replaceFirstChar { it.uppercase() }
                         }
 
@@ -218,7 +220,7 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
                     val configuredHeapMb = PerformanceSettingsManager.currentSettings.value.pluginJvmHeapMb
 
                     ChildProcessData(
-                        processId = "plugin-$pluginId",
+                        processId = known?.processId ?: "plugin-process-${handle.pid()}",
                         pluginId = pluginId,
                         displayName = displayName,
                         pid = handle.pid(),
@@ -353,6 +355,8 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
 
                     val processId = configCls.getMethod("getProcessId").invoke(config) as String
                     val displayName = configCls.getMethod("getDisplayName").invoke(config) as String
+                    val environment = configCls.getMethod("getEnvironment").invoke(config) as? Map<*, *>
+                    val pluginId = pluginIdFromProcessMetadata(processId, environment)
                     val pid =
                         try {
                             processCls.getMethod("getPid").invoke(process) as Long
@@ -368,7 +372,7 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
 
                     ChildProcessData(
                         processId = processId,
-                        pluginId = processId.removePrefix("plugin-"),
+                        pluginId = pluginId,
                         displayName = displayName,
                         pid = pid,
                         state = if (isAlive) "RUNNING" else "STOPPED",
@@ -405,3 +409,9 @@ class PerformanceDataProviderImpl : PerformanceDataProvider {
             pluginJvmInitialHeapMb = pluginJvmInitialHeapMb,
         )
 }
+
+/** Process identity is opaque; plugin identity comes from spawn metadata. */
+internal fun pluginIdFromProcessMetadata(
+    processId: String,
+    environment: Map<*, *>?,
+): String = environment?.get("BOSS_PLUGIN_ID") as? String ?: processId.removePrefix("plugin-")

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/WindowsArm64SourceIsolationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/WindowsArm64SourceIsolationTest.kt
@@ -53,6 +53,7 @@ class WindowsArm64SourceIsolationTest {
             "/plugin/IpcCompatibilityTest.kt",
             "/plugin/PluginStoreSetupIpcGateTest.kt",
             "/plugin/PluginStateDeltaTest.kt",
+            "/plugin/PluginProcessIdTest.kt",
         )
 
     /** Excluded for reasons unrelated to the platform, so not part of the mirror. */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginProcessIdTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginProcessIdTest.kt
@@ -1,0 +1,91 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.process.ManagedProcess
+import ai.rever.boss.process.ProcessConfig
+import ai.rever.boss.process.ProcessRegistry
+import ai.rever.boss.process.ProcessType
+import java.io.InputStream
+import java.io.OutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
+
+class PluginProcessIdTest {
+    private class LiveProcess(
+        private val pidValue: Long,
+    ) : Process() {
+        override fun getOutputStream(): OutputStream = OutputStream.nullOutputStream()
+
+        override fun getInputStream(): InputStream = InputStream.nullInputStream()
+
+        override fun getErrorStream(): InputStream = InputStream.nullInputStream()
+
+        override fun waitFor(): Int = 0
+
+        override fun exitValue(): Int = throw IllegalThreadStateException()
+
+        override fun destroy() = Unit
+
+        override fun isAlive(): Boolean = true
+
+        override fun pid(): Long = pidValue
+    }
+
+    private fun managedProcess(
+        processId: String,
+        pid: Long,
+    ) = ManagedProcess(
+        config =
+            ProcessConfig(
+                processId = processId,
+                processType = ProcessType.PLUGIN,
+                displayName = processId,
+                mainClass = "Main",
+            ),
+        process = LiveProcess(pid),
+        ipcAddress = "test://$processId",
+    )
+
+    @Test
+    fun `same plugin receives distinct process ids in different windows`() {
+        val firstWindow = pluginProcessId("window-a", "example-plugin")
+        val secondWindow = pluginProcessId("window-b", "example-plugin")
+
+        assertEquals("plugin-window-a-example-plugin", firstWindow)
+        assertEquals("plugin-window-b-example-plugin", secondWindow)
+        assertNotEquals(firstWindow, secondWindow)
+    }
+
+    @Test
+    fun `same plugin in two windows keeps both live registry entries`() {
+        val registry = ProcessRegistry()
+        val firstId = pluginProcessId("window-a", "example-plugin")
+        val secondId = pluginProcessId("window-b", "example-plugin")
+        val firstProcess = managedProcess(firstId, pid = 1)
+        val secondProcess = managedProcess(secondId, pid = 2)
+
+        registry.register(firstId, firstProcess)
+        registry.register(secondId, secondProcess)
+
+        assertEquals(2, registry.size)
+        assertSame(firstProcess, registry.getProcess(firstId))
+        assertSame(secondProcess, registry.getProcess(secondId))
+    }
+
+    @Test
+    fun `process id remains stable within the same window`() {
+        assertEquals(
+            pluginProcessId("window-a", "example-plugin"),
+            pluginProcessId("window-a", "example-plugin"),
+        )
+    }
+
+    @Test
+    fun `empty window id preserves legacy identity for non-window contexts`() {
+        assertEquals(
+            "plugin-example-plugin",
+            pluginProcessId("", "example-plugin"),
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginProcessIdTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginProcessIdTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class PluginProcessIdTest {
     private class LiveProcess(
@@ -52,8 +53,8 @@ class PluginProcessIdTest {
         val firstWindow = pluginProcessId("window-a", "example-plugin")
         val secondWindow = pluginProcessId("window-b", "example-plugin")
 
-        assertEquals("plugin-window-a-example-plugin", firstWindow)
-        assertEquals("plugin-window-b-example-plugin", secondWindow)
+        assertTrue(firstWindow.matches(Regex("plugin-[a-f0-9]{32}")))
+        assertTrue(secondWindow.matches(Regex("plugin-[a-f0-9]{32}")))
         assertNotEquals(firstWindow, secondWindow)
     }
 
@@ -71,6 +72,18 @@ class PluginProcessIdTest {
         assertEquals(2, registry.size)
         assertSame(firstProcess, registry.getProcess(firstId))
         assertSame(secondProcess, registry.getProcess(secondId))
+    }
+
+    @Test
+    fun `long manifest and window ids fit a typical Unix socket path`() {
+        val id =
+            pluginProcessId(
+                "123e4567-e89b-12d3-a456-426614174000",
+                "ai.rever.boss.plugin.dynamic.averylongpluginname",
+            )
+        val socketPath = "/Users/developer/.boss_debug/ipc/boss-plugin-$id.sock"
+        assertTrue(socketPath.toByteArray(Charsets.UTF_8).size < 104)
+        assertNotEquals(pluginProcessId("a-b", "c"), pluginProcessId("a", "b-c"))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/KernelReflectionContractTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/KernelReflectionContractTest.kt
@@ -20,8 +20,8 @@ import kotlin.test.assertTrue
  * constructor plus a synthetic defaults bridge, with no `@JvmOverloads` - so out-of-process plugins
  * would have stopped spawning entirely, in the same change that set out to stop them leaking.
  *
- * Each test below mirrors one reflective lookup in `DefaultPlugin` exactly. Keep them in step with
- * that call site: if a lookup here needs updating, the runtime behaviour changed.
+ * Tests mirror reflective lookups in `DefaultPlugin` and `PerformanceDataProviderImpl`. Keep them in step
+ * with those call sites: if a lookup here needs updating, the runtime behaviour changed.
  */
 class KernelReflectionContractTest {
     @Test
@@ -75,5 +75,21 @@ class KernelReflectionContractTest {
                 Class.forName("ai.rever.boss.process.ProcessRegistry"),
             )
         assertEquals(3, ctor.parameterCount)
+    }
+
+    @Test
+    fun `performance configuration metadata getters retain their reflective contract`() {
+        val config = Class.forName("ai.rever.boss.process.ProcessConfig")
+        assertEquals(String::class.java, config.getMethod("getProcessId").returnType)
+        assertEquals(String::class.java, config.getMethod("getDisplayName").returnType)
+        assertEquals(Map::class.java, config.getMethod("getEnvironment").returnType)
+    }
+
+    @Test
+    fun `performance managed process getters retain their reflective contract`() {
+        val process = Class.forName("ai.rever.boss.process.ManagedProcess")
+        assertEquals(Class.forName("ai.rever.boss.process.ProcessConfig"), process.getMethod("getConfig").returnType)
+        assertEquals(Long::class.javaPrimitiveType, process.getMethod("getPid").returnType)
+        assertEquals(Boolean::class.javaPrimitiveType, process.getMethod("isAlive").returnType)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/PluginProcessMetadataTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/PluginProcessMetadataTest.kt
@@ -1,0 +1,22 @@
+package ai.rever.boss.performance
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PluginProcessMetadataTest {
+    @Test
+    fun `opaque window process id never replaces explicit plugin identity`() {
+        assertEquals(
+            "ai.rever.boss.plugin.dynamic.example",
+            pluginIdFromProcessMetadata(
+                "plugin-d077f244defc24c228e8b49c4ad9a09e",
+                mapOf("BOSS_PLUGIN_ID" to "ai.rever.boss.plugin.dynamic.example"),
+            ),
+        )
+    }
+
+    @Test
+    fun `legacy processes without metadata retain their plugin name`() {
+        assertEquals("example-plugin", pluginIdFromProcessMetadata("plugin-example-plugin", emptyMap<String, String>()))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/PluginProcessMetadataTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/PluginProcessMetadataTest.kt
@@ -19,4 +19,10 @@ class PluginProcessMetadataTest {
     fun `legacy processes without metadata retain their plugin name`() {
         assertEquals("example-plugin", pluginIdFromProcessMetadata("plugin-example-plugin", emptyMap<String, String>()))
     }
+
+    @Test
+    fun `missing optional environment preserves legacy identity`() {
+        assertEquals("notes", pluginIdFromProcessMetadata("plugin-notes", processEnvironmentOrNull(Any())))
+        assertEquals("notes", pluginIdFromProcessMetadata("plugin-notes", mapOf("BOSS_PLUGIN_ID" to " ")))
+    }
 }

--- a/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessRegistry.kt
+++ b/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessRegistry.kt
@@ -30,9 +30,8 @@ class ProcessRegistry {
         val replaced = processes.put(id, process)
         // Replacing a *dead* handle is normal - that is what a respawn does. Replacing a live one
         // means two callers picked the same process id, and the evicted child becomes invisible to
-        // the shutdown hook while still running, i.e. an orphan. The known way to reach this is two
-        // windows spawning the same out-of-process plugin, since `plugin-<id>` carries no window
-        // discriminator while the registry is process-wide.
+        // the shutdown hook while still running, i.e. an orphan. Window-owned plugin spawners
+        // now use window-scoped identities; retain this diagnostic for any other colliding caller.
         if (replaced != null && replaced !== process && replaced.isAlive) {
             logger.warn(
                 "Registered id={} replaced a LIVE handle (pid={} -> {}); the evicted child will not be reaped",


### PR DESCRIPTION
Two windows running the same out-of-process plugin receive distinct bounded process identities, preventing deterministic registry eviction and IPC-name collisions. The child and state bridge use the configured identity; cleanup/readiness read the recorded configuration. Explicit metadata preserves plugin names in performance reporting. Addresses #135 item 1; existing reaping fixes remain separate.

## Contribution

@passionate-coder26 authored the window-scoped spawn/readiness/bridge/cleanup wiring and four identity/registry tests. Agent repairs add Windows ARM64 exclusions, a bounded 128-bit identity, explicit performance metadata, recorded-ID cleanup, session log mapping, optional-reflection fallback and contract regressions.

## Validation

17 identity/metadata/reflection-contract/Windows ARM64 tests passed. composeApp ktlintCheck/detekt passed. All tests had zero failures/errors/skips. Commands used the shared build lock and unchanged API pin.

Validated dev snapshot: `012e70256d9bbfc558277976aab20ce9ad98672b`. Head: `2489a0aba101964cad3cfea2e6447425de6aa778`. Final-head hosted checks and Claude review status are tracked in the review comments. No merge or auto-merge.

## Limits and manual validation

Per-window logs and sockets left by forced exits can accumulate. Spawn-log mapping is session-scoped, not a historical attribution index. Very long custom IPC roots and existing Windows TCP port-probe races remain resolver limitations; no cross-group resolver changes were made. Read-only sibling runtime inspection at 3fec74cc619f5c30c5e33c38dbb7a539873fc381 confirms configured process identity is passed through; the installed runtime artifact still needs smoke validation.

Manual: run the same OOP plugin in two windows (including a long manifest ID), verify both work and show correct names/distinct IDs and PIDs, close one window and verify the other survives, then check child reaping on a user-driven exit.

No app instance was launched or stopped; no live database migration was applied.
