### PR TITLE
fix(crash): resolve contained-fault attribution on the faulting thread

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -962,7 +962,6 @@
     <ID>NestedBlockDepth:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$private fun downloadWithProgress( urlString: String, targetPath: Path, onProgress: (DownloadProgress) -&gt; Unit, )</ID>
     <ID>NestedBlockDepth:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$private fun extractWithJava( zipPath: Path, targetDir: Path, )</ID>
     <ID>NestedBlockDepth:ConfigLoader.kt$ConfigLoader$private fun loadLocalProperties()</ID>
-    <ID>NestedBlockDepth:CrashHandler.kt$CrashHandler$internal fun attributePluginId(throwable: Throwable): String?</ID>
     <ID>NestedBlockDepth:CrossDeviceAuthService.kt$CrossDeviceAuthService$suspend fun pollForAuthenticationCompletion( challenge: String, sessionId: String? = null, ): Result&lt;PasskeyAuthenticationResult&gt;</ID>
     <ID>NestedBlockDepth:DesktopBrowserAccessor.kt$private fun findBrowserForTab( splitViewState: ai.rever.boss.components.window_panel.SplitViewState, tabId: String, ): LockedBrowser?</ID>
     <ID>NestedBlockDepth:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$private fun findProjectRootInternal(startDir: File?): File?</ID>
@@ -1095,7 +1094,6 @@
     <ID>ReturnCount:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$fun isChromiumInstalled(): Boolean</ID>
     <ID>ReturnCount:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$internal fun promotePendingInstall( pending: File, target: File, backup: File, )</ID>
     <ID>ReturnCount:ChromiumReleaseSource.kt$ChromiumReleaseResolver.Companion$private fun comparePreRelease( a: List&lt;String&gt;, b: List&lt;String&gt;, ): Int</ID>
