### PR TITLE
feat(plugins): add health and recovery center

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -48,12 +48,12 @@ import ai.rever.boss.html.HtmlFileOpenMode
 import ai.rever.boss.html.HtmlFileSettingsManager
 import ai.rever.boss.icons.FileIcons
 import ai.rever.boss.keymap.KeymapSettingsManager
-import ai.rever.boss.plugin.api.PluginLoaderDelegate
 import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.mcp.McpToolRegistryImpl
 import ai.rever.boss.platform.rememberDirectoryPicker
 import ai.rever.boss.plugin.api.Panel.Companion.left
 import ai.rever.boss.plugin.api.Panel.Companion.top
+import ai.rever.boss.plugin.api.PluginLoaderDelegate
 import ai.rever.boss.plugin.api.TabInfo
 import ai.rever.boss.plugin.sandbox.notification.ToastMessage
 import ai.rever.boss.plugin.sandbox.notification.ToastType

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -27,6 +27,7 @@ import ai.rever.boss.components.plugin.MissingHandlerPluginDialog
 import ai.rever.boss.components.plugin.MissingHandlerPluginEventBus
 import ai.rever.boss.components.plugin.PanelIds
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
+import ai.rever.boss.components.plugin.PluginHealthCenterDialog
 import ai.rever.boss.components.plugin.PluginLoadGateHost
 import ai.rever.boss.components.plugin.PluginLoadRemedyAccess
 import ai.rever.boss.components.plugin.PluginStoreVersionBridge