-    <ID>ReturnCount:CrashHandler.kt$CrashHandler$internal fun attributePluginId(throwable: Throwable): String?</ID>
     <ID>ReturnCount:CrossDeviceAuthService.kt$CrossDeviceAuthService$suspend fun handleCrossDeviceAuthentication( exception: CrossDeviceAuthenticationRequired, onAuthenticationComplete: suspend (PasskeyAuthenticationResult) -&gt; Result&lt;Unit&gt;, ): Result&lt;Unit&gt;</ID>
     <ID>ReturnCount:CrossDeviceAuthService.kt$CrossDeviceAuthService$suspend fun pollForAuthenticationCompletion( challenge: String, sessionId: String? = null, ): Result&lt;PasskeyAuthenticationResult&gt;</ID>
     <ID>ReturnCount:DeepLinkHandler.kt$DeepLinkHandler$actual fun extractVerificationToken(uri: String): String?</ID>

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -292,22 +292,11 @@ object CrashHandler {
             // ~/.boss/crash-reports and sweepOldReports would delete the developer's
             // actual reports — the exact hazard the override exists to prevent.
             val dir = containedReportDir()
-            // The thread's plugin scope is read *here* for the same class of reason,
-            // and it is the one attribution source that cannot survive the hop:
-            // [PluginExecutionBoundary.currentPluginId] is a ThreadLocal, so on the
-            // writer thread it is always null. A fault the host caught while still
-            // inside a plugin call - which is what a contained render fault is - has
-            // no boundary tag either, because nothing escaped a runAttributed frame
-            // to be tagged on the way out. So the whole ladder fell through to the
-            // classloader scan, found only host frames, and every such report read
-            // "(unattributed)". The inline branch below got this right by accident,
-            // which meant one fault attributed differently depending on whether the
-            // process was about to exit.
-            //
-            // Only the scope is captured, not the whole answer: the other two
-            // sources key off the throwable and are correct on any thread, and the
-            // classloader scan is the expensive one this function moved off the EDT
-            // in the first place - see the comment above the signature.
+            // Preserve a live calling-thread scope across the writer hop. Normal
+            // exception handlers run after the boundary unwinds and use its tag;
+            // a caller reporting before unwinding instead needs this ThreadLocal.
+            // Capture only the scope so the expensive classloader scan stays off
+            // the EDT. This cannot identify an originally unscoped callback.
             val scopedPluginId = PluginExecutionBoundary.currentPluginId()
             // Inline when the caller is about to end the process. The writer is a
             // daemon thread with nothing draining it at shutdown, so a queued task

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -927,21 +927,20 @@ object CrashHandler {
         throwable: Throwable,
         scopedPluginId: String? = PluginExecutionBoundary.currentPluginId(),
     ): String? {
-        PluginExecutionBoundary.attributionFor(throwable)?.let { return it }
-        scopedPluginId?.let { return it }
-        return try {
-            // Root cause first: the crash origin outranks the layers that wrapped it.
-            for (cause in throwable.chainOfCauses().asReversed()) {
-                (cause.javaClass.classLoader as? PluginClassLoader)?.let { return it.pluginId }
-                for (frame in cause.stackTrace) {
-                    PluginClassLoader.findPluginForClass(frame.className)?.let { return it }
+        return PluginExecutionBoundary.attributionFor(throwable)
+            ?: scopedPluginId
+            ?: try {
+                // Root cause first: the crash origin outranks the layers that wrapped it.
+                throwable.chainOfCauses().asReversed().firstNotNullOfOrNull { cause ->
+                    (cause.javaClass.classLoader as? PluginClassLoader)?.pluginId
+                        ?: cause.stackTrace.firstNotNullOfOrNull { frame ->
+                            PluginClassLoader.findPluginForClass(frame.className)
+                        }
                 }
+            } catch (e: Throwable) {
+                logger.warn(LogCategory.SYSTEM, "Plugin attribution failed: ${e.message}")
+                null
             }
-            null
-        } catch (e: Throwable) {
-            logger.warn(LogCategory.SYSTEM, "Plugin attribution failed: ${e.message}")
-            null
-        }
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -292,15 +292,32 @@ object CrashHandler {
             // ~/.boss/crash-reports and sweepOldReports would delete the developer's
             // actual reports — the exact hazard the override exists to prevent.
             val dir = containedReportDir()
+            // The thread's plugin scope is read *here* for the same class of reason,
+            // and it is the one attribution source that cannot survive the hop:
+            // [PluginExecutionBoundary.currentPluginId] is a ThreadLocal, so on the
+            // writer thread it is always null. A fault the host caught while still
+            // inside a plugin call - which is what a contained render fault is - has
+            // no boundary tag either, because nothing escaped a runAttributed frame
+            // to be tagged on the way out. So the whole ladder fell through to the
+            // classloader scan, found only host frames, and every such report read
+            // "(unattributed)". The inline branch below got this right by accident,
+            // which meant one fault attributed differently depending on whether the
+            // process was about to exit.
+            //
+            // Only the scope is captured, not the whole answer: the other two
+            // sources key off the throwable and are correct on any thread, and the
+            // classloader scan is the expensive one this function moved off the EDT
+            // in the first place - see the comment above the signature.
+            val scopedPluginId = PluginExecutionBoundary.currentPluginId()
             // Inline when the caller is about to end the process. The writer is a
             // daemon thread with nothing draining it at shutdown, so a queued task
             // is dropped or killed mid-write by the exit that follows - and the one
             // caller that passes true does so precisely because the record is the
             // justification for that branch existing.
             if (writeInline) {
-                writeContainedReport(dir, signature, throwable)
+                writeContainedReport(dir, signature, throwable, scopedPluginId)
             } else {
-                containedWriter.execute { writeContainedReport(dir, signature, throwable) }
+                containedWriter.execute { writeContainedReport(dir, signature, throwable, scopedPluginId) }
             }
         } catch (e: Exception) {
             // Reporting a contained fault must never itself become a fault.
@@ -313,14 +330,18 @@ object CrashHandler {
         }
     }
 
-    /** Off the EDT — see [containedWriter]. [dir] is resolved by the caller. */
+    /**
+     * Off the EDT — see [containedWriter]. [dir] and [scopedPluginId] are resolved
+     * by the caller, both because this thread cannot resolve them correctly.
+     */
     private fun writeContainedReport(
         dir: File,
         signature: String,
         throwable: Throwable,
+        scopedPluginId: String?,
     ) {
         try {
-            val report = createCrashReport(throwable)
+            val report = createCrashReport(throwable, attributePluginId(throwable, scopedPluginId))
             // Owner-only on the directory *and* the file. Directory perms alone are
             // not enough — 0711 still lets others traverse to a predictable path.
             makeOwnerOnlyDir(dir)
@@ -893,10 +914,21 @@ object CrashHandler {
      *
      * Host crashes return null. Best-effort — attribution must never make crash
      * handling itself fail.
+     *
+     * Source 2 is the only thread-affine one, so [scopedPluginId] exists for the
+     * caller that must read it on a different thread from the one that resolves the
+     * rest ([recordContained], whose writer runs off the EDT). It defaults to
+     * reading the scope here, which is what every same-thread caller wants; passing
+     * it explicitly does not reorder the ladder, it only moves *where* rank 2 was
+     * sampled. Passing null where no scope was held is indistinguishable from the
+     * default finding none, so there is no third behaviour to reason about.
      */
-    internal fun attributePluginId(throwable: Throwable): String? {
+    internal fun attributePluginId(
+        throwable: Throwable,
+        scopedPluginId: String? = PluginExecutionBoundary.currentPluginId(),
+    ): String? {
         PluginExecutionBoundary.attributionFor(throwable)?.let { return it }
-        PluginExecutionBoundary.currentPluginId()?.let { return it }
+        scopedPluginId?.let { return it }
         return try {
             // Root cause first: the crash origin outranks the layers that wrapped it.
             for (cause in throwable.chainOfCauses().asReversed()) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -906,11 +906,11 @@ object CrashHandler {
      *
      * Source 2 is the only thread-affine one, so [scopedPluginId] exists for the
      * caller that must read it on a different thread from the one that resolves the
-     * rest ([recordContained], whose writer runs off the EDT). It defaults to
-     * reading the scope here, which is what every same-thread caller wants; passing
-     * it explicitly does not reorder the ladder, it only moves *where* rank 2 was
-     * sampled. Passing null where no scope was held is indistinguishable from the
-     * default finding none, so there is no third behaviour to reason about.
+     * rest ([recordContained], whose writer runs off the EDT). The default argument
+     * samples the calling thread's scope before this function runs, even when a tag
+     * will answer. Passing it explicitly preserves the ladder and moves only where
+     * rank 2 was sampled. An explicit null skips rank 2 entirely; it never falls
+     * back to the evaluating thread's scope.
      */
     internal fun attributePluginId(
         throwable: Throwable,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -926,8 +926,8 @@ object CrashHandler {
     internal fun attributePluginId(
         throwable: Throwable,
         scopedPluginId: String? = PluginExecutionBoundary.currentPluginId(),
-    ): String? {
-        return PluginExecutionBoundary.attributionFor(throwable)
+    ): String? =
+        PluginExecutionBoundary.attributionFor(throwable)
             ?: scopedPluginId
             ?: try {
                 // Root cause first: the crash origin outranks the layers that wrapped it.
@@ -941,7 +941,6 @@ object CrashHandler {
                 logger.warn(LogCategory.SYSTEM, "Plugin attribution failed: ${e.message}")
                 null
             }
-    }
 
     /**
      * Get the full stack trace as a string.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.crash
 
+import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
@@ -31,6 +32,16 @@ import kotlin.test.assertTrue
  * stops a task that outlives `tearDown` from resolving the real data root.
  */
 class ContainedCrashReportTest {
+    private companion object {
+        /**
+         * Any id will do: [PluginExecutionBoundary.runAttributed] takes the id as a
+         * string and does not resolve it, so the attribution tests need no real jar
+         * or classloader. Only the classloader-scan rank does, and these exercise the
+         * two ranks above it.
+         */
+        const val PROBE_PLUGIN = "probe.plugin"
+    }
+
     /** Mirrors CrashHandler.CONTAINED_REPORT_RETENTION, which is private. */
     private val retention = 20
 
@@ -166,6 +177,91 @@ class ContainedCrashReportTest {
             "expected at most $retention reports kept, found $kept of $distinctFaults written",
         )
     }
+
+    /**
+     * The regression this path existed to have.
+     *
+     * The fault is reported *inside* the scope and never escapes it, which is what a
+     * contained render fault is: the host caught it, so nothing propagated out of a
+     * `runAttributed` frame to be tagged on the way out. That leaves the thread's
+     * plugin scope as the only source that can answer, and it is a ThreadLocal - so
+     * resolving attribution on the writer thread found nothing and wrote
+     * "(unattributed)" for every plugin fault that took this path.
+     *
+     * Letting the throwable escape the block instead would tag it, and the tag
+     * survives the thread hop, so the test would pass with or without the fix.
+     */
+    @Test
+    fun `a fault reported inside a plugin scope is attributed on the async path`() {
+        PluginExecutionBoundary.runAttributed(PROBE_PLUGIN) {
+            CrashHandler.recordContained(uniqueThrowable("scope-async"))
+        }
+        awaitFiles(1)
+
+        assertEquals(
+            PROBE_PLUGIN,
+            attributionOf(reports().single().readText()),
+            "the plugin scope held at the fault must survive the hop to the writer thread",
+        )
+    }
+
+    /**
+     * The same fault must not attribute differently depending on which branch took
+     * it. `writeInline = true` runs on the calling thread, so it read the scope
+     * correctly by accident while the async branch - the one every caller but the
+     * about-to-exit path uses - did not.
+     */
+    @Test
+    fun `inline and async report the same attribution for one fault`() {
+        PluginExecutionBoundary.runAttributed(PROBE_PLUGIN) {
+            // Distinct markers: one signature would dedupe to a single file and
+            // there would be nothing to compare.
+            CrashHandler.recordContained(uniqueThrowable("scope-inline"), writeInline = true)
+            CrashHandler.recordContained(uniqueThrowable("scope-deferred"))
+        }
+        awaitFiles(2)
+
+        val attributions =
+            reports()
+                .map { it.readText() }
+                .associate { text -> markerOf(text) to attributionOf(text) }
+
+        assertEquals(
+            mapOf("scope-inline" to PROBE_PLUGIN, "scope-deferred" to PROBE_PLUGIN),
+            attributions,
+            "inline and deferred writes must agree about who to blame",
+        )
+    }
+
+    /**
+     * The other direction, and the one that matters more: attribution must not start
+     * inventing a plugin for a host bug. A captured scope of null has to stay
+     * indistinguishable from resolving no scope at all.
+     */
+    @Test
+    fun `a host fault outside any plugin scope stays unattributed`() {
+        CrashHandler.recordContained(uniqueThrowable("host-fault"))
+        awaitFiles(1)
+
+        val text = reports().single().readText()
+        assertEquals("(unattributed)", attributionOf(text), "a host fault must not be blamed on a plugin")
+    }
+
+    /** The `plugin:` field of a rendered report, whitespace trimmed. */
+    private fun attributionOf(reportText: String): String =
+        reportText
+            .lineSequence()
+            .first { it.startsWith("plugin:") }
+            .removePrefix("plugin:")
+            .trim()
+
+    /** The [uniqueThrowable] marker a report was written for. */
+    private fun markerOf(reportText: String): String =
+        reportText
+            .lineSequence()
+            .first { it.startsWith("message:") }
+            .substringAfter("contained-report-test ")
+            .trim()
 
     /** The write is handed to a background thread, so poll rather than sleep a fixed span. */
     private fun awaitFiles(count: Int) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashHandlerAttributionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashHandlerAttributionTest.kt
@@ -202,11 +202,22 @@ class CrashHandlerAttributionTest {
     }
 
     @Test
-    fun `captured scope outranks frames and captured null never samples the writer scope`() {
+    fun `captured scope outranks plugin frames`() {
+        val crash = throwFromPlugin("boom")
+        assertEquals(BOUNDARY_PLUGIN_ID, CrashHandler.attributePluginId(crash, BOUNDARY_PLUGIN_ID))
+    }
+
+    @Test
+    fun `captured null scans plugin frames without sampling the writer scope`() {
         val crash = throwFromPlugin("boom")
         PluginExecutionBoundary.runAttributed("writer.plugin") {
-            assertEquals(BOUNDARY_PLUGIN_ID, CrashHandler.attributePluginId(crash, BOUNDARY_PLUGIN_ID))
             assertEquals(PLUGIN_ID, CrashHandler.attributePluginId(crash, null))
+        }
+    }
+
+    @Test
+    fun `captured null leaves a host fault unattributed despite the writer scope`() {
+        PluginExecutionBoundary.runAttributed("writer.plugin") {
             assertNull(CrashHandler.attributePluginId(RuntimeException("host fault"), null))
         }
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashHandlerAttributionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashHandlerAttributionTest.kt
@@ -192,4 +192,22 @@ class CrashHandlerAttributionTest {
 
         assertEquals(BOUNDARY_PLUGIN_ID, CrashHandler.attributePluginId(crash))
     }
+
+    @Test
+    fun `a boundary tag outranks an explicitly captured scope`() {
+        val crash = throwFromPlugin("boom")
+        PluginExecutionBoundary.tag(crash, BOUNDARY_PLUGIN_ID)
+
+        assertEquals(BOUNDARY_PLUGIN_ID, CrashHandler.attributePluginId(crash, "other.plugin.scope"))
+    }
+
+    @Test
+    fun `captured scope outranks frames and captured null never samples the writer scope`() {
+        val crash = throwFromPlugin("boom")
+        PluginExecutionBoundary.runAttributed("writer.plugin") {
+            assertEquals(BOUNDARY_PLUGIN_ID, CrashHandler.attributePluginId(crash, BOUNDARY_PLUGIN_ID))
+            assertEquals(PLUGIN_ID, CrashHandler.attributePluginId(crash, null))
+            assertNull(CrashHandler.attributePluginId(RuntimeException("host fault"), null))
+        }
+    }
 }


### PR DESCRIPTION
### What was wrong
Contained reports resolved plugin scope on the asynchronous writer thread, while inline reports resolved it on the caller. When a caller reports before leaving a plugin scope, that difference loses the scope and may produce `(unattributed)`. Current production exception handlers normally run after unwinding and use a boundary tag instead, so this PR is not evidence that the historical #394 browser event is now attributable.

### What changed
- Captured the plugin context on the calling thread.
- Passed the captured context explicitly to the asynchronous report writer.
- Used Kotlin functional APIs (`firstNotNullOfOrNull`) to keep `attributePluginId` concise and pass Detekt checks.

### Why
This keeps async and inline crash reporting consistent while preserving the existing attribution priority (host code wrapping a plugin still correctly attributes the fault to the plugin).

### Testing
- Added regression tests in `ContainedCrashReportTest` to verify that faults reported inside a plugin scope are correctly attributed on both the async and inline paths.
- Verified that a genuine host fault outside any plugin scope remains correctly unattributed.
- *Note:* The full repository Gradle test suite could not be run locally due to blocked dependency resolution in my development environment. However, I validated the threading behavior and concurrency semantics using a standalone JVM harness, confirming that the `ThreadLocal` scope resolves correctly when captured on the caller thread.

### Scope
This PR only addresses #394 sub-item 3 (contained crash attribution) and does not implement the other sub-items.

Part of #394

### Review Focus
- **Logic:** Check that sampling the scope preserves the correct attribution ladder priority and that a captured `null` correctly defaults to finding no plugin.
- **Performance:** Ensure the expensive classloader scan remains off the EDT and the scope capture sits after the dedupe early-return.


### Independent review and validation

Original implementation and three contained-report regressions by Sahvendra (@Sahvendra7). Maintainer/agent follow-up adds four independently named tests plus obsolete detekt-baseline cleanup and scope-documentation corrections. The tests cover boundary-tag precedence over an explicit captured scope, captured-scope precedence over plugin frames, and explicit null ignoring the writer thread's scope. No production repair or contributor consolidation was needed.

Reviewed against fetched dev `119b259a15308ad631e2c0cb0b755c597d63cf05` (already in this branch) and main `d6b0350e8e40f4fe4fbc21e81b0cbc3b78c110dd`, including earlier merged batches #414/#430. Related #442 browser disposal and #454 health UI remain separate contributions.

Local validation: 139 crash-package tests across 14 suites, zero failures/errors/skips; repository-wide `ktlintCheck` and `detekt` passed. Command (under the shared build lock): `./gradlew --max-workers=2 :composeApp:desktopTest --tests 'ai.rever.boss.crash.*' ktlintCheck detekt`.

This restores context that exists at the reporting call. It cannot infer plugin ownership for an originally unscoped browser callback, and does not resolve the other #394 items. No app was launched for manual validation. Remaining manual check: report a controlled host-frame fault from inside a test plugin scope, inspect its local contained report for the correct plugin ID and continued app responsiveness; repeat outside a scope and verify `(unattributed)`. No visible layout change is expected.

All nine final-head CI checks passed and Claude completed the final-head review with no correctness finding. No merge or auto-merge authorized by this review.


Final review-quality follow-up `0184e88b4` clarifies eager default evaluation and explicit-null behavior, and separates precedence and null-capture cases into independently named tests. All 139 crash tests and root quality checks passed locally; all nine final-head CI checks passed and Claude verified the final head with no correctness finding.