@@ -459,6 +460,13 @@ internal fun BossAppDialogs(state: BossAppState) {
         // In the MAIN composition, not inside whichever chrome raised it - see BossAppState.
         state.draggablePanelComponent.ToolLauncherDialog(
             onDismiss = { state.showToolLauncherDialog = false },
+        )
+    }
+
+    if (state.showPluginHealthCenter) {
+        PluginHealthCenterDialog(
+            manager = state.currentDefaultPlugin?.dynamicPluginManager,
+            onDismiss = { state.showPluginHealthCenter = false },
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -48,6 +48,7 @@ import ai.rever.boss.html.HtmlFileOpenMode
 import ai.rever.boss.html.HtmlFileSettingsManager
 import ai.rever.boss.icons.FileIcons
 import ai.rever.boss.keymap.KeymapSettingsManager
+import ai.rever.boss.plugin.api.PluginLoaderDelegate
 import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.mcp.McpToolRegistryImpl
 import ai.rever.boss.platform.rememberDirectoryPicker
@@ -466,6 +467,7 @@ internal fun BossAppDialogs(state: BossAppState) {
     if (state.showPluginHealthCenter) {
         PluginHealthCenterDialog(
             manager = state.currentDefaultPlugin?.dynamicPluginManager,
+            delegate = state.currentDefaultPlugin?.getPluginAPI(PluginLoaderDelegate::class.java),
             onDismiss = { state.showPluginHealthCenter = false },
         )
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppMenuActionEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppMenuActionEffects.kt
@@ -617,6 +617,13 @@ internal fun BossAppMenuActionEffects(
             }.launchIn(this)
     }
 
+    LaunchedEffect(windowId) {
+        MenuActionsHandler.showPluginHealthCenterEvents
+            .onEach { eventWindowId ->
+                if (eventWindowId == windowId) state.showPluginHealthCenter = true
+            }.launchIn(this)
+    }
+
     // Handle "Reload Panel" (by panel ID) menu events, which reload the owning plugin
     LaunchedEffect(windowId) {
         MenuActionsHandler.reloadPluginEvents

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
@@ -95,6 +95,9 @@ internal class BossAppState(
      * `ToolLauncherButton`.
      */
     var showToolLauncherDialog by mutableStateOf(false)
+
+    /** Window-local operational view of plugin lifecycle problems and their safe remedies. */
+    var showPluginHealthCenter by mutableStateOf(false)
     var showProjectDialog by mutableStateOf(false)
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1357,7 +1357,8 @@ class DynamicPluginManager(
             // must resume any still-registered panels just like a refused uninstall does.
             logger.warn(
                 LogCategory.SYSTEM,
-                "Plugin uninstall cancelled after UI teardown; plugin remains installed and closed tabs may need reopening",
+                "Plugin uninstall cancelled after UI teardown; plugin remains installed and " +
+                    "closed tabs may need reopening",
                 mapOf("pluginId" to pluginId),
             )
             notifyPanelsRefresh(pluginId)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1355,6 +1355,11 @@ class DynamicPluginManager(
         } catch (cancelled: kotlinx.coroutines.CancellationException) {
             // Tab/panel disposal happens before the lock; cancellation while waiting for it
             // must resume any still-registered panels just like a refused uninstall does.
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Plugin uninstall cancelled after UI teardown; plugin remains installed and closed tabs may need reopening",
+                mapOf("pluginId" to pluginId),
+            )
             notifyPanelsRefresh(pluginId)
             throw cancelled
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1357,9 +1357,8 @@ class DynamicPluginManager(
             // must resume any still-registered panels just like a refused uninstall does.
             logger.warn(
                 LogCategory.SYSTEM,
-                "Plugin uninstall cancelled after UI teardown; plugin remains installed and " +
-                    "closed tabs may need reopening",
-                mapOf("pluginId" to pluginId),
+                "Plugin uninstall caller cancelled; cleanup may already have completed",
+                mapOf("pluginId" to pluginId, "stillInstalled" to isInstalled(pluginId)),
             )
             notifyPanelsRefresh(pluginId)
             throw cancelled

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1428,7 +1428,7 @@ class DynamicPluginManager(
                         )
                         val trackingContext = trackingContexts.remove(pluginId)
                         trackingContext?.unregisterAll()
-                        managerScope.launch { sandboxManager.removeSandbox(pluginId) }
+                        sandboxManager.removeSandbox(pluginId)
                         removePluginState(pluginId)
                         return@withLock Result.success(Unit)
                     }
@@ -1497,16 +1497,12 @@ class DynamicPluginManager(
                 val trackingContext = trackingContexts.remove(pluginId)
                 trackingContext?.unregisterAll()
 
-                // Remove sandbox
-                managerScope.launch {
-                    sandboxManager.removeSandbox(pluginId)
-                }
+                // Complete teardown before reload can create a replacement sandbox for this ID.
+                sandboxManager.removeSandbox(pluginId)
 
                 // Terminate out-of-process child if applicable
                 if (manifest.isolationMode == "out-of-process") {
-                    managerScope.launch {
-                        outOfProcessSpawner?.terminate(pluginId)
-                    }
+                    outOfProcessSpawner?.terminate(pluginId)
                 }
 
                 // Unload the plugin

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1332,24 +1332,31 @@ class DynamicPluginManager(
         force: Boolean = false,
         waitForGC: Boolean = false,
     ): Result<Unit> =
-        uninstallPlugin(
-            pluginId = pluginId,
-            force = force,
-            waitForGC = waitForGC,
-            closeTabsAcrossWindows = true,
-        ).also { outcome ->
-            // The teardown inside detached this plugin's sidebar panels so they would dispose
-            // while the loader was still open. If the unload then did not happen, nothing else
-            // puts them back: the plugin is still loaded, its panels are still registered, and no
-            // (re)install is coming to call notifyPanelsRefresh. Resuming here is what stops a
-            // refused uninstall from blanking a slot for the rest of the session, and a no-op
-            // when nothing was detached.
-            //
-            // Here rather than in the private overload because this is the entry point every
-            // user-facing unload takes (update, reload, remove). The other caller that tears
-            // tabs down globally is dispose(), which is the app shutting down - a panel that
-            // never comes back is exactly right there.
-            if (outcome.isFailure) notifyPanelsRefresh(pluginId)
+        try {
+            uninstallPlugin(
+                pluginId = pluginId,
+                force = force,
+                waitForGC = waitForGC,
+                closeTabsAcrossWindows = true,
+            ).also { outcome ->
+                // The teardown inside detached this plugin's sidebar panels so they would dispose
+                // while the loader was still open. If the unload then did not happen, nothing else
+                // puts them back: the plugin is still loaded, its panels are still registered, and no
+                // (re)install is coming to call notifyPanelsRefresh. Resuming here is what stops a
+                // refused uninstall from blanking a slot for the rest of the session, and a no-op
+                // when nothing was detached.
+                //
+                // Here rather than in the private overload because this is the entry point every
+                // user-facing unload takes (update, reload, remove). The other caller that tears
+                // tabs down globally is dispose(), which is the app shutting down - a panel that
+                // never comes back is exactly right there.
+                if (outcome.isFailure) notifyPanelsRefresh(pluginId)
+            }
+        } catch (cancelled: kotlinx.coroutines.CancellationException) {
+            // Tab/panel disposal happens before the lock; cancellation while waiting for it
+            // must resume any still-registered panels just like a refused uninstall does.
+            notifyPanelsRefresh(pluginId)
+            throw cancelled
         }
 
     private suspend fun uninstallPlugin(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -35,6 +35,7 @@ import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
@@ -1401,146 +1402,150 @@ class DynamicPluginManager(
             }
         }
         return mutex.withLock {
-            try {
-                logger.info(
-                    LogCategory.SYSTEM,
-                    "Uninstalling plugin",
-                    mapOf(
-                        "pluginId" to pluginId,
-                        "force" to force,
-                    ),
-                )
-
-                val loadedPlugin = pluginLoader.getPlugin(pluginId)
-                if (loadedPlugin == null) {
-                    // Plugin not in classloader — may have been unloaded during
-                    // incompatibility handling but still tracked in _pluginStates.
-                    // Clean up state so the update flow can proceed to reinstall.
-                    val pluginState = _pluginStates.value[pluginId]
-                    if (pluginState != null) {
-                        logger.info(
-                            LogCategory.SYSTEM,
-                            "Plugin already unloaded from classloader, cleaning up state",
-                            mapOf(
-                                "pluginId" to pluginId,
-                                "state" to pluginState.state.name,
-                            ),
-                        )
-                        val trackingContext = trackingContexts.remove(pluginId)
-                        trackingContext?.unregisterAll()
-                        sandboxManager.removeSandbox(pluginId)
-                        removePluginState(pluginId)
-                        return@withLock Result.success(Unit)
-                    }
-                    return@withLock Result.failure(
-                        PluginUnloadException("Plugin not found: $pluginId", pluginId),
-                    )
-                }
-
-                val manifest = loadedPlugin.manifest
-
-                // Check if plugin can be unloaded (system plugins may be protected)
-                if (!manifest.canUnload && !force) {
-                    logger.warn(
+            // Once destructive cleanup starts, finish sandbox, loader and state cleanup even if
+            // the requesting dialog/window disappears. Lock acquisition remains cancellable.
+            withContext(NonCancellable) {
+                try {
+                    logger.info(
                         LogCategory.SYSTEM,
-                        "Cannot unload system plugin",
+                        "Uninstalling plugin",
                         mapOf(
                             "pluginId" to pluginId,
-                            "systemPlugin" to manifest.systemPlugin,
+                            "force" to force,
                         ),
                     )
-                    return@withLock Result.failure(
-                        PluginUnloadException(
-                            "Cannot unload system plugin: $pluginId (canUnload=false)",
-                            pluginId,
-                            listOf("System plugin is protected from unloading"),
-                        ),
-                    )
-                }
 
-                // Check if unload is allowed
-                if (!force) {
-                    val canUnload = checkCanUnload(pluginId)
-                    if (!canUnload.isAllowed) {
-                        val reasons = (canUnload as CanUnloadResult.NotAllowed).reasons
-                        return@withLock Result.failure(
-                            PluginUnloadException(
-                                "Cannot unload plugin: ${reasons.joinToString("; ")}",
-                                pluginId,
-                                reasons,
-                            ),
+                    val loadedPlugin = pluginLoader.getPlugin(pluginId)
+                    if (loadedPlugin == null) {
+                        // Plugin not in classloader — may have been unloaded during
+                        // incompatibility handling but still tracked in _pluginStates.
+                        // Clean up state so the update flow can proceed to reinstall.
+                        val pluginState = _pluginStates.value[pluginId]
+                        if (pluginState != null) {
+                            logger.info(
+                                LogCategory.SYSTEM,
+                                "Plugin already unloaded from classloader, cleaning up state",
+                                mapOf(
+                                    "pluginId" to pluginId,
+                                    "state" to pluginState.state.name,
+                                ),
+                            )
+                            val trackingContext = trackingContexts.remove(pluginId)
+                            trackingContext?.unregisterAll()
+                            sandboxManager.removeSandbox(pluginId)
+                            removePluginState(pluginId)
+                            return@withContext Result.success(Unit)
+                        }
+                        return@withContext Result.failure(
+                            PluginUnloadException("Plugin not found: $pluginId", pluginId),
                         )
                     }
-                }
 
-                // Notify listeners before unload
-                notifyListeners { it.beforePluginUnload(manifest) }
+                    val manifest = loadedPlugin.manifest
 
-                // Prepare unload-aware components
-                for (ref in unloadAwareComponents) {
-                    val component = ref.get() ?: continue
-                    try {
-                        component.prepareForUnload(pluginId)
-                    } catch (e: Exception) {
+                    // Check if plugin can be unloaded (system plugins may be protected)
+                    if (!manifest.canUnload && !force) {
                         logger.warn(
                             LogCategory.SYSTEM,
-                            "Error preparing component for unload",
+                            "Cannot unload system plugin",
                             mapOf(
                                 "pluginId" to pluginId,
+                                "systemPlugin" to manifest.systemPlugin,
                             ),
-                            error = e,
+                        )
+                        return@withContext Result.failure(
+                            PluginUnloadException(
+                                "Cannot unload system plugin: $pluginId (canUnload=false)",
+                                pluginId,
+                                listOf("System plugin is protected from unloading"),
+                            ),
                         )
                     }
+
+                    // Check if unload is allowed
+                    if (!force) {
+                        val canUnload = checkCanUnload(pluginId)
+                        if (!canUnload.isAllowed) {
+                            val reasons = (canUnload as CanUnloadResult.NotAllowed).reasons
+                            return@withContext Result.failure(
+                                PluginUnloadException(
+                                    "Cannot unload plugin: ${reasons.joinToString("; ")}",
+                                    pluginId,
+                                    reasons,
+                                ),
+                            )
+                        }
+                    }
+
+                    // Notify listeners before unload
+                    notifyListeners { it.beforePluginUnload(manifest) }
+
+                    // Prepare unload-aware components
+                    for (ref in unloadAwareComponents) {
+                        val component = ref.get() ?: continue
+                        try {
+                            component.prepareForUnload(pluginId)
+                        } catch (e: Exception) {
+                            logger.warn(
+                                LogCategory.SYSTEM,
+                                "Error preparing component for unload",
+                                mapOf(
+                                    "pluginId" to pluginId,
+                                ),
+                                error = e,
+                            )
+                        }
+                    }
+
+                    // Unregister all panels and tabs
+                    val trackingContext = trackingContexts.remove(pluginId)
+                    trackingContext?.unregisterAll()
+
+                    // Complete teardown before reload can create a replacement sandbox for this ID.
+                    sandboxManager.removeSandbox(pluginId)
+
+                    // Terminate out-of-process child if applicable
+                    if (manifest.isolationMode == "out-of-process") {
+                        outOfProcessSpawner?.terminate(pluginId)
+                    }
+
+                    // Unload the plugin
+                    // force flows through: without it the loader re-blocks
+                    // canUnload=false system plugins, leaving their classloaders
+                    // parented to a superseded ApiClassLoader after a hot swap.
+                    val unloadResult = pluginLoader.unloadPlugin(pluginId, waitForGC, force)
+                    if (unloadResult.isFailure) {
+                        notifyListeners { it.pluginUnloadFailed(manifest, unloadResult.exceptionOrNull()!!) }
+                        return@withContext unloadResult
+                    }
+
+                    // Update state
+                    removePluginState(pluginId)
+
+                    // Notify listeners
+                    notifyListeners { it.pluginUnloaded(manifest) }
+                    emitPluginLifecycle(manifest.pluginId, PluginLifecycleState.UNLOADED)
+
+                    logger.info(
+                        LogCategory.SYSTEM,
+                        "Plugin uninstalled successfully",
+                        mapOf(
+                            "pluginId" to pluginId,
+                        ),
+                    )
+
+                    Result.success(Unit)
+                } catch (e: Exception) {
+                    logger.error(
+                        LogCategory.SYSTEM,
+                        "Failed to uninstall plugin",
+                        mapOf(
+                            "pluginId" to pluginId,
+                        ),
+                        e,
+                    )
+                    Result.failure(e)
                 }
-
-                // Unregister all panels and tabs
-                val trackingContext = trackingContexts.remove(pluginId)
-                trackingContext?.unregisterAll()
-
-                // Complete teardown before reload can create a replacement sandbox for this ID.
-                sandboxManager.removeSandbox(pluginId)
-
-                // Terminate out-of-process child if applicable
-                if (manifest.isolationMode == "out-of-process") {
-                    outOfProcessSpawner?.terminate(pluginId)
-                }
-
-                // Unload the plugin
-                // force flows through: without it the loader re-blocks
-                // canUnload=false system plugins, leaving their classloaders
-                // parented to a superseded ApiClassLoader after a hot swap.
-                val unloadResult = pluginLoader.unloadPlugin(pluginId, waitForGC, force)
-                if (unloadResult.isFailure) {
-                    notifyListeners { it.pluginUnloadFailed(manifest, unloadResult.exceptionOrNull()!!) }
-                    return@withLock unloadResult
-                }
-
-                // Update state
-                removePluginState(pluginId)
-
-                // Notify listeners
-                notifyListeners { it.pluginUnloaded(manifest) }
-                emitPluginLifecycle(manifest.pluginId, PluginLifecycleState.UNLOADED)
-
-                logger.info(
-                    LogCategory.SYSTEM,
-                    "Plugin uninstalled successfully",
-                    mapOf(
-                        "pluginId" to pluginId,
-                    ),
-                )
-
-                Result.success(Unit)
-            } catch (e: Exception) {
-                logger.error(
-                    LogCategory.SYSTEM,
-                    "Failed to uninstall plugin",
-                    mapOf(
-                        "pluginId" to pluginId,
-                    ),
-                    e,
-                )
-                Result.failure(e)
             }
         }
     }
@@ -2461,6 +2466,7 @@ class DynamicPluginManager(
         _pluginStates.value = _pluginStates.value - pluginId
         PluginRecoveryQuarantine.clear(pluginId)
         PluginCrashRegistry.clearCrash(pluginId)
+        PluginCrashRegistry.clearIncompatible(pluginId)
         // The build verdict describes a loaded plugin, so it goes with it. A reload re-probes on the
         // way back in, so dropping it here does not make a reloaded panel lose its tag.
         PluginBuildRegistry.clear(pluginId)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1359,6 +1359,26 @@ class DynamicPluginManager(
             throw cancelled
         }
 
+    /** Cancellation must reach the public compensation before a free mutex admits destructive cleanup. */
+    internal suspend fun teardownPluginTabsForUnload(pluginId: String) {
+        pluginTabsTeardown?.let { teardown ->
+            try {
+                teardown(pluginId)
+            } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                throw cancelled
+            } catch (t: Throwable) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Plugin tab teardown before unload failed (continuing)",
+                    mapOf(
+                        "pluginId" to pluginId,
+                        "error" to (t.message ?: t::class.simpleName),
+                    ),
+                )
+            }
+        }
+    }
+
     private suspend fun uninstallPlugin(
         pluginId: String,
         force: Boolean,
@@ -1393,20 +1413,7 @@ class DynamicPluginManager(
             candidate != null &&
             (force || (candidate.manifest.canUnload && checkCanUnload(pluginId).isAllowed))
         ) {
-            pluginTabsTeardown?.let { teardown ->
-                try {
-                    teardown(pluginId)
-                } catch (t: Throwable) {
-                    logger.warn(
-                        LogCategory.SYSTEM,
-                        "Plugin tab teardown before unload failed (continuing)",
-                        mapOf(
-                            "pluginId" to pluginId,
-                            "error" to (t.message ?: t::class.simpleName),
-                        ),
-                    )
-                }
-            }
+            teardownPluginTabsForUnload(pluginId)
         }
         return mutex.withLock {
             // Once destructive cleanup starts, finish sandbox, loader and state cleanup even if

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -94,11 +94,9 @@ object PluginDependencyResolution {
      * nothing at all, silently re-creating the problem this feature exists to remove.
      *
      * [isIncompatible] qualifies the **jar** clause only, and must not override LOADED.
-     * `PluginCrashRegistry` keeps the flag until something clears it, and the only caller of
-     * `clearIncompatible` is the re-enable path - not install or update. So a plugin that failed
-     * registration, was updated from the Toolbox's own "Plugin Incompatible" prompt and is now
-     * running still carries the flag; excluding it would report a *running* plugin as missing,
-     * and taking Install would then discard the download and claim it "did not start".
+     * Uninstall and re-enable clear the incompatibility marker. LOADED remains authoritative
+     * even if a stale marker is observed across a lifecycle transition: reporting a running
+     * plugin as missing would discard a redundant download and claim it did not start.
      *
      * The jar clause needs [isIncompatible] to stay honest. There are **two** binary
      * incompatibility paths in `installPlugin` and only one of them fails: the load-time one

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.plugin.api.PluginLoaderDelegate
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
 import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
@@ -24,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -56,10 +58,19 @@ internal data class PluginHealthRow(
     val action: PluginHealthAction? = null,
 )
 
+internal class PluginHealthOperationState {
+    var workingPluginId by mutableStateOf<String?>(null)
+    var actionError by mutableStateOf<String?>(null)
+}
+
+@Composable
+internal fun rememberPluginHealthOperationState(): PluginHealthOperationState = remember { PluginHealthOperationState() }
+
 /** Host-owned operational surface for plugin status and existing safe recovery actions. */
 @Composable
 internal fun PluginHealthCenterDialog(
     manager: DynamicPluginManager?,
+    delegate: PluginLoaderDelegate?,
     onDismiss: () -> Unit,
 ) {
     val pluginStates by (manager?.pluginStates ?: return).collectAsState()
@@ -69,35 +80,35 @@ internal fun PluginHealthCenterDialog(
     val incompatible = pluginStates.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.isIncompatible(it) }
     val rows = pluginHealthRows(pluginStates, gates, crashedPluginIds, inaccessible, incompatible)
     val scope = rememberCoroutineScope()
-    var workingPluginId by mutableStateOf<String?>(null)
-    var actionError by mutableStateOf<String?>(null)
+    val operation = rememberPluginHealthOperationState()
 
     BossDialog(
-        onDismissRequest = { if (workingPluginId == null) onDismiss() },
+        onDismissRequest = { if (operation.workingPluginId == null) onDismiss() },
         properties =
             DialogProperties(
-                dismissOnBackPress = workingPluginId == null,
-                dismissOnClickOutside = workingPluginId == null,
+                dismissOnBackPress = operation.workingPluginId == null,
+                dismissOnClickOutside = operation.workingPluginId == null,
                 usePlatformDefaultWidth = false,
             ),
     ) {
         PluginHealthCenterCard(
             rows = rows,
-            actionError = actionError,
-            workingPluginId = workingPluginId,
+            actionError = operation.actionError,
+            workingPluginId = operation.workingPluginId,
             onDismiss = onDismiss,
             onAction = { row, action ->
-                if (workingPluginId == null) {
-                    workingPluginId = row.pluginId
-                    actionError = null
+                if (operation.workingPluginId == null) {
+                    operation.workingPluginId = row.pluginId
+                    operation.actionError = null
                     launchHealthAction(
                         scope = scope,
                         manager = manager,
+                        delegate = delegate,
                         row = row,
                         action = action,
                         onFinished = { error ->
-                            actionError = error
-                            workingPluginId = null
+                            operation.actionError = error
+                            operation.workingPluginId = null
                         },
                     )
                 }
@@ -184,6 +195,7 @@ private fun PluginHealthRows(
 private fun launchHealthAction(
     scope: kotlinx.coroutines.CoroutineScope,
     manager: DynamicPluginManager,
+    delegate: PluginLoaderDelegate?,
     row: PluginHealthRow,
     action: PluginHealthAction,
     onFinished: (String?) -> Unit,
@@ -192,10 +204,12 @@ private fun launchHealthAction(
         val result =
             runCatching {
                 if (currentHealthAction(manager, row.pluginId) == action) {
-                    when (action) {
-                        PluginHealthAction.ENABLE -> manager.enablePlugin(row.pluginId)
-                        PluginHealthAction.RELOAD -> manager.reloadPlugin(row.pluginId).map { Unit }
+                    // The delegate persists Enable and coordinates reload teardown and refresh.
+                    val succeeded = when (action) {
+                        PluginHealthAction.ENABLE -> delegate?.enablePlugin(row.pluginId) == true
+                        PluginHealthAction.RELOAD -> delegate?.reloadPlugin(row.pluginId) != null
                     }
+                    if (succeeded) Result.success(Unit) else Result.failure(IllegalStateException("Recovery failed"))
                 } else {
                     Result.failure(IllegalStateException("Plugin health changed"))
                 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
@@ -1,6 +1,9 @@
 package ai.rever.boss.components.plugin
 
 import ai.rever.boss.plugin.api.PluginLoaderDelegate
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import ai.rever.boss.plugin.sandbox.SandboxState
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
 import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
@@ -24,6 +27,7 @@ import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -35,7 +39,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+
+private val healthLogger = BossLogger.forComponent("PluginHealthCenter")
 
 /** A lifecycle status presented by the host without duplicating plugin state. */
 internal enum class PluginHealthStatus {
@@ -64,8 +71,7 @@ internal class PluginHealthOperationState {
 }
 
 @Composable
-internal fun rememberPluginHealthOperationState(): PluginHealthOperationState =
-    remember { PluginHealthOperationState() }
+internal fun rememberHealthOperation(): PluginHealthOperationState = remember { PluginHealthOperationState() }
 
 /** Host-owned operational surface for plugin status and existing safe recovery actions. */
 @Composable
@@ -74,14 +80,18 @@ internal fun PluginHealthCenterDialog(
     delegate: PluginLoaderDelegate?,
     onDismiss: () -> Unit,
 ) {
-    val pluginStates by (manager?.pluginStates ?: return).collectAsState()
-    val gates by PluginLoadGateRegistry.gates.collectAsState()
-    val crashedPluginIds = PluginCrashRegistry.crashedPlugins.keys
-    val inaccessible = manager.getInaccessiblePlugins().mapTo(mutableSetOf()) { it.pluginId }
-    val incompatible = pluginStates.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.isIncompatible(it) }
-    val rows = pluginHealthRows(pluginStates, gates, crashedPluginIds, inaccessible, incompatible)
+    if (manager == null) {
+        BossDialog(onDismissRequest = onDismiss) {
+            Column(Modifier.padding(20.dp)) {
+                Text("Plugin management is not available in this window yet.")
+                TextButton(onClick = onDismiss) { Text("Close") }
+            }
+        }
+        return
+    }
+    val rows = observeHealthRows(manager)
     val scope = rememberCoroutineScope()
-    val operation = rememberPluginHealthOperationState()
+    val operation = rememberHealthOperation()
 
     BossDialog(
         onDismissRequest = { if (operation.workingPluginId == null) onDismiss() },
@@ -115,6 +125,33 @@ internal fun PluginHealthCenterDialog(
             },
         )
     }
+}
+
+@Composable
+private fun observeHealthRows(manager: DynamicPluginManager): List<PluginHealthRow> {
+    val pluginStates by manager.pluginStates.collectAsState()
+    val gates by PluginLoadGateRegistry.gates.collectAsState()
+    val crashedPluginIds = PluginCrashRegistry.crashedPlugins.keys
+    val inaccessible = manager.getInaccessiblePlugins().mapTo(mutableSetOf()) { it.pluginId }
+    val incompatible =
+        (pluginStates.keys + crashedPluginIds).filterTo(mutableSetOf()) { PluginCrashRegistry.isIncompatible(it) }
+    val sandboxDisabled =
+        pluginStates.keys.filterTo(mutableSetOf()) { id ->
+            key(id) {
+                manager.sandboxManager
+                    .getSandbox(id)
+                    ?.state
+                    ?.collectAsState()
+                    ?.value == SandboxState.DISABLED
+            }
+        }
+    return pluginHealthRows(
+        healthStatesWithSandboxDisables(pluginStates, sandboxDisabled),
+        gates,
+        crashedPluginIds,
+        inaccessible,
+        incompatible,
+    )
 }
 
 @Composable
@@ -155,7 +192,7 @@ private fun PluginHealthHeader(actionError: String?) {
     )
     Spacer(Modifier.height(6.dp))
     Text(
-        text = "Current plugin lifecycle state. Recovery actions use the existing host flows.",
+        text = "See why a plugin is unavailable and recover it when possible.",
         color = BossTheme.colors.textSecondary,
         fontSize = 13.sp,
     )
@@ -186,6 +223,7 @@ private fun PluginHealthRows(
             PluginHealthRowCard(
                 row = row,
                 working = workingPluginId == row.pluginId,
+                actionsEnabled = workingPluginId == null,
                 onAction = { action -> onAction(row, action) },
             )
         }
@@ -200,24 +238,44 @@ private fun kotlinx.coroutines.CoroutineScope.launchHealthAction(
     onFinished: (String?) -> Unit,
 ) {
     launch {
-        val result =
-            runCatching {
-                if (currentHealthAction(manager, row.pluginId) == action) {
-                    // The delegate persists Enable and coordinates reload teardown and refresh.
-                    val succeeded =
-                        when (action) {
-                            PluginHealthAction.ENABLE -> delegate?.enablePlugin(row.pluginId) == true
-                            PluginHealthAction.RELOAD -> delegate?.reloadPlugin(row.pluginId) != null
-                        }
-                    if (succeeded) Result.success(Unit) else Result.failure(IllegalStateException("Recovery failed"))
-                } else {
-                    Result.failure(IllegalStateException("Plugin health changed"))
-                }
-            }.getOrElse { Result.failure(it) }
-        val verb = if (action == PluginHealthAction.ENABLE) "enable" else "reload"
-        onFinished(
-            if (result.isFailure) "Could not $verb this plugin. Check BOSS logs for details." else null,
+        healthLogger.info(
+            LogCategory.SYSTEM,
+            "Plugin health recovery requested",
+            mapOf("pluginId" to row.pluginId, "action" to action.name),
         )
+        if (currentHealthAction(manager, row.pluginId) != action) {
+            healthLogger.info(
+                LogCategory.SYSTEM,
+                "Plugin health changed before recovery",
+                mapOf("pluginId" to row.pluginId),
+            )
+            onFinished("Plugin state changed. Review its current status and try again.")
+            return@launch
+        }
+        if (delegate == null) {
+            healthLogger.warn(LogCategory.SYSTEM, "Plugin health recovery delegate unavailable")
+            onFinished("Plugin recovery is not available in this window yet.")
+            return@launch
+        }
+        val succeeded =
+            runCatching {
+                // The delegate persists Enable and coordinates reload teardown and refresh.
+                // Reload's uninstall already clears the old crash and quarantine markers.
+                when (action) {
+                    PluginHealthAction.ENABLE -> delegate.enablePlugin(row.pluginId)
+                    PluginHealthAction.RELOAD -> delegate.reloadPlugin(row.pluginId) != null
+                }
+            }.getOrElse {
+                if (it is CancellationException) throw it
+                healthLogger.warn(
+                    LogCategory.SYSTEM,
+                    "Plugin health recovery failed",
+                    mapOf("pluginId" to row.pluginId, "errorType" to it.javaClass.simpleName),
+                )
+                false
+            }
+        val verb = if (action == PluginHealthAction.ENABLE) "enable" else "reload"
+        onFinished(if (succeeded) null else "Could not $verb this plugin. Check BOSS logs for details.")
     }
 }
 
@@ -228,7 +286,11 @@ private fun currentHealthAction(
 ): PluginHealthAction? {
     val states = manager.pluginStates.value
     return pluginHealthRows(
-        pluginStates = states,
+        pluginStates =
+            healthStatesWithSandboxDisables(
+                states,
+                states.keys.filterTo(mutableSetOf()) { sandboxIsDisabled(manager, it) },
+            ),
         loadGates = PluginLoadGateRegistry.gates.value,
         crashedPluginIds = states.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.hasCrashed(it) },
         inaccessiblePluginIds = manager.getInaccessiblePlugins().mapTo(mutableSetOf()) { it.pluginId },
@@ -240,6 +302,7 @@ private fun currentHealthAction(
 private fun PluginHealthRowCard(
     row: PluginHealthRow,
     working: Boolean,
+    actionsEnabled: Boolean,
     onAction: (PluginHealthAction) -> Unit,
 ) {
     Card(backgroundColor = BossTheme.colors.raised, elevation = 0.dp) {
@@ -272,7 +335,7 @@ private fun PluginHealthRowCard(
                 Spacer(Modifier.width(12.dp))
                 Button(
                     onClick = { onAction(action) },
-                    enabled = !working,
+                    enabled = actionsEnabled,
                     colors = ButtonDefaults.buttonColors(backgroundColor = BossTheme.colors.signal),
                 ) {
                     if (working) {
@@ -295,3 +358,12 @@ private fun PluginHealthStatus.label(): String =
         PluginHealthStatus.NEEDS_ATTENTION -> "Needs attention"
         PluginHealthStatus.UNAVAILABLE -> "Unavailable"
     }
+
+private fun sandboxIsDisabled(
+    manager: DynamicPluginManager,
+    pluginId: String,
+): Boolean =
+    manager.sandboxManager
+        .getSandbox(pluginId)
+        ?.state
+        ?.value == SandboxState.DISABLED

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
@@ -64,7 +64,8 @@ internal class PluginHealthOperationState {
 }
 
 @Composable
-internal fun rememberPluginHealthOperationState(): PluginHealthOperationState = remember { PluginHealthOperationState() }
+internal fun rememberPluginHealthOperationState(): PluginHealthOperationState =
+    remember { PluginHealthOperationState() }
 
 /** Host-owned operational surface for plugin status and existing safe recovery actions. */
 @Composable
@@ -100,8 +101,7 @@ internal fun PluginHealthCenterDialog(
                 if (operation.workingPluginId == null) {
                     operation.workingPluginId = row.pluginId
                     operation.actionError = null
-                    launchHealthAction(
-                        scope = scope,
+                    scope.launchHealthAction(
                         manager = manager,
                         delegate = delegate,
                         row = row,
@@ -192,23 +192,23 @@ private fun PluginHealthRows(
     }
 }
 
-private fun launchHealthAction(
-    scope: kotlinx.coroutines.CoroutineScope,
+private fun kotlinx.coroutines.CoroutineScope.launchHealthAction(
     manager: DynamicPluginManager,
     delegate: PluginLoaderDelegate?,
     row: PluginHealthRow,
     action: PluginHealthAction,
     onFinished: (String?) -> Unit,
 ) {
-    scope.launch {
+    launch {
         val result =
             runCatching {
                 if (currentHealthAction(manager, row.pluginId) == action) {
                     // The delegate persists Enable and coordinates reload teardown and refresh.
-                    val succeeded = when (action) {
-                        PluginHealthAction.ENABLE -> delegate?.enablePlugin(row.pluginId) == true
-                        PluginHealthAction.RELOAD -> delegate?.reloadPlugin(row.pluginId) != null
-                    }
+                    val succeeded =
+                        when (action) {
+                            PluginHealthAction.ENABLE -> delegate?.enablePlugin(row.pluginId) == true
+                            PluginHealthAction.RELOAD -> delegate?.reloadPlugin(row.pluginId) != null
+                        }
                     if (succeeded) Result.success(Unit) else Result.failure(IllegalStateException("Recovery failed"))
                 } else {
                     Result.failure(IllegalStateException("Plugin health changed"))

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
@@ -290,7 +290,10 @@ private fun currentHealthAction(
             healthStatesWithSandboxDisables(
                 states,
                 states.keys.filterTo(mutableSetOf()) { id ->
-                    manager.sandboxManager.getSandbox(id)?.state?.value == SandboxState.DISABLED
+                    manager.sandboxManager
+                        .getSandbox(id)
+                        ?.state
+                        ?.value == SandboxState.DISABLED
                 },
             ),
         loadGates = PluginLoadGateRegistry.gates.value,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.plugin.sandbox.SandboxState
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
 import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.services.auth.AuthStateManager
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -132,25 +133,25 @@ private fun observeHealthRows(manager: DynamicPluginManager): List<PluginHealthR
     val pluginStates by manager.pluginStates.collectAsState()
     val gates by PluginLoadGateRegistry.gates.collectAsState()
     val crashedPluginIds = PluginCrashRegistry.crashedPlugins.keys
-    val inaccessible = manager.getInaccessiblePlugins().mapTo(mutableSetOf()) { it.pluginId }
-    val incompatible =
-        (pluginStates.keys + crashedPluginIds).filterTo(mutableSetOf()) { PluginCrashRegistry.isIncompatible(it) }
-    val sandboxDisabled =
-        pluginStates.keys.filterTo(mutableSetOf()) { id ->
-            key(id) {
+    val user by AuthStateManager.currentUser.collectAsState()
+    val inaccessible =
+        healthInaccessiblePluginIds(pluginStates, user?.isAdmin == true, user?.permissions?.toSet() ?: emptySet())
+    val incompatible by PluginCrashRegistry.incompatiblePlugins.collectAsState()
+    val sandboxDisabled = mutableSetOf<String>()
+    for (id in pluginStates.keys) {
+        key(id) {
+            val state =
                 manager.sandboxManager
                     .getSandbox(id)
                     ?.state
                     ?.collectAsState()
-                    ?.value == SandboxState.DISABLED
-            }
+                    ?.value
+            if (state == SandboxState.DISABLED) sandboxDisabled.add(id)
         }
-    return pluginHealthRows(
-        healthStatesWithSandboxDisables(pluginStates, sandboxDisabled),
-        gates,
-        crashedPluginIds,
-        inaccessible,
-        incompatible,
+    }
+    return healthRowsWithSandboxDisables(
+        pluginHealthRows(pluginStates, gates, crashedPluginIds, inaccessible, incompatible),
+        sandboxDisabled,
     )
 }
 
@@ -285,21 +286,17 @@ private fun currentHealthAction(
     pluginId: String,
 ): PluginHealthAction? {
     val states = manager.pluginStates.value
-    return pluginHealthRows(
-        pluginStates =
-            healthStatesWithSandboxDisables(
-                states,
-                states.keys.filterTo(mutableSetOf()) { id ->
-                    manager.sandboxManager
-                        .getSandbox(id)
-                        ?.state
-                        ?.value == SandboxState.DISABLED
-                },
-            ),
-        loadGates = PluginLoadGateRegistry.gates.value,
-        crashedPluginIds = states.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.hasCrashed(it) },
-        inaccessiblePluginIds = manager.getInaccessiblePlugins().mapTo(mutableSetOf()) { it.pluginId },
-        incompatiblePluginIds = states.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.isIncompatible(it) },
+    val user = AuthStateManager.currentUser.value
+    return healthRowsWithSandboxDisables(
+        pluginHealthRows(
+            pluginStates = states,
+            loadGates = PluginLoadGateRegistry.gates.value,
+            crashedPluginIds = states.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.hasCrashed(it) },
+            inaccessiblePluginIds =
+                healthInaccessiblePluginIds(states, user?.isAdmin == true, user?.permissions?.toSet() ?: emptySet()),
+            incompatiblePluginIds = PluginCrashRegistry.incompatiblePlugins.value,
+        ),
+        states.keys.filterTo(mutableSetOf()) { manager.sandboxManager.isPluginDisabled(it) },
     ).firstOrNull { it.pluginId == pluginId }?.action
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
@@ -360,12 +360,3 @@ private fun PluginHealthStatus.label(): String =
         PluginHealthStatus.NEEDS_ATTENTION -> "Needs attention"
         PluginHealthStatus.UNAVAILABLE -> "Unavailable"
     }
-
-private fun sandboxIsDisabled(
-    manager: DynamicPluginManager,
-    pluginId: String,
-): Boolean =
-    manager.sandboxManager
-        .getSandbox(pluginId)
-        ?.state
-        ?.value == SandboxState.DISABLED

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
@@ -1,0 +1,283 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
+import ai.rever.boss.plugin.ui.BossDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.launch
+
+/** A lifecycle status presented by the host without duplicating plugin state. */
+internal enum class PluginHealthStatus {
+    HEALTHY,
+    NEEDS_ATTENTION,
+    UNAVAILABLE,
+}
+
+/** Existing, deliberately narrow lifecycle operations that the center may invoke. */
+internal enum class PluginHealthAction {
+    ENABLE,
+    RELOAD,
+}
+
+internal data class PluginHealthRow(
+    val pluginId: String,
+    val displayName: String,
+    val status: PluginHealthStatus,
+    val detail: String,
+    val action: PluginHealthAction? = null,
+)
+
+/** Host-owned operational surface for plugin status and existing safe recovery actions. */
+@Composable
+internal fun PluginHealthCenterDialog(
+    manager: DynamicPluginManager?,
+    onDismiss: () -> Unit,
+) {
+    val pluginStates by (manager?.pluginStates ?: return).collectAsState()
+    val gates by PluginLoadGateRegistry.gates.collectAsState()
+    val crashedPluginIds = PluginCrashRegistry.crashedPlugins.keys
+    val inaccessible = manager.getInaccessiblePlugins().mapTo(mutableSetOf()) { it.pluginId }
+    val incompatible = pluginStates.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.isIncompatible(it) }
+    val rows = pluginHealthRows(pluginStates, gates, crashedPluginIds, inaccessible, incompatible)
+    val scope = rememberCoroutineScope()
+    var workingPluginId by mutableStateOf<String?>(null)
+    var actionError by mutableStateOf<String?>(null)
+
+    BossDialog(
+        onDismissRequest = { if (workingPluginId == null) onDismiss() },
+        properties =
+            DialogProperties(
+                dismissOnBackPress = workingPluginId == null,
+                dismissOnClickOutside = workingPluginId == null,
+                usePlatformDefaultWidth = false,
+            ),
+    ) {
+        PluginHealthCenterCard(
+            rows = rows,
+            actionError = actionError,
+            workingPluginId = workingPluginId,
+            onDismiss = onDismiss,
+            onAction = { row, action ->
+                if (workingPluginId == null) {
+                    workingPluginId = row.pluginId
+                    actionError = null
+                    launchHealthAction(
+                        scope = scope,
+                        manager = manager,
+                        row = row,
+                        action = action,
+                        onFinished = { error ->
+                            actionError = error
+                            workingPluginId = null
+                        },
+                    )
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun PluginHealthCenterCard(
+    rows: List<PluginHealthRow>,
+    actionError: String?,
+    workingPluginId: String?,
+    onDismiss: () -> Unit,
+    onAction: (PluginHealthRow, PluginHealthAction) -> Unit,
+) {
+    Card(
+        modifier = Modifier.width(560.dp),
+        shape = RoundedCornerShape(8.dp),
+        backgroundColor = BossTheme.colors.panel,
+        elevation = 8.dp,
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            PluginHealthHeader(actionError)
+            Spacer(Modifier.height(14.dp))
+            PluginHealthRows(rows, workingPluginId, onAction)
+            Spacer(Modifier.height(12.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss, enabled = workingPluginId == null) {
+                    Text("Close")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PluginHealthHeader(actionError: String?) {
+    Text(
+        text = "Plugin Health & Recovery",
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        color = BossTheme.colors.textPrimary,
+    )
+    Spacer(Modifier.height(6.dp))
+    Text(
+        text = "Current plugin lifecycle state. Recovery actions use the existing host flows.",
+        color = BossTheme.colors.textSecondary,
+        fontSize = 13.sp,
+    )
+    if (actionError != null) {
+        Spacer(Modifier.height(10.dp))
+        Text(actionError, color = BossTheme.colors.alert, fontSize = 13.sp)
+    }
+}
+
+@Composable
+private fun PluginHealthRows(
+    rows: List<PluginHealthRow>,
+    workingPluginId: String?,
+    onAction: (PluginHealthRow, PluginHealthAction) -> Unit,
+) {
+    if (rows.isEmpty()) {
+        Text(
+            text = "No plugins are currently registered in this window.",
+            color = BossTheme.colors.textSecondary,
+        )
+        return
+    }
+    LazyColumn(
+        modifier = Modifier.height(320.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(rows, key = { it.pluginId }) { row ->
+            PluginHealthRowCard(
+                row = row,
+                working = workingPluginId == row.pluginId,
+                onAction = { action -> onAction(row, action) },
+            )
+        }
+    }
+}
+
+private fun launchHealthAction(
+    scope: kotlinx.coroutines.CoroutineScope,
+    manager: DynamicPluginManager,
+    row: PluginHealthRow,
+    action: PluginHealthAction,
+    onFinished: (String?) -> Unit,
+) {
+    scope.launch {
+        val result =
+            runCatching {
+                if (currentHealthAction(manager, row.pluginId) == action) {
+                    when (action) {
+                        PluginHealthAction.ENABLE -> manager.enablePlugin(row.pluginId)
+                        PluginHealthAction.RELOAD -> manager.reloadPlugin(row.pluginId).map { Unit }
+                    }
+                } else {
+                    Result.failure(IllegalStateException("Plugin health changed"))
+                }
+            }.getOrElse { Result.failure(it) }
+        val verb = if (action == PluginHealthAction.ENABLE) "enable" else "reload"
+        onFinished(
+            if (result.isFailure) "Could not $verb this plugin. Check BOSS logs for details." else null,
+        )
+    }
+}
+
+/** Re-check action eligibility immediately before a user action can mutate plugin lifecycle. */
+private fun currentHealthAction(
+    manager: DynamicPluginManager,
+    pluginId: String,
+): PluginHealthAction? {
+    val states = manager.pluginStates.value
+    return pluginHealthRows(
+        pluginStates = states,
+        loadGates = PluginLoadGateRegistry.gates.value,
+        crashedPluginIds = states.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.hasCrashed(it) },
+        inaccessiblePluginIds = manager.getInaccessiblePlugins().mapTo(mutableSetOf()) { it.pluginId },
+        incompatiblePluginIds = states.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.isIncompatible(it) },
+    ).firstOrNull { it.pluginId == pluginId }?.action
+}
+
+@Composable
+private fun PluginHealthRowCard(
+    row: PluginHealthRow,
+    working: Boolean,
+    onAction: (PluginHealthAction) -> Unit,
+) {
+    Card(backgroundColor = BossTheme.colors.raised, elevation = 0.dp) {
+        Row(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    row.displayName,
+                    fontWeight = FontWeight.Medium,
+                    color = BossTheme.colors.textPrimary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    row.pluginId,
+                    color = BossTheme.colors.textSecondary,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    "${row.status.label()} · ${row.detail}",
+                    color = BossTheme.colors.textSecondary,
+                    fontSize = 12.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            row.action?.let { action ->
+                Spacer(Modifier.width(12.dp))
+                Button(
+                    onClick = { onAction(action) },
+                    enabled = !working,
+                    colors = ButtonDefaults.buttonColors(backgroundColor = BossTheme.colors.signal),
+                ) {
+                    if (working) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.height(16.dp).width(16.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Text(if (action == PluginHealthAction.ENABLE) "Enable" else "Reload")
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun PluginHealthStatus.label(): String =
+    when (this) {
+        PluginHealthStatus.HEALTHY -> "Healthy"
+        PluginHealthStatus.NEEDS_ATTENTION -> "Needs attention"
+        PluginHealthStatus.UNAVAILABLE -> "Unavailable"
+    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterDialog.kt
@@ -289,7 +289,9 @@ private fun currentHealthAction(
         pluginStates =
             healthStatesWithSandboxDisables(
                 states,
-                states.keys.filterTo(mutableSetOf()) { sandboxIsDisabled(manager, it) },
+                states.keys.filterTo(mutableSetOf()) { id ->
+                    manager.sandboxManager.getSandbox(id)?.state?.value == SandboxState.DISABLED
+                },
             ),
         loadGates = PluginLoadGateRegistry.gates.value,
         crashedPluginIds = states.keys.filterTo(mutableSetOf()) { PluginCrashRegistry.hasCrashed(it) },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
@@ -20,7 +20,7 @@ internal fun pluginHealthRows(
     incompatiblePluginIds: Set<String>,
 ): List<PluginHealthRow> {
     val pluginIds =
-        (pluginStates.keys + loadGates.keys + crashedPluginIds + incompatiblePluginIds).toSet()
+        (pluginStates.keys + loadGates.keys + crashedPluginIds + incompatiblePluginIds + inaccessiblePluginIds).toSet()
     return pluginIds
         .map { pluginId ->
             healthRowFor(
@@ -89,10 +89,14 @@ private fun infoRow(
             )
         }
 
-        info.errorMessage != null -> {
+        info.errorMessage != null || info.state == PluginState.ERROR -> {
             attentionRow(info, "The plugin reported a manager error.").copy(
                 action = reloadActionFor(info),
             )
+        }
+
+        info.state != PluginState.LOADED -> {
+            unavailableRow(info, "The plugin is not currently running.")
         }
 
         else -> {
@@ -165,7 +169,7 @@ private fun attentionRow(
 )
 
 private fun reloadActionFor(info: DynamicPluginInfo): PluginHealthAction? =
-    if (!HotReloadPolicy.requiresRestartInsteadOfHotReload(info.manifest.pluginId)) {
+    if (info.state == PluginState.LOADED && !HotReloadPolicy.requiresRestartInsteadOfHotReload(info.manifest.pluginId)) {
         PluginHealthAction.RELOAD
     } else {
         null

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
@@ -169,7 +169,10 @@ private fun attentionRow(
 )
 
 private fun reloadActionFor(info: DynamicPluginInfo): PluginHealthAction? =
-    if (info.state == PluginState.LOADED && !HotReloadPolicy.requiresRestartInsteadOfHotReload(info.manifest.pluginId)) {
+    if (
+        info.state == PluginState.LOADED &&
+        !HotReloadPolicy.requiresRestartInsteadOfHotReload(info.manifest.pluginId)
+    ) {
         PluginHealthAction.RELOAD
     } else {
         null

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
@@ -20,7 +20,7 @@ internal fun pluginHealthRows(
     incompatiblePluginIds: Set<String>,
 ): List<PluginHealthRow> {
     val pluginIds =
-        (pluginStates.keys + loadGates.keys + crashedPluginIds + incompatiblePluginIds + inaccessiblePluginIds).toSet()
+        (pluginStates.keys + loadGates.keys + crashedPluginIds + inaccessiblePluginIds).toSet()
     return pluginIds
         .map { pluginId ->
             healthRowFor(
@@ -91,7 +91,7 @@ private fun infoRow(
 
         info.errorMessage != null || info.state == PluginState.ERROR -> {
             attentionRow(info, "The plugin reported a manager error.").copy(
-                action = reloadActionFor(info),
+                action = reloadActionFor(input.pluginId, info),
             )
         }
 
@@ -168,10 +168,13 @@ private fun attentionRow(
     detail,
 )
 
-private fun reloadActionFor(info: DynamicPluginInfo): PluginHealthAction? =
+private fun reloadActionFor(
+    pluginId: String,
+    info: DynamicPluginInfo,
+): PluginHealthAction? =
     if (
         info.state == PluginState.LOADED &&
-        !HotReloadPolicy.requiresRestartInsteadOfHotReload(info.manifest.pluginId)
+        !HotReloadPolicy.requiresRestartInsteadOfHotReload(pluginId)
     ) {
         PluginHealthAction.RELOAD
     } else {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
@@ -1,0 +1,172 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PluginState
+
+private data class HealthRowInputs(
+    val pluginId: String,
+    val info: DynamicPluginInfo?,
+    val gate: PluginLoadGate?,
+    val crashed: Boolean,
+    val inaccessible: Boolean,
+    val incompatible: Boolean,
+)
+
+/** Maps existing manager, crash and load-gate facts into a compact operational view. */
+internal fun pluginHealthRows(
+    pluginStates: Map<String, DynamicPluginInfo>,
+    loadGates: Map<String, PluginLoadGate>,
+    crashedPluginIds: Set<String>,
+    inaccessiblePluginIds: Set<String>,
+    incompatiblePluginIds: Set<String>,
+): List<PluginHealthRow> {
+    val pluginIds =
+        (pluginStates.keys + loadGates.keys + crashedPluginIds + incompatiblePluginIds).toSet()
+    return pluginIds
+        .map { pluginId ->
+            healthRowFor(
+                HealthRowInputs(
+                    pluginId = pluginId,
+                    info = pluginStates[pluginId],
+                    gate = loadGates[pluginId],
+                    crashed = pluginId in crashedPluginIds,
+                    inaccessible = pluginId in inaccessiblePluginIds,
+                    incompatible = pluginId in incompatiblePluginIds,
+                ),
+            )
+        }.sortedWith(
+            compareBy<PluginHealthRow> { it.status != PluginHealthStatus.NEEDS_ATTENTION }
+                .thenBy { it.displayName.lowercase() },
+        )
+}
+
+private fun healthRowFor(input: HealthRowInputs): PluginHealthRow =
+    input.gate?.let { gateRow(input, it) }
+        ?: input.info?.let { infoRow(input, it) }
+        ?: unknownRow(input)
+
+private fun gateRow(
+    input: HealthRowInputs,
+    gate: PluginLoadGate,
+) = PluginHealthRow(
+    pluginId = input.pluginId,
+    displayName = input.info?.manifest?.displayName ?: gate.displayName,
+    status = PluginHealthStatus.NEEDS_ATTENTION,
+    detail =
+        when (gate) {
+            is PluginLoadGate.NeedsNewerHost -> "This plugin requires a newer BOSS version."
+            is PluginLoadGate.NeedsNewerApi -> "This plugin requires a newer plugin API version."
+            is PluginLoadGate.SignatureRejected -> "The plugin signature could not be verified."
+        },
+)
+
+private fun infoRow(
+    input: HealthRowInputs,
+    info: DynamicPluginInfo,
+): PluginHealthRow =
+    when {
+        input.inaccessible -> {
+            unavailableRow(info, "Access is required for this plugin.")
+        }
+
+        input.incompatible -> {
+            attentionRow(info, "This plugin is incompatible with the current runtime.")
+        }
+
+        input.crashed -> {
+            attentionRow(info, "The plugin needs recovery after an unexpected failure.").copy(
+                action =
+                    info
+                        .takeIf {
+                            it.state == PluginState.LOADED &&
+                                !HotReloadPolicy.requiresRestartInsteadOfHotReload(input.pluginId)
+                        }?.let { PluginHealthAction.RELOAD },
+            )
+        }
+
+        info.state == PluginState.DISABLED -> {
+            unavailableRow(info, "The plugin is disabled.").copy(
+                action = if (!info.enabled) PluginHealthAction.ENABLE else null,
+            )
+        }
+
+        info.errorMessage != null -> {
+            attentionRow(info, "The plugin reported a manager error.").copy(
+                action = reloadActionFor(info),
+            )
+        }
+
+        else -> {
+            PluginHealthRow(
+                info.manifest.pluginId,
+                info.manifest.displayName,
+                PluginHealthStatus.HEALTHY,
+                "Running normally.",
+            )
+        }
+    }
+
+private fun unknownRow(input: HealthRowInputs): PluginHealthRow =
+    when {
+        input.inaccessible -> {
+            PluginHealthRow(
+                input.pluginId,
+                input.pluginId,
+                PluginHealthStatus.UNAVAILABLE,
+                "Access is required for this plugin.",
+            )
+        }
+
+        input.incompatible -> {
+            PluginHealthRow(
+                input.pluginId,
+                input.pluginId,
+                PluginHealthStatus.NEEDS_ATTENTION,
+                "This plugin is incompatible with the current runtime.",
+            )
+        }
+
+        input.crashed -> {
+            PluginHealthRow(
+                input.pluginId,
+                input.pluginId,
+                PluginHealthStatus.NEEDS_ATTENTION,
+                "The plugin needs recovery after an unexpected failure.",
+            )
+        }
+
+        else -> {
+            PluginHealthRow(
+                input.pluginId,
+                input.pluginId,
+                PluginHealthStatus.UNAVAILABLE,
+                "Plugin information is unavailable.",
+            )
+        }
+    }
+
+private fun unavailableRow(
+    info: DynamicPluginInfo,
+    detail: String,
+) = PluginHealthRow(
+    info.manifest.pluginId,
+    info.manifest.displayName,
+    PluginHealthStatus.UNAVAILABLE,
+    detail,
+)
+
+private fun attentionRow(
+    info: DynamicPluginInfo,
+    detail: String,
+) = PluginHealthRow(
+    info.manifest.pluginId,
+    info.manifest.displayName,
+    PluginHealthStatus.NEEDS_ATTENTION,
+    detail,
+)
+
+private fun reloadActionFor(info: DynamicPluginInfo): PluginHealthAction? =
+    if (!HotReloadPolicy.requiresRestartInsteadOfHotReload(info.manifest.pluginId)) {
+        PluginHealthAction.RELOAD
+    } else {
+        null
+    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
@@ -41,7 +41,7 @@ internal fun pluginHealthRows(
 
 private fun healthRowFor(input: HealthRowInputs): PluginHealthRow =
     input.gate?.let { gateRow(input, it) }
-        ?: input.info?.let { infoRow(input, it) }
+        ?: input.info?.let { infoRow(input, it).copy(pluginId = input.pluginId) }
         ?: unknownRow(input)
 
 private fun gateRow(
@@ -178,15 +178,36 @@ private fun reloadActionFor(info: DynamicPluginInfo): PluginHealthAction? =
         null
     }
 
-/** Watchdog disables stop the sandbox without changing the manager's loaded entry. */
-internal fun healthStatesWithSandboxDisables(
-    states: Map<String, DynamicPluginInfo>,
+/** Watchdog stops retain registrations: recover through full reload, never bare enable. */
+internal fun healthRowsWithSandboxDisables(
+    rows: List<PluginHealthRow>,
     disabledPluginIds: Set<String>,
-): Map<String, DynamicPluginInfo> =
-    states.mapValues { (id, info) ->
-        if (id in disabledPluginIds && info.state == PluginState.LOADED) {
-            info.copy(state = PluginState.DISABLED, enabled = false)
+): List<PluginHealthRow> =
+    rows.map { row ->
+        if (row.pluginId in disabledPluginIds && row.status == PluginHealthStatus.HEALTHY) {
+            val requiresRestart = HotReloadPolicy.requiresRestartInsteadOfHotReload(row.pluginId)
+            row.copy(
+                status = PluginHealthStatus.NEEDS_ATTENTION,
+                detail =
+                    if (requiresRestart) {
+                        "Restart BOSS to recover this plugin."
+                    } else {
+                        "The plugin stopped and needs recovery."
+                    },
+                action = if (requiresRestart) null else PluginHealthAction.RELOAD,
+            )
         } else {
-            info
+            row
         }
     }
+
+/** Evaluate access directly, including the legacy admin-only gate omitted by permission banners. */
+internal fun healthInaccessiblePluginIds(
+    states: Map<String, DynamicPluginInfo>,
+    isAdmin: Boolean,
+    permissions: Set<String>,
+): Set<String> =
+    states
+        .filterValues { info ->
+            !pluginAccessAllowed(isAdmin, permissions, info.manifest.requiresAdmin, info.manifest.requiredPermissions)
+        }.keys

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginHealthRows.kt
@@ -177,3 +177,16 @@ private fun reloadActionFor(info: DynamicPluginInfo): PluginHealthAction? =
     } else {
         null
     }
+
+/** Watchdog disables stop the sandbox without changing the manager's loaded entry. */
+internal fun healthStatesWithSandboxDisables(
+    states: Map<String, DynamicPluginInfo>,
+    disabledPluginIds: Set<String>,
+): Map<String, DynamicPluginInfo> =
+    states.mapValues { (id, info) ->
+        if (id in disabledPluginIds && info.state == PluginState.LOADED) {
+            info.copy(state = PluginState.DISABLED, enabled = false)
+        } else {
+            info
+        }
+    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/MenuActionsHandler.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/MenuActionsHandler.kt
@@ -739,6 +739,14 @@ object MenuActionsHandler {
         _reloadAllPluginsEvents.tryEmit(windowId)
     }
 
+    private val _showPluginHealthCenterEvents = MutableSharedFlow<String>(extraBufferCapacity = 10)
+    val showPluginHealthCenterEvents: SharedFlow<String> = _showPluginHealthCenterEvents.asSharedFlow()
+
+    /** Open the host-owned Plugin Health & Recovery Center for one window. */
+    fun triggerShowPluginHealthCenter(windowId: String) {
+        _showPluginHealthCenterEvents.tryEmit(windowId)
+    }
+
     /**
      * Trigger the "Reload Panel" action for a specific panel in the specified window. Despite the
      * menu's wording this reloads the owning plugin's jar and resets its slots in every window.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -1048,6 +1048,13 @@ fun ApplicationScope.BossWindow(
                     },
                 )
 
+                Item(
+                    "Plugin Health & Recovery...",
+                    onClick = {
+                        MenuActionsHandler.triggerShowPluginHealthCenter(windowState.id)
+                    },
+                )
+
                 // Debug: Test crash reporter (Issue #543)
                 // This crashes during Compose composition to properly test the separate window crash dialog
                 Separator()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
@@ -1,0 +1,171 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.api.PluginState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class PluginHealthCenterTest {
+    @Test
+    fun `maps disabled plugin to existing enable action`() {
+        val row =
+            pluginHealthRows(
+                pluginStates = mapOf("notes" to plugin("notes", "Notes", PluginState.DISABLED)),
+                loadGates = emptyMap(),
+                crashedPluginIds = emptySet(),
+                inaccessiblePluginIds = emptySet(),
+                incompatiblePluginIds = emptySet(),
+            ).single()
+
+        assertEquals(PluginHealthStatus.UNAVAILABLE, row.status)
+        assertEquals(PluginHealthAction.ENABLE, row.action)
+    }
+
+    @Test
+    fun `load gate takes precedence over a manager state`() {
+        val row =
+            pluginHealthRows(
+                pluginStates = mapOf("notes" to plugin("notes", "Notes", PluginState.LOADED)),
+                loadGates = mapOf("notes" to PluginLoadGate.NeedsNewerHost("notes", "Notes", "9.5.0", "9.4.0")),
+                crashedPluginIds = emptySet(),
+                inaccessiblePluginIds = emptySet(),
+                incompatiblePluginIds = emptySet(),
+            ).single()
+
+        assertEquals(PluginHealthStatus.NEEDS_ATTENTION, row.status)
+        assertNull(row.action)
+        assertEquals("This plugin requires a newer BOSS version.", row.detail)
+    }
+
+    @Test
+    fun `inaccessible or incompatible plugin never receives a recovery action`() {
+        val state = mapOf("notes" to plugin("notes", "Notes", PluginState.DISABLED))
+
+        val inaccessible = pluginHealthRows(state, emptyMap(), emptySet(), setOf("notes"), emptySet()).single()
+        val incompatible = pluginHealthRows(state, emptyMap(), setOf("notes"), emptySet(), setOf("notes")).single()
+
+        assertEquals(PluginHealthStatus.UNAVAILABLE, inaccessible.status)
+        assertNull(inaccessible.action)
+        assertEquals(PluginHealthStatus.NEEDS_ATTENTION, incompatible.status)
+        assertNull(incompatible.action)
+    }
+
+    @Test
+    fun `crash state is classified without retaining or displaying its throwable`() {
+        val row =
+            pluginHealthRows(
+                mapOf("notes" to plugin("notes", "Notes", PluginState.LOADED)),
+                emptyMap(),
+                setOf("notes"),
+                emptySet(),
+                emptySet(),
+            ).single()
+
+        assertEquals(PluginHealthStatus.NEEDS_ATTENTION, row.status)
+        assertEquals(PluginHealthAction.RELOAD, row.action)
+        assertEquals("The plugin needs recovery after an unexpected failure.", row.detail)
+    }
+
+    @Test
+    fun `disabled plugin marked enabled is not offered a second enable`() {
+        val row =
+            pluginHealthRows(
+                mapOf("notes" to plugin("notes", "Notes", PluginState.DISABLED, enabled = true)),
+                emptyMap(),
+                emptySet(),
+                emptySet(),
+                emptySet(),
+            ).single()
+
+        assertEquals(PluginHealthStatus.UNAVAILABLE, row.status)
+        assertNull(row.action)
+    }
+
+    @Test
+    fun `manager errors are presented as a safe summary`() {
+        val row =
+            pluginHealthRows(
+                mapOf(
+                    "notes" to
+                        plugin(
+                            "notes",
+                            "Notes",
+                            PluginState.LOADED,
+                            errorMessage = "token=secret at C:/Users/Ayush/.boss",
+                        ),
+                ),
+                emptyMap(),
+                emptySet(),
+                emptySet(),
+                emptySet(),
+            ).single()
+
+        assertEquals("The plugin reported a manager error.", row.detail)
+        assertFalse(row.detail.contains("secret"))
+        assertFalse(row.detail.contains("C:/"))
+        assertEquals(PluginHealthAction.RELOAD, row.action)
+    }
+
+    @Test
+    fun `hot reload exclusions never receive a reload action`() {
+        val pluginId = TabTypePlugins.FLUCK_BROWSER
+        val row =
+            pluginHealthRows(
+                mapOf(
+                    pluginId to
+                        plugin(
+                            pluginId,
+                            "Browser",
+                            PluginState.LOADED,
+                            errorMessage = "failure",
+                        ),
+                ),
+                emptyMap(),
+                emptySet(),
+                emptySet(),
+                emptySet(),
+            ).single()
+
+        assertEquals(PluginHealthStatus.NEEDS_ATTENTION, row.status)
+        assertNull(row.action)
+    }
+
+    @Test
+    fun `signature gate keeps its internal reason out of the health center`() {
+        val row =
+            pluginHealthRows(
+                emptyMap(),
+                mapOf("notes" to PluginLoadGate.SignatureRejected("notes", "Notes", "signature path C:/private/token")),
+                emptySet(),
+                emptySet(),
+                emptySet(),
+            ).single()
+
+        assertEquals("The plugin signature could not be verified.", row.detail)
+        assertFalse(row.detail.contains("C:/"))
+    }
+
+    private fun plugin(
+        id: String,
+        name: String,
+        state: PluginState,
+        enabled: Boolean = state == PluginState.LOADED,
+        errorMessage: String? = null,
+    ) = DynamicPluginInfo(
+        manifest =
+            PluginManifest(
+                pluginId = id,
+                displayName = name,
+                version = "1.0.0",
+                apiVersion = "1.0.0",
+                mainClass = "com.example.$id",
+            ),
+        jarPath = "C:/plugins/$id.jar",
+        state = state,
+        loadedAt = 0,
+        enabled = enabled,
+        errorMessage = errorMessage,
+    )
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
@@ -147,6 +147,35 @@ class PluginHealthCenterTest {
         assertFalse(row.detail.contains("C:/"))
     }
 
+    @Test
+    fun `transitional and unloaded states are not healthy and cannot reload`() {
+        for (state in PluginState.entries.filter { it != PluginState.LOADED && it != PluginState.DISABLED }) {
+            val row = pluginHealthRows(
+                mapOf("notes" to plugin("notes", "Notes", state)),
+                emptyMap(), emptySet(), emptySet(), emptySet(),
+            ).single()
+            assertFalse(row.status == PluginHealthStatus.HEALTHY, state.name)
+            assertNull(row.action, state.name)
+        }
+    }
+
+    @Test
+    fun `an error during unloading cannot offer reload`() {
+        val row = pluginHealthRows(
+            mapOf("notes" to plugin("notes", "Notes", PluginState.UNLOADING, errorMessage = "error")),
+            emptyMap(), emptySet(), emptySet(), emptySet(),
+        ).single()
+        assertNull(row.action)
+    }
+
+    @Test
+    fun `access-only record remains visible without a loaded manager entry`() {
+        val row = pluginHealthRows(emptyMap(), emptyMap(), emptySet(), setOf("notes"), emptySet()).single()
+        assertEquals(PluginHealthStatus.UNAVAILABLE, row.status)
+        assertEquals("Access is required for this plugin.", row.detail)
+        assertNull(row.action)
+    }
+
     private fun plugin(
         id: String,
         name: String,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
@@ -221,6 +221,16 @@ class PluginHealthCenterTest {
         assertEquals(emptySet(), healthInaccessiblePluginIds(states, true, emptySet()))
     }
 
+    @Test
+    fun `process-wide incompatibility does not create rows for another window or an uninstalled plugin`() {
+        assertEquals(emptyList(), pluginHealthRows(emptyMap(), emptyMap(), emptySet(), emptySet(), setOf("other")))
+        val states = mapOf("notes" to plugin("notes", "Notes", PluginState.LOADED))
+        val rows = pluginHealthRows(states, emptyMap(), emptySet(), emptySet(), setOf("other", "notes"))
+        assertEquals(listOf("notes"), rows.map { it.pluginId })
+        assertEquals(PluginHealthStatus.NEEDS_ATTENTION, rows.single().status)
+        assertNull(rows.single().action)
+    }
+
     private fun plugin(
         id: String,
         name: String,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
@@ -150,10 +150,14 @@ class PluginHealthCenterTest {
     @Test
     fun `transitional and unloaded states are not healthy and cannot reload`() {
         for (state in PluginState.entries.filter { it != PluginState.LOADED && it != PluginState.DISABLED }) {
-            val row = pluginHealthRows(
-                mapOf("notes" to plugin("notes", "Notes", state)),
-                emptyMap(), emptySet(), emptySet(), emptySet(),
-            ).single()
+            val row =
+                pluginHealthRows(
+                    mapOf("notes" to plugin("notes", "Notes", state)),
+                    emptyMap(),
+                    emptySet(),
+                    emptySet(),
+                    emptySet(),
+                ).single()
             assertFalse(row.status == PluginHealthStatus.HEALTHY, state.name)
             assertNull(row.action, state.name)
         }
@@ -161,10 +165,14 @@ class PluginHealthCenterTest {
 
     @Test
     fun `an error during unloading cannot offer reload`() {
-        val row = pluginHealthRows(
-            mapOf("notes" to plugin("notes", "Notes", PluginState.UNLOADING, errorMessage = "error")),
-            emptyMap(), emptySet(), emptySet(), emptySet(),
-        ).single()
+        val row =
+            pluginHealthRows(
+                mapOf("notes" to plugin("notes", "Notes", PluginState.UNLOADING, errorMessage = "error")),
+                emptyMap(),
+                emptySet(),
+                emptySet(),
+                emptySet(),
+            ).single()
         assertNull(row.action)
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
@@ -184,6 +184,22 @@ class PluginHealthCenterTest {
         assertNull(row.action)
     }
 
+    @Test
+    fun `watchdog disabled sandbox is not reported as healthy by its loaded manager entry`() {
+        val states = mapOf("notes" to plugin("notes", "Notes", PluginState.LOADED))
+        val row =
+            pluginHealthRows(
+                healthStatesWithSandboxDisables(states, setOf("notes")),
+                emptyMap(),
+                emptySet(),
+                emptySet(),
+                emptySet(),
+            ).single()
+        assertEquals(PluginHealthStatus.UNAVAILABLE, row.status)
+        assertEquals(PluginHealthAction.ENABLE, row.action)
+        assertEquals(states, healthStatesWithSandboxDisables(states, emptySet()))
+    }
+
     private fun plugin(
         id: String,
         name: String,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthCenterTest.kt
@@ -185,19 +185,40 @@ class PluginHealthCenterTest {
     }
 
     @Test
-    fun `watchdog disabled sandbox is not reported as healthy by its loaded manager entry`() {
+    fun `watchdog disabled sandbox offers full reload instead of registering twice`() {
         val states = mapOf("notes" to plugin("notes", "Notes", PluginState.LOADED))
-        val row =
-            pluginHealthRows(
-                healthStatesWithSandboxDisables(states, setOf("notes")),
-                emptyMap(),
-                emptySet(),
-                emptySet(),
-                emptySet(),
-            ).single()
-        assertEquals(PluginHealthStatus.UNAVAILABLE, row.status)
-        assertEquals(PluginHealthAction.ENABLE, row.action)
-        assertEquals(states, healthStatesWithSandboxDisables(states, emptySet()))
+        val healthy = pluginHealthRows(states, emptyMap(), emptySet(), emptySet(), emptySet())
+        val row = healthRowsWithSandboxDisables(healthy, setOf("notes")).single()
+        assertEquals(PluginHealthStatus.NEEDS_ATTENTION, row.status)
+        assertEquals(PluginHealthAction.RELOAD, row.action)
+        assertEquals(healthy, healthRowsWithSandboxDisables(healthy, emptySet()))
+    }
+
+    @Test
+    fun `watchdog recovery respects native restart and access restrictions`() {
+        val id = HotReloadPolicy.NOT_HOT_RELOADABLE.first()
+        val states = mapOf(id to plugin(id, "Browser", PluginState.LOADED))
+        val healthy = pluginHealthRows(states, emptyMap(), emptySet(), emptySet(), emptySet())
+        val row = healthRowsWithSandboxDisables(healthy, setOf(id)).single()
+        assertNull(row.action)
+        assertEquals("Restart BOSS to recover this plugin.", row.detail)
+        val hidden = pluginHealthRows(states, emptyMap(), emptySet(), setOf(id), emptySet())
+        assertEquals(hidden, healthRowsWithSandboxDisables(hidden, setOf(id)))
+    }
+
+    @Test
+    fun `admin-only entries explain access and preserve manager row identity`() {
+        val info =
+            plugin("manifest-id", "Admin", PluginState.DISABLED).let {
+                it.copy(manifest = it.manifest.copy(requiresAdmin = true), enabled = true)
+            }
+        val states = mapOf("manager-id" to info)
+        val hidden = healthInaccessiblePluginIds(states, false, emptySet())
+        val row = pluginHealthRows(states, emptyMap(), emptySet(), hidden, emptySet()).single()
+        assertEquals("manager-id", row.pluginId)
+        assertEquals("Access is required for this plugin.", row.detail)
+        assertNull(row.action)
+        assertEquals(emptySet(), healthInaccessiblePluginIds(states, true, emptySet()))
     }
 
     private fun plugin(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthOperationStateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthOperationStateTest.kt
@@ -17,7 +17,7 @@ class PluginHealthOperationStateTest {
         val revision = mutableStateOf(0)
         lateinit var current: PluginHealthOperationState
         rule.setContent {
-            current = rememberPluginHealthOperationState()
+            current = rememberHealthOperation()
             Text("Revision ${revision.value}, busy ${current.workingPluginId}, error ${current.actionError}")
         }
         rule.waitForIdle()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthOperationStateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginHealthOperationStateTest.kt
@@ -1,0 +1,43 @@
+package ai.rever.boss.components.plugin
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class PluginHealthOperationStateTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun `busy and failure feedback survive lifecycle recomposition`() {
+        val revision = mutableStateOf(0)
+        lateinit var current: PluginHealthOperationState
+        rule.setContent {
+            current = rememberPluginHealthOperationState()
+            Text("Revision ${revision.value}, busy ${current.workingPluginId}, error ${current.actionError}")
+        }
+        rule.waitForIdle()
+        val original = current
+        rule.runOnIdle {
+            current.workingPluginId = "notes"
+            revision.value++
+        }
+        rule.waitForIdle()
+        rule.runOnIdle {
+            assertSame(original, current)
+            assertEquals("notes", current.workingPluginId)
+            current.workingPluginId = null
+            current.actionError = "Could not enable this plugin."
+            revision.value++
+        }
+        rule.waitForIdle()
+        rule.runOnIdle {
+            assertSame(original, current)
+            assertEquals("Could not enable this plugin.", current.actionError)
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginSandboxUnloadAwaitTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginSandboxUnloadAwaitTest.kt
@@ -1,0 +1,79 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PanelRegistry
+import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.api.PluginType
+import ai.rever.boss.plugin.api.TabRegistry
+import ai.rever.boss.plugin.sandbox.PluginSandboxManager
+import ai.rever.boss.plugin.sandbox.PluginSandboxManagerImpl
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PluginSandboxUnloadAwaitTest {
+    @Test
+    fun `uninstall waits for sandbox teardown before reporting reload can proceed`() =
+        runBlocking {
+            val real = PluginSandboxManagerImpl()
+            val started = CompletableDeferred<Unit>()
+            val release = CompletableDeferred<Unit>()
+            val sandboxManager =
+                object : PluginSandboxManager by real {
+                    override suspend fun removeSandbox(pluginId: String) {
+                        started.complete(Unit)
+                        release.await()
+                        real.removeSandbox(pluginId)
+                    }
+                }
+            val manager =
+                DynamicPluginManager(
+                    PanelRegistry(),
+                    TabRegistry(),
+                    sandboxManager,
+                    createSandboxedContext = { _, _ -> error("No plugin is loaded in this fixture") },
+                )
+            val id = "com.example.await-removal"
+            val info =
+                DynamicPluginInfo(
+                    manifest =
+                        PluginManifest(
+                            pluginId = id,
+                            displayName = "Await removal",
+                            version = "1.0.0",
+                            apiVersion = "1.0",
+                            mainClass = "example.Plugin",
+                            type = PluginType.PANEL,
+                        ),
+                    jarPath = "/unused.jar",
+                    state = PluginState.ERROR,
+                    loadedAt = 0L,
+                    enabled = false,
+                )
+            // Reproduce the existing unload-with-state-only path without loading a real plugin JAR.
+            manager.javaClass
+                .getDeclaredMethod("updatePluginState", String::class.java, DynamicPluginInfo::class.java)
+                .apply {
+                    isAccessible = true
+                    invoke(manager, id, info)
+                }
+            val uninstall = async(start = CoroutineStart.UNDISPATCHED) { manager.uninstallPlugin(id, force = true) }
+            try {
+                withTimeout(5_000) { started.await() }
+                assertFalse(uninstall.isCompleted, "reload must not overtake its sandbox removal")
+                release.complete(Unit)
+                assertTrue(withTimeout(5_000) { uninstall.await() }.isSuccess)
+                assertFalse(manager.isInstalled(id))
+            } finally {
+                release.complete(Unit)
+                uninstall.join()
+                manager.disposeWindow()
+                real.dispose()
+            }
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginSandboxUnloadAwaitTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginSandboxUnloadAwaitTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -23,6 +24,40 @@ class PluginSandboxUnloadAwaitTest {
 
     @Test
     fun `caller cancellation cannot abandon destructive cleanup`() = verifyRemoval(cancelCaller = true)
+
+    @Test
+    fun `cancellation waiting for cleanup lock refreshes surviving panels`() =
+        runBlocking {
+            val sandboxManager = PluginSandboxManagerImpl()
+            val manager =
+                DynamicPluginManager(
+                    PanelRegistry(),
+                    TabRegistry(),
+                    sandboxManager,
+                    createSandboxedContext = { _, _ -> error("No plugin is loaded in this fixture") },
+                )
+            val lock =
+                manager.javaClass
+                    .getDeclaredField("mutex")
+                    .apply { isAccessible = true }
+                    .get(manager) as Mutex
+            val previousRefresh = DynamicPluginManager.pluginPanelsRefresh
+            var refreshed = false
+            DynamicPluginManager.pluginPanelsRefresh = { id, _ -> if (id == "waiting-plugin") refreshed = true }
+            lock.lock()
+            val uninstall = async(start = CoroutineStart.UNDISPATCHED) { manager.uninstallPlugin("waiting-plugin") }
+            try {
+                assertFalse(uninstall.isCompleted)
+                uninstall.cancel()
+                withTimeout(5_000) { uninstall.join() }
+                assertTrue(refreshed, "Cancellation must compensate panel detachment before lock acquisition")
+            } finally {
+                lock.unlock()
+                DynamicPluginManager.pluginPanelsRefresh = previousRefresh
+                manager.disposeWindow()
+                sandboxManager.dispose()
+            }
+        }
 
     private fun verifyRemoval(cancelCaller: Boolean) =
         runBlocking {
@@ -57,7 +92,7 @@ class PluginSandboxUnloadAwaitTest {
             val uninstall = async(start = CoroutineStart.UNDISPATCHED) { manager.uninstallPlugin(id, force = true) }
             try {
                 withTimeout(5_000) { started.await() }
-                assertFalse(uninstall.isCompleted, "reload must not overtake its sandbox removal")
+                assertFalse(uninstall.isCompleted, "uninstall must await its sandbox removal")
                 if (cancelCaller) uninstall.cancel()
                 release.complete(Unit)
                 if (cancelCaller) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginSandboxUnloadAwaitTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginSandboxUnloadAwaitTest.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.plugin.api.PluginType
 import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.sandbox.PluginSandboxManager
 import ai.rever.boss.plugin.sandbox.PluginSandboxManagerImpl
+import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
@@ -18,7 +19,12 @@ import kotlin.test.assertTrue
 
 class PluginSandboxUnloadAwaitTest {
     @Test
-    fun `uninstall waits for sandbox teardown before reporting reload can proceed`() =
+    fun `uninstall awaits sandbox teardown before returning`() = verifyRemoval(cancelCaller = false)
+
+    @Test
+    fun `caller cancellation cannot abandon destructive cleanup`() = verifyRemoval(cancelCaller = true)
+
+    private fun verifyRemoval(cancelCaller: Boolean) =
         runBlocking {
             val real = PluginSandboxManagerImpl()
             val started = CompletableDeferred<Unit>()
@@ -39,22 +45,7 @@ class PluginSandboxUnloadAwaitTest {
                     createSandboxedContext = { _, _ -> error("No plugin is loaded in this fixture") },
                 )
             val id = "com.example.await-removal"
-            val info =
-                DynamicPluginInfo(
-                    manifest =
-                        PluginManifest(
-                            pluginId = id,
-                            displayName = "Await removal",
-                            version = "1.0.0",
-                            apiVersion = "1.0",
-                            mainClass = "example.Plugin",
-                            type = PluginType.PANEL,
-                        ),
-                    jarPath = "/unused.jar",
-                    state = PluginState.ERROR,
-                    loadedAt = 0L,
-                    enabled = false,
-                )
+            val info = unloadedInfo(id)
             // Reproduce the existing unload-with-state-only path without loading a real plugin JAR.
             manager.javaClass
                 .getDeclaredMethod("updatePluginState", String::class.java, DynamicPluginInfo::class.java)
@@ -62,18 +53,44 @@ class PluginSandboxUnloadAwaitTest {
                     isAccessible = true
                     invoke(manager, id, info)
                 }
+            PluginCrashRegistry.markIncompatible(id)
             val uninstall = async(start = CoroutineStart.UNDISPATCHED) { manager.uninstallPlugin(id, force = true) }
             try {
                 withTimeout(5_000) { started.await() }
                 assertFalse(uninstall.isCompleted, "reload must not overtake its sandbox removal")
+                if (cancelCaller) uninstall.cancel()
                 release.complete(Unit)
-                assertTrue(withTimeout(5_000) { uninstall.await() }.isSuccess)
+                if (cancelCaller) {
+                    withTimeout(5_000) { uninstall.join() }
+                    assertTrue(uninstall.isCancelled)
+                } else {
+                    assertTrue(withTimeout(5_000) { uninstall.await() }.isSuccess)
+                }
                 assertFalse(manager.isInstalled(id))
+                assertFalse(PluginCrashRegistry.isIncompatible(id))
             } finally {
                 release.complete(Unit)
                 uninstall.join()
                 manager.disposeWindow()
                 real.dispose()
+                PluginCrashRegistry.clearIncompatible(id)
             }
         }
+
+    private fun unloadedInfo(id: String): DynamicPluginInfo =
+        DynamicPluginInfo(
+            manifest =
+                PluginManifest(
+                    pluginId = id,
+                    displayName = "Await removal",
+                    version = "1.0.0",
+                    apiVersion = "1.0",
+                    mainClass = "example.Plugin",
+                    type = PluginType.PANEL,
+                ),
+            jarPath = "/unused.jar",
+            state = PluginState.ERROR,
+            loadedAt = 0L,
+            enabled = false,
+        )
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginSandboxUnloadAwaitTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginSandboxUnloadAwaitTest.kt
@@ -59,6 +59,42 @@ class PluginSandboxUnloadAwaitTest {
             }
         }
 
+    @Test
+    fun `cancellation during UI disposal cannot proceed into destructive cleanup`() =
+        runBlocking {
+            val sandboxManager = PluginSandboxManagerImpl()
+            val manager =
+                DynamicPluginManager(
+                    PanelRegistry(),
+                    TabRegistry(),
+                    sandboxManager,
+                    createSandboxedContext = { _, _ -> error("No plugin is loaded in this fixture") },
+                )
+            val previousTeardown = DynamicPluginManager.pluginTabsTeardown
+            val started = CompletableDeferred<Unit>()
+            val disposal = CompletableDeferred<Unit>()
+            var proceeded = false
+            DynamicPluginManager.pluginTabsTeardown = {
+                started.complete(Unit)
+                disposal.await()
+            }
+            val teardown =
+                async(start = CoroutineStart.UNDISPATCHED) {
+                    manager.teardownPluginTabsForUnload("disposal-plugin")
+                    proceeded = true
+                }
+            try {
+                withTimeout(5_000) { started.await() }
+                teardown.cancel()
+                withTimeout(5_000) { teardown.join() }
+                assertFalse(proceeded, "Cancelled disposal must propagate before acquiring even an uncontended lock")
+            } finally {
+                DynamicPluginManager.pluginTabsTeardown = previousTeardown
+                manager.disposeWindow()
+                sandboxManager.dispose()
+            }
+        }
+
     private fun verifyRemoval(cancelCaller: Boolean) =
         runBlocking {
             val real = PluginSandboxManagerImpl()

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -15,6 +15,9 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -240,19 +243,20 @@ object PluginCrashRegistry {
      * Persists across crash clear/tab close cycles so the DISABLED state fallback
      * can show the "incompatible" variant.
      */
-    private val _incompatiblePlugins = ConcurrentHashMap.newKeySet<String>()
+    private val _incompatiblePlugins = MutableStateFlow<Set<String>>(emptySet())
+    val incompatiblePlugins = _incompatiblePlugins.asStateFlow()
 
     /** Mark a plugin as incompatible (called from sandbox when binary incompatibility is detected). */
     fun markIncompatible(pluginId: String) {
-        _incompatiblePlugins.add(pluginId)
+        _incompatiblePlugins.update { it + pluginId }
     }
 
     /** Check if a plugin was disabled due to binary incompatibility. */
-    fun isIncompatible(pluginId: String): Boolean = _incompatiblePlugins.contains(pluginId)
+    fun isIncompatible(pluginId: String): Boolean = pluginId in _incompatiblePlugins.value
 
     /** Clear incompatible state (e.g., after plugin update). */
     fun clearIncompatible(pluginId: String) {
-        _incompatiblePlugins.remove(pluginId)
+        _incompatiblePlugins.update { it - pluginId }
     }
 }
 

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -384,10 +384,10 @@ class InProcessPluginSandbox(
      * `rememberCoroutineScope`, so closing the tab or switching side panels
      * during the up-to-two-second `awaitTermination` cancelled exactly here.
      */
-    override suspend fun restart(): Result<Unit> {
+    override suspend fun restart(): Result<Unit> =
         if (disabled.get()) {
-            return Result.failure(IllegalStateException("Plugin sandbox is disabled"))
-        }
+            Result.failure(IllegalStateException("Plugin sandbox is disabled"))
+        } else {
         logger.info(
             LogCategory.SYSTEM,
             "Restarting plugin sandbox",
@@ -397,36 +397,33 @@ class InProcessPluginSandbox(
             ),
         )
 
-        val retiredExecutor =
-            runCatching { swapInFreshRuntime() }
-                .getOrElse { error ->
-                    // Only reachable if the fresh pool cannot be created at all.
-                    // UNHEALTHY rather than RESTARTING because the watchdog
-                    // still looks at UNHEALTHY, so a sandbox this failed on can
-                    // still be seen and retried.
-                    _state.value = SandboxState.UNHEALTHY
-                    logger.error(
-                        LogCategory.SYSTEM,
-                        "Failed to restart plugin sandbox",
-                        mapOf(
-                            "pluginId" to pluginId,
-                        ),
-                        error,
-                    )
-                    return Result.failure(error)
-                }
+        val swap = runCatching { swapInFreshRuntime() }
+        val retiredExecutor = swap.getOrNull()
+        when {
+            swap.isFailure -> {
+                _state.value = SandboxState.UNHEALTHY
+                val error = requireNotNull(swap.exceptionOrNull())
+                logger.error(
+                    LogCategory.SYSTEM,
+                    "Failed to restart plugin sandbox",
+                    mapOf("pluginId" to pluginId),
+                    error,
+                )
+                Result.failure(error)
+            }
 
-        if (retiredExecutor == null) {
-            return Result.failure(IllegalStateException("Plugin sandbox was disabled during restart"))
-        }
+            retiredExecutor == null -> {
+                Result.failure(IllegalStateException("Plugin sandbox was disabled during restart"))
+            }
 
-        logger.info(
+            else -> {
+                logger.info(
             LogCategory.SYSTEM,
             "Plugin sandbox restarted successfully",
             mapOf(
                 "pluginId" to pluginId,
             ),
-        )
+                )
 
         // Cleanup of the pool the plugin no longer runs on. It has already had
         // shutdown() called under the lock, so it drains either way; this only
@@ -434,8 +431,10 @@ class InProcessPluginSandbox(
         // here is allowed to propagate - the sandbox is already running, and
         // swallowing a CancellationException into Result.failure would report a
         // restart that did happen as one that did not.
-        shutdownExecutor(retiredExecutor)
-        return Result.success(Unit)
+                shutdownExecutor(retiredExecutor)
+                Result.success(Unit)
+            }
+        }
     }
 
     /**

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -388,54 +388,54 @@ class InProcessPluginSandbox(
         if (disabled.get()) {
             Result.failure(IllegalStateException("Plugin sandbox is disabled"))
         } else {
-        logger.info(
-            LogCategory.SYSTEM,
-            "Restarting plugin sandbox",
-            mapOf(
-                "pluginId" to pluginId,
-                "restartAttempt" to (_healthMetrics.value.restartAttempts + 1),
-            ),
-        )
+            logger.info(
+                LogCategory.SYSTEM,
+                "Restarting plugin sandbox",
+                mapOf(
+                    "pluginId" to pluginId,
+                    "restartAttempt" to (_healthMetrics.value.restartAttempts + 1),
+                ),
+            )
 
-        val swap = runCatching { swapInFreshRuntime() }
-        val retiredExecutor = swap.getOrNull()
-        when {
-            swap.isFailure -> {
-                _state.value = SandboxState.UNHEALTHY
-                val error = requireNotNull(swap.exceptionOrNull())
-                logger.error(
-                    LogCategory.SYSTEM,
-                    "Failed to restart plugin sandbox",
-                    mapOf("pluginId" to pluginId),
-                    error,
-                )
-                Result.failure(error)
-            }
+            val swap = runCatching { swapInFreshRuntime() }
+            val retiredExecutor = swap.getOrNull()
+            when {
+                swap.isFailure -> {
+                    _state.value = SandboxState.UNHEALTHY
+                    val error = requireNotNull(swap.exceptionOrNull())
+                    logger.error(
+                        LogCategory.SYSTEM,
+                        "Failed to restart plugin sandbox",
+                        mapOf("pluginId" to pluginId),
+                        error,
+                    )
+                    Result.failure(error)
+                }
 
-            retiredExecutor == null -> {
-                Result.failure(IllegalStateException("Plugin sandbox was disabled during restart"))
-            }
+                retiredExecutor == null -> {
+                    Result.failure(IllegalStateException("Plugin sandbox was disabled during restart"))
+                }
 
-            else -> {
-                logger.info(
-            LogCategory.SYSTEM,
-            "Plugin sandbox restarted successfully",
-            mapOf(
-                "pluginId" to pluginId,
-            ),
-                )
+                else -> {
+                    logger.info(
+                        LogCategory.SYSTEM,
+                        "Plugin sandbox restarted successfully",
+                        mapOf(
+                            "pluginId" to pluginId,
+                        ),
+                    )
 
-        // Cleanup of the pool the plugin no longer runs on. It has already had
-        // shutdown() called under the lock, so it drains either way; this only
-        // waits for it and force-kills a pool that will not go. Cancellation
-        // here is allowed to propagate - the sandbox is already running, and
-        // swallowing a CancellationException into Result.failure would report a
-        // restart that did happen as one that did not.
-                shutdownExecutor(retiredExecutor)
-                Result.success(Unit)
+                    // Cleanup of the pool the plugin no longer runs on. It has already had
+                    // shutdown() called under the lock, so it drains either way; this only
+                    // waits for it and force-kills a pool that will not go. Cancellation
+                    // here is allowed to propagate - the sandbox is already running, and
+                    // swallowing a CancellationException into Result.failure would report a
+                    // restart that did happen as one that did not.
+                    shutdownExecutor(retiredExecutor)
+                    Result.success(Unit)
+                }
             }
         }
-    }
 
     /**
      * Swap in a fresh pool and bring the sandbox back to [SandboxState.RUNNING].

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -472,15 +472,14 @@ class InProcessPluginSandbox(
             // Under the lock, so a concurrent stop() cannot capture the
             // pool this restart just installed and retire it instead.
             retiredExecutor.shutdown()
+            // Publish the running generation under the same lock that accepts
+            // a restart. Otherwise setDisabled() can win between the check and
+            // this state write, leaving a disabled sandbox reporting RUNNING.
+            _healthMetrics.update { it.withSuccessfulRestart() }
+            _state.value = SandboxState.RUNNING
+            isRunning.set(true)
+            startHeartbeatJob()
         }
-
-        // Mark as running with successful restart metrics
-        _healthMetrics.update { it.withSuccessfulRestart() }
-        _state.value = SandboxState.RUNNING
-        isRunning.set(true)
-
-        // Start automatic heartbeat recording
-        startHeartbeatJob()
 
         return retiredExecutor
     }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -40,6 +40,7 @@ class InProcessPluginSandbox(
     /** Readable by the manager, which enforces this plugin's restart budget. */
     internal val config: SandboxConfig = SandboxConfig(),
 ) : PluginSandbox {
+    private val disabled = AtomicBoolean(false)
     private val logger = BossLogger.forComponent("InProcessPluginSandbox")
 
     // State management
@@ -384,6 +385,9 @@ class InProcessPluginSandbox(
      * during the up-to-two-second `awaitTermination` cancelled exactly here.
      */
     override suspend fun restart(): Result<Unit> {
+        if (disabled.get()) {
+            return Result.failure(IllegalStateException("Plugin sandbox is disabled"))
+        }
         logger.info(
             LogCategory.SYSTEM,
             "Restarting plugin sandbox",
@@ -412,6 +416,10 @@ class InProcessPluginSandbox(
                     return Result.failure(error)
                 }
 
+        if (retiredExecutor == null) {
+            return Result.failure(IllegalStateException("Plugin sandbox was disabled during restart"))
+        }
+
         logger.info(
             LogCategory.SYSTEM,
             "Plugin sandbox restarted successfully",
@@ -439,19 +447,19 @@ class InProcessPluginSandbox(
      *
      * @return the retired pool, for the caller to wait on.
      */
-    private fun swapInFreshRuntime(): ExecutorService {
-        _state.value = SandboxState.RESTARTING
-
-        // Record the crash
-        _healthMetrics.update { it.withCrash() }
-
-        // Cancel heartbeat job
-        heartbeatJob?.cancel()
-        heartbeatJob = null
-
+    private fun swapInFreshRuntime(): ExecutorService? {
         // Synchronize executor/job swap to prevent other threads from accessing stale references
         val retiredExecutor: ExecutorService
         synchronized(restartLock) {
+            if (disabled.get()) return null
+            _state.value = SandboxState.RESTARTING
+
+            // Record the crash
+            _healthMetrics.update { it.withCrash() }
+
+            // Cancel heartbeat job
+            heartbeatJob?.cancel()
+            heartbeatJob = null
             // Cancel the plugin's in-flight coroutines and re-arm the scope
             // for new work. The scope object itself is deliberately kept -
             // see the note on [sandboxScope].
@@ -591,7 +599,17 @@ class InProcessPluginSandbox(
                 "pluginId" to pluginId,
             ),
         )
-        _state.value = SandboxState.DISABLED
+        synchronized(restartLock) {
+            disabled.set(true)
+            _state.value = SandboxState.DISABLED
+        }
+    }
+
+    /** Only the manager's explicit enable path may re-arm a disabled sandbox. */
+    internal fun clearDisabledForEnable() {
+        synchronized(restartLock) {
+            disabled.set(false)
+        }
     }
 
     /**

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -173,6 +173,7 @@ interface PluginSandboxListener {
  */
 class PluginSandboxManagerImpl(
     private val defaultConfig: SandboxConfig = SandboxConfig(),
+    private val awaitRestartBackoff: suspend (Long) -> Unit = { delay -> kotlinx.coroutines.delay(delay) },
 ) : PluginSandboxManager {
     private val logger = BossLogger.forComponent("PluginSandboxManager")
 
@@ -417,6 +418,11 @@ class PluginSandboxManagerImpl(
             sandboxes[pluginId]
                 ?: return Result.failure(IllegalArgumentException("No sandbox found for plugin: $pluginId"))
 
+        return restartSandbox(sandbox)
+    }
+
+    private suspend fun restartSandbox(sandbox: InProcessPluginSandbox): Result<Unit> {
+        val pluginId = sandbox.pluginId
         logger.info(
             LogCategory.SYSTEM,
             "Restarting plugin",
@@ -446,6 +452,23 @@ class PluginSandboxManagerImpl(
         }
     }
 
+    /** Admit a delayed watchdog restart only for the sandbox generation that scheduled it. */
+    private suspend fun restartIfCurrentAndEnabled(sandbox: InProcessPluginSandbox): Result<Unit> {
+        val admitted =
+            synchronized(sandboxes) {
+                sandboxes[sandbox.pluginId] === sandbox && sandbox.pluginId !in disabledPlugins
+            }
+        if (!admitted) {
+            logger.info(
+                LogCategory.SYSTEM,
+                "Skipping stale plugin watchdog restart",
+                mapOf("pluginId" to sandbox.pluginId),
+            )
+            return Result.failure(IllegalStateException("Plugin sandbox restart is no longer current"))
+        }
+        return restartSandbox(sandbox)
+    }
+
     override suspend fun disablePlugin(pluginId: String): Result<Unit> =
         runCatching {
             logger.info(
@@ -467,8 +490,12 @@ class PluginSandboxManagerImpl(
                 return@runCatching
             }
             val watchdog = watchdogs[pluginId]
-            sandbox.stop()
             if (markDisabledIfCurrent(sandbox)) {
+                // Publish disabled before teardown so a backoff that wakes while stop() suspends
+                // cannot admit a restart for this sandbox generation.
+                sandbox.stop()
+                // stop() publishes STOPPED; retain the explicit terminal state for callers.
+                sandbox.setDisabled()
                 // Guard the watchdog too: a replacement may have arrived between the map reads.
                 watchdog?.stop()
                 notifyListeners { it.onPluginDisabled(pluginId) }
@@ -489,6 +516,7 @@ class PluginSandboxManagerImpl(
 
             val sandbox = sandboxes[pluginId]
             if (sandbox != null) {
+                sandbox.clearDisabledForEnable()
                 // Restart the watchdog
                 val watchdog =
                     PluginWatchdog(
@@ -579,8 +607,8 @@ class PluginSandboxManagerImpl(
             ),
         )
 
-        kotlinx.coroutines.delay(backoffDelay)
-        restartPlugin(pluginId)
+        awaitRestartBackoff(backoffDelay)
+        restartIfCurrentAndEnabled(sandbox)
     }
 
     private fun calculateBackoff(

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -343,9 +343,11 @@ class PluginSandboxManagerImpl(
 
         // Stop and remove sandbox
         sandboxes[pluginId]?.stop()
-        sandboxes.remove(pluginId)
-        // Disable state belongs to the removed instance, not its future replacement.
-        disabledPlugins.remove(pluginId)
+        synchronized(sandboxes) {
+            sandboxes.remove(pluginId)
+            // Disable state belongs to the removed instance, not its future replacement.
+            disabledPlugins.remove(pluginId)
+        }
 
         // Unregister from health monitor
         healthMonitor.unregisterSandbox(pluginId)
@@ -383,10 +385,11 @@ class PluginSandboxManagerImpl(
 
             // 3. Stop sandbox
             sandboxes[pluginId]?.stop()
-            sandboxes.remove(pluginId)
-
-            // 4. Remove from disabled set if present
-            disabledPlugins.remove(pluginId)
+            synchronized(sandboxes) {
+                sandboxes.remove(pluginId)
+                // 4. Remove from disabled set if present
+                disabledPlugins.remove(pluginId)
+            }
 
             // 5. Unregister from health monitor
             healthMonitor.unregisterSandbox(pluginId)
@@ -501,6 +504,18 @@ class PluginSandboxManagerImpl(
 
     override fun getDisabledPlugins(): Set<String> = disabledPlugins.toSet()
 
+    /** A cancelled watchdog must not publish disable state for a removed or replaced instance. */
+    internal fun markDisabledIfCurrent(sandbox: InProcessPluginSandbox): Boolean =
+        synchronized(sandboxes) {
+            if (sandboxes[sandbox.pluginId] !== sandbox) {
+                false
+            } else {
+                sandbox.setDisabled()
+                disabledPlugins.add(sandbox.pluginId)
+                true
+            }
+        }
+
     /**
      * What the watchdog asks for when a plugin looks dead. Internal rather than
      * private so the budget-exhaustion branch - the one path that disables a
@@ -538,12 +553,13 @@ class PluginSandboxManagerImpl(
             // plugin disabled this way stranded a two-thread non-daemon pool
             // for the life of the process. So: tear the sandbox down first,
             // and stop the watchdog once nothing is left that needs to suspend.
+            val watchdog = watchdogs[pluginId]
             sandbox.stop()
-            sandbox.setDisabled()
-            disabledPlugins.add(pluginId)
-            notifyListeners { it.onPluginDisabled(pluginId) }
-            // Last: prevents further restart attempts, and cancels us.
-            watchdogs[pluginId]?.stop()
+            if (markDisabledIfCurrent(sandbox)) {
+                notifyListeners { it.onPluginDisabled(pluginId) }
+                // Last: stop this instance's watchdog, never a replacement's.
+                watchdog?.stop()
+            }
             return
         }
 

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -587,8 +587,9 @@ class PluginSandboxManagerImpl(
             // for the life of the process. So: tear the sandbox down first,
             // and stop the watchdog once nothing is left that needs to suspend.
             val watchdog = watchdogs[pluginId]
-            sandbox.stop()
             if (markDisabledIfCurrent(sandbox)) {
+                sandbox.stop()
+                sandbox.setDisabled()
                 notifyListeners { it.onPluginDisabled(pluginId) }
                 // Last: stop this instance's watchdog, never a replacement's.
                 watchdog?.stop()

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -455,19 +455,14 @@ class PluginSandboxManagerImpl(
                 ),
             )
 
-            disabledPlugins.add(pluginId)
-
-            val sandbox = sandboxes[pluginId]
-            if (sandbox != null) {
-                // Stop the watchdog to prevent auto-restart
-                watchdogs[pluginId]?.stop()
-
-                // Stop the sandbox and set state to DISABLED
-                sandbox.stop()
-                sandbox.setDisabled()
+            // Missing/removed instances must not leave a disable flag for a future replacement.
+            val sandbox = sandboxes[pluginId] ?: return@runCatching
+            val watchdog = watchdogs[pluginId]
+            watchdog?.stop()
+            sandbox.stop()
+            if (markDisabledIfCurrent(sandbox)) {
+                notifyListeners { it.onPluginDisabled(pluginId) }
             }
-
-            notifyListeners { it.onPluginDisabled(pluginId) }
         }
 
     override suspend fun enablePlugin(pluginId: String): Result<Unit> =

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -344,6 +344,8 @@ class PluginSandboxManagerImpl(
         // Stop and remove sandbox
         sandboxes[pluginId]?.stop()
         sandboxes.remove(pluginId)
+        // Disable state belongs to the removed instance, not its future replacement.
+        disabledPlugins.remove(pluginId)
 
         // Unregister from health monitor
         healthMonitor.unregisterSandbox(pluginId)

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -102,7 +102,8 @@ interface PluginSandboxManager {
     suspend fun restartPlugin(pluginId: String): Result<Unit>
 
     /**
-     * Disable a plugin. It will be stopped and won't auto-restart.
+     * Disable an existing plugin. It will be stopped and won't auto-restart.
+     * A missing sandbox is already stopped and is a no-op.
      * @param pluginId Plugin identifier
      * @return Result indicating success or failure
      */
@@ -321,8 +322,8 @@ class PluginSandboxManagerImpl(
     override fun getSandbox(pluginId: String): PluginSandbox? = sandboxes[pluginId]
 
     /**
-     * Note the watchdog-then-sandbox order here, in [disablePlugin] and in
-     * [fullyUnloadPlugin]. It is safe at these three sites only because none of
+     * Note the watchdog-then-sandbox order here and in [fullyUnloadPlugin].
+     * It is safe at these two sites only because neither of
      * them is reached from inside a watchdog coroutine. The same order in
      * [handleRestartRequest] stopped the coroutine that was executing it and so
      * skipped the suspending pool teardown entirely - see the comment there
@@ -456,11 +457,20 @@ class PluginSandboxManagerImpl(
             )
 
             // Missing/removed instances must not leave a disable flag for a future replacement.
-            val sandbox = sandboxes[pluginId] ?: return@runCatching
+            val sandbox = sandboxes[pluginId]
+            if (sandbox == null) {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Disable skipped: sandbox already removed",
+                    mapOf("pluginId" to pluginId),
+                )
+                return@runCatching
+            }
             val watchdog = watchdogs[pluginId]
-            watchdog?.stop()
             sandbox.stop()
             if (markDisabledIfCurrent(sandbox)) {
+                // Guard the watchdog too: a replacement may have arrived between the map reads.
+                watchdog?.stop()
                 notifyListeners { it.onPluginDisabled(pluginId) }
             }
         }

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginRestartDisableRaceTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginRestartDisableRaceTest.kt
@@ -63,8 +63,12 @@ class PluginRestartDisableRaceTest {
             val release = CountDownLatch(1)
             val failure = AtomicReference<Throwable?>()
             val restartLock =
-                sandbox.javaClass.getDeclaredField("restartLock").apply { isAccessible = true }.get(sandbox)
+                sandbox.javaClass
+                    .getDeclaredField("restartLock")
+                    .apply { isAccessible = true }
+                    .get(sandbox)
             val stateField = sandbox.javaClass.getDeclaredField("_state").apply { isAccessible = true }
+
             @Suppress("UNCHECKED_CAST")
             val state = stateField.get(sandbox) as MutableStateFlow<SandboxState>
             // Park the real restart at its final publication, without adding a production hook.

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginRestartDisableRaceTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginRestartDisableRaceTest.kt
@@ -23,8 +23,9 @@ class PluginRestartDisableRaceTest {
     @Test
     fun `budget disable rejects restart while executor teardown is parked`() =
         runBlocking {
-            val manager = PluginSandboxManagerImpl(SandboxConfig(maxRestartAttempts = 0))
-            val sandbox = manager.createSandbox("budget-disable-race") as InProcessPluginSandbox
+            val config = SandboxConfig(maxRestartAttempts = 0)
+            val manager = PluginSandboxManagerImpl(config)
+            val sandbox = manager.createSandbox("budget-disable-race", config) as InProcessPluginSandbox
             val entered = CountDownLatch(1)
             val release = CountDownLatch(1)
             sandbox.start().getOrThrow()
@@ -106,7 +107,10 @@ class PluginRestartDisableRaceTest {
             }
         }
 
-    private fun blockedOn(thread: Thread, lock: Any): Boolean {
+    private fun blockedOn(
+        thread: Thread,
+        lock: Any,
+    ): Boolean {
         val info = ManagementFactory.getThreadMXBean().getThreadInfo(thread.id) ?: return false
         return info.threadState == Thread.State.BLOCKED &&
             info.lockInfo?.identityHashCode == System.identityHashCode(lock)

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginRestartDisableRaceTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginRestartDisableRaceTest.kt
@@ -1,0 +1,131 @@
+package ai.rever.boss.plugin.sandbox
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import java.lang.management.ManagementFactory
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PluginRestartDisableRaceTest {
+    @Test
+    fun `budget disable rejects restart while executor teardown is parked`() =
+        runBlocking {
+            val manager = PluginSandboxManagerImpl(SandboxConfig(maxRestartAttempts = 0))
+            val sandbox = manager.createSandbox("budget-disable-race") as InProcessPluginSandbox
+            val entered = CountDownLatch(1)
+            val release = CountDownLatch(1)
+            sandbox.start().getOrThrow()
+            sandbox.sandboxScope.launch {
+                entered.countDown()
+                check(release.await(5, TimeUnit.SECONDS)) { "Plugin work was not released" }
+            }
+            var disabling: kotlinx.coroutines.Deferred<Unit>? = null
+            try {
+                assertTrue(entered.await(5, TimeUnit.SECONDS))
+                disabling =
+                    async(start = CoroutineStart.UNDISPATCHED) {
+                        manager.handleRestartRequest(sandbox.pluginId)
+                    }
+                assertFalse(disabling.isCompleted, "Budget disable must be waiting for the old executor")
+                assertTrue(manager.restartPlugin(sandbox.pluginId).isFailure, "A disabling sandbox must reject restart")
+                release.countDown()
+                withTimeout(5_000) { disabling.await() }
+                assertTrue(manager.isPluginDisabled(sandbox.pluginId))
+                assertEquals(SandboxState.DISABLED, sandbox.state.value)
+                assertTrue(sandbox.isExecutorTerminated(), "Budget disable must leave no replacement executor")
+            } finally {
+                release.countDown()
+                disabling?.join()
+                manager.dispose()
+            }
+        }
+
+    @Test
+    fun `disable cannot be overwritten by an admitted restart publishing running`() =
+        runBlocking {
+            val sandbox = InProcessPluginSandbox("restart-disable-race")
+            sandbox.start().getOrThrow()
+            val publishing = CountDownLatch(1)
+            val release = CountDownLatch(1)
+            val failure = AtomicReference<Throwable?>()
+            val restartLock =
+                sandbox.javaClass.getDeclaredField("restartLock").apply { isAccessible = true }.get(sandbox)
+            val stateField = sandbox.javaClass.getDeclaredField("_state").apply { isAccessible = true }
+            @Suppress("UNCHECKED_CAST")
+            val state = stateField.get(sandbox) as MutableStateFlow<SandboxState>
+            // Park the real restart at its final publication, without adding a production hook.
+            stateField.set(sandbox, PausedRunningState(state, publishing, release))
+            val restarting =
+                thread(name = "sandbox-restart-test") {
+                    runCatching { runBlocking { sandbox.restart().getOrThrow() } }
+                        .onFailure { failure.compareAndSet(null, it) }
+                }
+            var disabling: Thread? = null
+            try {
+                assertTrue(publishing.await(5, TimeUnit.SECONDS), "Restart must reach RUNNING publication")
+                disabling =
+                    thread(name = "sandbox-disable-test") {
+                        runCatching {
+                            sandbox.setDisabled()
+                            runBlocking { sandbox.stop().getOrThrow() }
+                            sandbox.setDisabled()
+                        }.onFailure { failure.compareAndSet(null, it) }
+                    }
+                // The fixed path blocks on the restart lock. The old path completes disable
+                // here, then overwrites it with RUNNING when the parked publication resumes.
+                val disableThread = disabling
+                withTimeout(5_000) {
+                    while (disableThread.isAlive && !blockedOn(disableThread, restartLock)) delay(1)
+                }
+                release.countDown()
+                restarting.join(5_000)
+                disableThread.join(5_000)
+                assertFalse(restarting.isAlive)
+                assertFalse(disableThread.isAlive)
+                assertNull(failure.get())
+                assertEquals(SandboxState.DISABLED, sandbox.state.value)
+                assertTrue(sandbox.isExecutorTerminated())
+            } finally {
+                release.countDown()
+                restarting.join(5_000)
+                disabling?.join(5_000)
+                sandbox.stop()
+            }
+        }
+
+    private fun blockedOn(thread: Thread, lock: Any): Boolean {
+        val info = ManagementFactory.getThreadMXBean().getThreadInfo(thread.id) ?: return false
+        return info.threadState == Thread.State.BLOCKED &&
+            info.lockInfo?.identityHashCode == System.identityHashCode(lock)
+    }
+
+    @OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+    private class PausedRunningState(
+        private val delegate: MutableStateFlow<SandboxState>,
+        private val publishing: CountDownLatch,
+        private val release: CountDownLatch,
+    ) : MutableStateFlow<SandboxState> by delegate {
+        override var value: SandboxState
+            get() = delegate.value
+            set(value) {
+                if (value == SandboxState.RUNNING) {
+                    publishing.countDown()
+                    check(release.await(5, TimeUnit.SECONDS)) { "Publication was not released" }
+                }
+                delegate.value = value
+            }
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
@@ -171,6 +171,17 @@ class PluginSandboxManagerTest {
     @Nested
     inner class DisableEnableTests {
         @Test
+        fun `disable after removal cannot poison a future sandbox`() =
+            runTest {
+                manager.createSandbox("plugin-1")
+                manager.removeSandbox("plugin-1")
+                manager.disablePlugin("plugin-1").getOrThrow()
+                assertFalse(manager.isPluginDisabled("plugin-1"))
+                manager.createSandbox("plugin-1")
+                assertFalse(manager.isPluginDisabled("plugin-1"))
+            }
+
+        @Test
         fun `disablePlugin marks plugin as disabled`() =
             runTest {
                 manager.createSandbox("plugin-1")

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
@@ -210,6 +210,50 @@ class PluginSandboxManagerTest {
                     raceManager.dispose()
                 }
             }
+
+        @Test
+        fun `backoff restart cannot affect a replacement sandbox`() =
+            runBlocking {
+                val enteredBackoff = CompletableDeferred<Unit>()
+                val releaseBackoff = CompletableDeferred<Unit>()
+                val config = SandboxConfig(restartBackoffBaseMs = 1)
+                val raceManager =
+                    PluginSandboxManagerImpl(
+                        defaultConfig = config,
+                        awaitRestartBackoff = {
+                            enteredBackoff.complete(Unit)
+                            releaseBackoff.await()
+                        },
+                    )
+                var restarted = false
+                raceManager.addListener(
+                    object : PluginSandboxListener {
+                        override fun onPluginRestarted(pluginId: String) {
+                            restarted = true
+                        }
+                    },
+                )
+                val old = raceManager.createSandbox("plugin-1", config) as InProcessPluginSandbox
+                old.start()
+                val scheduled = async { raceManager.handleRestartRequest("plugin-1") }
+                try {
+                    withTimeout(5_000) { enteredBackoff.await() }
+                    raceManager.removeSandbox("plugin-1")
+                    val replacement = raceManager.createSandbox("plugin-1", config) as InProcessPluginSandbox
+                    replacement.start()
+
+                    releaseBackoff.complete(Unit)
+                    withTimeout(5_000) { scheduled.await() }
+
+                    assertFalse(restarted, "A backoff from the removed sandbox must not restart its replacement")
+                    assertEquals(SandboxState.RUNNING, replacement.state.value)
+                    assertTrue(old.isExecutorTerminated())
+                } finally {
+                    releaseBackoff.complete(Unit)
+                    scheduled.join()
+                    raceManager.dispose()
+                }
+            }
     }
 
     @Nested
@@ -244,6 +288,7 @@ class PluginSandboxManagerTest {
                 manager.enablePlugin("plugin-1")
 
                 assertFalse(manager.isPluginDisabled("plugin-1"))
+                assertTrue(manager.restartPlugin("plugin-1").isSuccess)
             }
 
         @Test

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
@@ -112,6 +112,19 @@ class PluginSandboxManagerTest {
             }
 
         @Test
+        fun `late watchdog disable cannot mark a replacement sandbox disabled`() =
+            runTest {
+                val old = manager.createSandbox("plugin-1") as InProcessPluginSandbox
+                manager.removeSandbox("plugin-1")
+                manager.createSandbox("plugin-1")
+                assertFalse(manager.markDisabledIfCurrent(old))
+                assertFalse(manager.isPluginDisabled("plugin-1"))
+                val current = manager.getSandbox("plugin-1") as InProcessPluginSandbox
+                assertTrue(manager.markDisabledIfCurrent(current))
+                assertTrue(manager.isPluginDisabled("plugin-1"))
+            }
+
+        @Test
         fun `removeSandbox is safe for unknown plugin`() =
             runTest {
                 // Should not throw

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
@@ -99,6 +99,19 @@ class PluginSandboxManagerTest {
             }
 
         @Test
+        fun `removing disabled sandbox clears recovery bookkeeping before replacement`() =
+            runTest {
+                val old = manager.createSandbox("plugin-1")
+                manager.disablePlugin("plugin-1").getOrThrow()
+                assertTrue(manager.isPluginDisabled("plugin-1"))
+                manager.removeSandbox("plugin-1")
+                assertFalse(manager.isPluginDisabled("plugin-1"))
+                val replacement = manager.createSandbox("plugin-1")
+                assertTrue(old !== replacement)
+                assertFalse(manager.isPluginDisabled("plugin-1"))
+            }
+
+        @Test
         fun `removeSandbox is safe for unknown plugin`() =
             runTest {
                 // Should not throw

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.sandbox
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -165,6 +166,49 @@ class PluginSandboxManagerTest {
                 val result = manager.restartPlugin("plugin-1")
 
                 assertTrue(result.isSuccess)
+            }
+
+        @Test
+        fun `backoff restart cannot resurrect a sandbox disabled while it waits`() =
+            runBlocking {
+                val enteredBackoff = CompletableDeferred<Unit>()
+                val releaseBackoff = CompletableDeferred<Unit>()
+                val config = SandboxConfig(restartBackoffBaseMs = 1)
+                val raceManager =
+                    PluginSandboxManagerImpl(
+                        defaultConfig = config,
+                        awaitRestartBackoff = {
+                            enteredBackoff.complete(Unit)
+                            releaseBackoff.await()
+                        },
+                    )
+                var restarted = false
+                raceManager.addListener(
+                    object : PluginSandboxListener {
+                        override fun onPluginRestarted(pluginId: String) {
+                            restarted = true
+                        }
+                    },
+                )
+                val sandbox = raceManager.createSandbox("plugin-1", config) as InProcessPluginSandbox
+                sandbox.start()
+                val scheduled = async { raceManager.handleRestartRequest("plugin-1") }
+                try {
+                    withTimeout(5_000) { enteredBackoff.await() }
+                    raceManager.disablePlugin("plugin-1").getOrThrow()
+                    assertTrue(raceManager.isPluginDisabled("plugin-1"))
+
+                    releaseBackoff.complete(Unit)
+                    withTimeout(5_000) { scheduled.await() }
+
+                    assertFalse(restarted, "A restart queued for the disabled sandbox must be rejected")
+                    assertEquals(SandboxState.DISABLED, sandbox.state.value)
+                    assertTrue(sandbox.isExecutorTerminated())
+                } finally {
+                    releaseBackoff.complete(Unit)
+                    scheduled.join()
+                    raceManager.dispose()
+                }
             }
     }
 

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginIncompatibilityObservationTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginIncompatibilityObservationTest.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.plugin.sandbox.ui
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -15,7 +17,10 @@ class PluginIncompatibilityObservationTest {
             val observed = mutableListOf<Boolean>()
             val job =
                 launch(Dispatchers.Unconfined) {
-                    PluginCrashRegistry.incompatiblePlugins.collect { observed.add(id in it) }
+                    PluginCrashRegistry.incompatiblePlugins
+                        .map { id in it }
+                        .distinctUntilChanged()
+                        .collect { observed.add(it) }
                 }
             try {
                 PluginCrashRegistry.markIncompatible(id)

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginIncompatibilityObservationTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginIncompatibilityObservationTest.kt
@@ -1,0 +1,29 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PluginIncompatibilityObservationTest {
+    @Test
+    fun `runtime incompatibility and recovery publish without a manager state change`() =
+        runBlocking {
+            val id = "health-observation-test"
+            PluginCrashRegistry.clearIncompatible(id)
+            val observed = mutableListOf<Boolean>()
+            val job =
+                launch(Dispatchers.Unconfined) {
+                    PluginCrashRegistry.incompatiblePlugins.collect { observed.add(id in it) }
+                }
+            try {
+                PluginCrashRegistry.markIncompatible(id)
+                PluginCrashRegistry.clearIncompatible(id)
+                assertEquals(listOf(false, true, false), observed)
+            } finally {
+                job.cancel()
+                PluginCrashRegistry.clearIncompatible(id)
+            }
+        }
+}


### PR DESCRIPTION
Help > Plugin Health & Recovery brings window-local plugin status and guarded recovery into one dialog. It explains access, incompatibility and load gates; normal disabled plugins use Enable, watchdog-disabled plugins use full Reload where supported, and native restart-only plugins show restart guidance. Busy/error feedback survives recomposition, and replacement waits for teardown.

## Contributor provenance

@Ayush04-C (Ayush Santosh Chhatre) authored the menu/dialog, health projection and eight original precedence/privacy/eligibility tests. His follow-up commits `f80ab1e3`, `dca24688`, `a9e56c6b` and `ffb2bb82` add disabled/backoff restart admission, lock-protected RUNNING publication, guarded budget exhaustion, cancellation diagnostics, and backoff/replacement/enable regression coverage. These follow-ups are distinct from the original submission.

Earlier agent repairs added remembered operation state, delegate/persistence routing, live auth/incompatibility/sandbox observation, recovery policy, cancellation handling, completed teardown, stale-instance protection and regression tests. This sweep preserves the author follow-ups, integrates dev `de6694cb`, adds deterministic regressions for RUNNING publication versus disable and restart during budget teardown, and makes the cancellation diagnostic report observed installed state accurately. Agent work is not credited as original contributor work.

The shared sandbox guard overlaps #436, whose restart-limit event/toast/persistence feature remains separate. #457's coroutine join is also separate; this PR does not claim that behavior or complete the broader #394 incident.

## Validation

Local validation: **79 affected host tests and 150 sandbox tests passed** across the full run and the corrected two-test rerun; zero remaining failures/errors/skips. Repository **ktlintCheck and detekt passed**. The agent fixture required setup/formatting corrections before passing; those intermediate failures are reviewer work, not author defects. Test XML and logs are saved in the review audit.

API pin remains 1.0.88; the resolved JAR matches the published release digest. All local Gradle commands used the shared build lock. The previous shared-dev store-import failure is fixed by dev commit `6308b1626`; it is not an author defect.

Claude reviewed `a9e56c6b` in [run 34467540095](https://github.com/risa-labs-inc/BossConsole/actions/runs/34467540095). Its substantive restart races are addressed by the author's `ffb2bb82` follow-up and the regression coverage above. Final-head CI/review status is recorded in the review comment; no final-head Claude approval is claimed. No merge or auto-merge.

## Limits and manual validation

Display and action snapshots can briefly differ; recovery rechecks current eligibility. Tests cover the state-only uninstall cancellation boundary and real sandbox race/teardown behavior. Full loaded/OOP uninstall and installed-plugin UI behavior remain manual checks, not inferred from unit tests. The existing error-boundary bare Enable path and cosmetic refinements remain separate.

Manual: check both themes, long names and small windows; open two windows and change admin access/incompatibility while the dialog is open; verify disabled/watchdog/native restart-only rows, Enable persistence and full Reload. Cancel a requesting window during recovery and confirm cleanup and panel compensation. Confirm failures show a specific error without reporting success.

No app instance was launched or stopped, no plugin was deployed, and no live database migration was applied.
