### PR TITLE
fix(browser): stop the secret-suggestion scorer over-matching unrelated sites (#460)

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
@@ -113,14 +113,49 @@ object WebsiteMatchingUtil {
     }
 
     /**
+     * Public-suffix-ish labels that must not, by themselves, count as a shared token
+     * between two domains in [calculateMatchScore]'s partial-match fallback.
+     *
+     * Not a full public suffix list (see the Mozilla PSL for that) - just the labels
+     * this codebase's own [extractMainDomain] already treats as TLDs, plus the other
+     * common single-label TLDs likely to appear in saved secret websites. Good enough
+     * to close BossConsole#460's "every .com secret matches every .com site" case
+     * without taking on a PSL dependency for a threshold this coarse to begin with.
+     */
+    private val COMMON_TLD_LABELS =
+        setOf(
+            "com",
+            "org",
+            "net",
+            "edu",
+            "gov",
+            "mil",
+            "int",
+            "io",
+            "co",
+            "app",
+            "dev",
+            "me",
+            "info",
+            "biz",
+            "xyz",
+            // the second labels of the two-part TLDs extractMainDomain special-cases
+            "uk",
+            "au",
+            "in",
+            "jp",
+            "br",
+            "za",
+        )
+
+    /**
      * Match secrets for a specific domain with scoring.
      *
      * Returns secrets sorted by relevance (highest score first).
      * Matching logic:
      * - Exact match (google.com == google.com): score 1.0
      * - Subdomain match (login.google.com vs google.com): score 0.9
-     * - Domain contains (google.com contains "google"): score 0.7
-     * - Partial match ("google" in "google-workspace.com"): score 0.5
+     * - Partial match, sharing a non-TLD label ("google" in "google-workspace.com"): score 0.5
      *
      * @param domain Current website domain (e.g., "google.com")
      * @param secrets List of all available secrets
@@ -178,15 +213,12 @@ object WebsiteMatchingUtil {
                 MatchScore(0.9f, "subdomain")
             }
 
-            // Domain contains other (google.com contains google)
-            secretNorm.contains(domainNorm) || domainNorm.contains(secretNorm) -> {
-                MatchScore(0.7f, "domain")
-            }
-
-            // Partial match (same keywords)
+            // Partial match: a shared label that is NOT itself a bare TLD/public-suffix
+            // segment. Without excluding those, every ".com" secret shares the label
+            // "com" with every ".com" site and scores as a match (BossConsole#460).
             else -> {
-                val secretParts = secretNorm.split(".", "-", "_")
-                val domainParts = domainNorm.split(".", "-", "_")
+                val secretParts = secretNorm.split(".", "-", "_").filterNot { it in COMMON_TLD_LABELS }
+                val domainParts = domainNorm.split(".", "-", "_").filterNot { it in COMMON_TLD_LABELS }
                 val commonParts = secretParts.intersect(domainParts.toSet())
 
                 if (commonParts.isNotEmpty()) {
@@ -265,7 +297,9 @@ object WebsiteMatchingUtil {
                 // Generic formatting: example-site → Example Site
                 nameWithoutTld
                     .split("-", "_")
-                    .joinToString(" ") { it.replaceFirstChar { c -> if (c.isLowerCase()) c.titlecase() else it } }
+                    .joinToString(" ") {
+                        it.replaceFirstChar { c -> if (c.isLowerCase()) c.titlecase() else c.toString() }
+                    }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
@@ -24,7 +24,7 @@ object WebsiteMatchingUtil {
     data class MatchedSecret(
         val secret: SecretEntry,
         val matchScore: Float, // 0.0 - 1.0
-        val matchReason: String, // "exact", "subdomain", "partial", "domain"
+        val matchReason: String, // "exact", "subdomain"
     ) : Comparable<MatchedSecret> {
         override fun compareTo(other: MatchedSecret): Int {
             return other.matchScore.compareTo(this.matchScore) // Descending
@@ -113,49 +113,23 @@ object WebsiteMatchingUtil {
     }
 
     /**
-     * Public-suffix-ish labels that must not, by themselves, count as a shared token
-     * between two domains in [calculateMatchScore]'s partial-match fallback.
-     *
-     * Not a full public suffix list (see the Mozilla PSL for that) - just the labels
-     * this codebase's own [extractMainDomain] already treats as TLDs, plus the other
-     * common single-label TLDs likely to appear in saved secret websites. Good enough
-     * to close BossConsole#460's "every .com secret matches every .com site" case
-     * without taking on a PSL dependency for a threshold this coarse to begin with.
-     */
-    private val COMMON_TLD_LABELS =
-        setOf(
-            "com",
-            "org",
-            "net",
-            "edu",
-            "gov",
-            "mil",
-            "int",
-            "io",
-            "co",
-            "app",
-            "dev",
-            "me",
-            "info",
-            "biz",
-            "xyz",
-            // the second labels of the two-part TLDs extractMainDomain special-cases
-            "uk",
-            "au",
-            "in",
-            "jp",
-            "br",
-            "za",
-        )
-
-    /**
      * Match secrets for a specific domain with scoring.
      *
      * Returns secrets sorted by relevance (highest score first).
      * Matching logic:
      * - Exact match (google.com == google.com): score 1.0
      * - Subdomain match (login.google.com vs google.com): score 0.9
-     * - Partial match, sharing a non-TLD label ("google" in "google-workspace.com"): score 0.5
+     *
+     * Deliberately just these two. A credential surface should favor precision over recall:
+     * exact-plus-subdomain is what a password manager keys on, covers every legitimate case,
+     * and cannot put a secret in front of a domain the user is not actually on. An earlier
+     * token-overlap "partial" tier (matching on any shared word after splitting on `.`/`-`/`_`)
+     * was removed for exactly that reason - filtering bare TLD labels ("com", "org", ...) out
+     * of the comparison closed the "every .com secret matches every .com site" case
+     * (BossConsole#460), but the tier still matched two different registrable domains that
+     * merely share a brand-ish label (`apple.com` vs `apple.org`, `google.com` vs
+     * `google-workspace.com`) - the same wrong-site-credential problem, just narrower. See
+     * [WebsiteMatchingUtilTest] for the cross-domain cases this is required not to match.
      *
      * @param domain Current website domain (e.g., "google.com")
      * @param secrets List of all available secrets
@@ -203,29 +177,26 @@ object WebsiteMatchingUtil {
         val domainNorm = currentDomain.lowercase().trim()
 
         return when {
+            // Without this, two blank sides (e.g. a secret with no recorded website, or a
+            // domain extraction failure that fell through to an empty string) would satisfy
+            // the exact-match check below vacuously: "" == "".
+            secretNorm.isEmpty() || domainNorm.isEmpty() -> {
+                MatchScore(0.0f, "no_match")
+            }
+
             // Exact match
             secretNorm == domainNorm -> {
                 MatchScore(1.0f, "exact")
             }
 
-            // Subdomain match (login.google.com vs google.com)
+            // Subdomain match (login.google.com vs google.com) - a real subdomain boundary,
+            // never a bare substring: "snapple.com".endsWith(".apple.com") is false.
             secretNorm.endsWith(".$domainNorm") || domainNorm.endsWith(".$secretNorm") -> {
                 MatchScore(0.9f, "subdomain")
             }
 
-            // Partial match: a shared label that is NOT itself a bare TLD/public-suffix
-            // segment. Without excluding those, every ".com" secret shares the label
-            // "com" with every ".com" site and scores as a match (BossConsole#460).
             else -> {
-                val secretParts = secretNorm.split(".", "-", "_").filterNot { it in COMMON_TLD_LABELS }
-                val domainParts = domainNorm.split(".", "-", "_").filterNot { it in COMMON_TLD_LABELS }
-                val commonParts = secretParts.intersect(domainParts.toSet())
-
-                if (commonParts.isNotEmpty()) {
-                    MatchScore(0.5f, "partial")
-                } else {
-                    MatchScore(0.0f, "no_match")
-                }
+                MatchScore(0.0f, "no_match")
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
@@ -10,7 +10,7 @@ import ai.rever.boss.utils.logging.LogCategory
  * Handles:
  * - Domain extraction from URLs
  * - Subdomain normalization (login.google.com → google.com)
- * - Fuzzy matching between secret website and current domain
+ * - Exact and dot-boundary matching between secret website and current domain
  * - Scoring and ranking of matched secrets
  *
  * Used by Issue #56 - Secret Access Integration with Fluck Browser
@@ -120,16 +120,10 @@ object WebsiteMatchingUtil {
      * - Exact match (google.com == google.com): score 1.0
      * - Subdomain match (login.google.com vs google.com): score 0.9
      *
-     * Deliberately just these two. A credential surface should favor precision over recall:
-     * exact-plus-subdomain is what a password manager keys on, covers every legitimate case,
-     * and cannot put a secret in front of a domain the user is not actually on. An earlier
-     * token-overlap "partial" tier (matching on any shared word after splitting on `.`/`-`/`_`)
-     * was removed for exactly that reason - filtering bare TLD labels ("com", "org", ...) out
-     * of the comparison closed the "every .com secret matches every .com site" case
-     * (BossConsole#460), but the tier still matched two different registrable domains that
-     * merely share a brand-ish label (`apple.com` vs `apple.org`, `google.com` vs
-     * `google-workspace.com`) - the same wrong-site-credential problem, just narrower. See
-     * [WebsiteMatchingUtilTest] for the cross-domain cases this is required not to match.
+     * Substrings and shared labels do not establish a domain relationship and must not
+     * produce credential suggestions. Only equality and a dot-delimited suffix qualify.
+     * This scorer does not validate public suffixes; [extractMainDomain] retains its existing
+     * limited suffix handling, so this is not a complete registrable-domain policy.
      *
      * @param domain Current website domain (e.g., "google.com")
      * @param secrets List of all available secrets

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WebsiteMatchingBoundaryRegressionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WebsiteMatchingBoundaryRegressionTest.kt
@@ -1,0 +1,60 @@
+package ai.rever.boss.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WebsiteMatchingBoundaryRegressionTest {
+    @Test
+    fun `calculateMatchScore enforces domain boundaries and rejects substrings`() {
+        // 1. Exact match
+        var match = WebsiteMatchingUtil.calculateMatchScore("apple.com", "apple.com")
+        assertEquals(1.0f, match.score)
+        assertEquals("exact", match.reason)
+
+        // 2. Legitimate subdomain match in both directions
+        match = WebsiteMatchingUtil.calculateMatchScore("apple.com", "login.apple.com")
+        assertEquals(0.9f, match.score)
+        assertEquals("subdomain", match.reason)
+
+        match = WebsiteMatchingUtil.calculateMatchScore("login.apple.com", "apple.com")
+        assertEquals(0.9f, match.score)
+        assertEquals("subdomain", match.reason)
+
+        // 3. Substring collision rejection
+        match = WebsiteMatchingUtil.calculateMatchScore("apple.com", "snapple.com")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+
+        match = WebsiteMatchingUtil.calculateMatchScore("snapple.com", "apple.com")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+
+        match = WebsiteMatchingUtil.calculateMatchScore("apple.com", "login-apple.com")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+
+        // 4. Same-TLD rejection
+        match = WebsiteMatchingUtil.calculateMatchScore("google.com", "example.com")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+
+        // 5. Multi-part TLD/domain rejection
+        match = WebsiteMatchingUtil.calculateMatchScore("google.co.uk", "example.co.uk")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+    }
+
+    @Test
+    fun `getDisplayName formats domain names correctly`() {
+        // Base case
+        assertEquals("Google", WebsiteMatchingUtil.getDisplayName("google.com"))
+
+        // 6. Digit-initial display names (regression test for the duplication bug)
+        assertEquals("1password", WebsiteMatchingUtil.getDisplayName("1password.com"))
+        assertEquals("9gag", WebsiteMatchingUtil.getDisplayName("9gag.com"))
+
+        // 7. Existing hyphen/underscore formatting regression
+        assertEquals("Example Site", WebsiteMatchingUtil.getDisplayName("example-site.com"))
+        assertEquals("Some Example Site", WebsiteMatchingUtil.getDisplayName("some_example-site.com"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WebsiteMatchingUtilTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WebsiteMatchingUtilTest.kt
@@ -1,0 +1,86 @@
+package ai.rever.boss.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins [WebsiteMatchingUtil.calculateMatchScore] and [WebsiteMatchingUtil.getDisplayName]
+ * against the over-broad matching BossConsole#460 reports: an unanchored `contains` check
+ * that let a secret for one site surface on an unrelated one sharing a substring, and a
+ * token-overlap fallback that let any shared TLD label ("com", "org", ...) count as a match.
+ */
+class WebsiteMatchingUtilTest {
+    // ---- Finding A: unanchored substring must not match ----
+
+    @Test
+    fun `a secret for apple does not match a site that merely contains the word as a substring`() {
+        val score = WebsiteMatchingUtil.calculateMatchScore("apple.com", "snapple.com")
+        assertEquals(0.0f, score.score)
+        assertEquals("no_match", score.reason)
+    }
+
+    // ---- Finding B: a bare TLD/public-suffix label must not count as a shared token ----
+
+    @Test
+    fun `a dot-com secret does not match an unrelated dot-com site`() {
+        val score = WebsiteMatchingUtil.calculateMatchScore("google.com", "example.com")
+        assertEquals(0.0f, score.score)
+        assertEquals("no_match", score.reason)
+    }
+
+    @Test
+    fun `a dot-org secret does not match an unrelated dot-org site`() {
+        val score = WebsiteMatchingUtil.calculateMatchScore("wikipedia.org", "example.org")
+        assertEquals(0.0f, score.score)
+    }
+
+    // ---- Legitimate matches must survive the fix ----
+
+    @Test
+    fun `exact match still scores 1_0`() {
+        val score = WebsiteMatchingUtil.calculateMatchScore("google.com", "google.com")
+        assertEquals(1.0f, score.score)
+        assertEquals("exact", score.reason)
+    }
+
+    @Test
+    fun `a subdomain still matches its parent domain`() {
+        val score = WebsiteMatchingUtil.calculateMatchScore("google.com", "login.google.com")
+        assertEquals(0.9f, score.score)
+        assertEquals("subdomain", score.reason)
+    }
+
+    @Test
+    fun `a shared non-TLD label still partially matches`() {
+        val score = WebsiteMatchingUtil.calculateMatchScore("google.com", "google-workspace.com")
+        assertEquals(0.5f, score.score)
+        assertEquals("partial", score.reason)
+    }
+
+    @Test
+    fun `two entirely unrelated domains score zero`() {
+        val score = WebsiteMatchingUtil.calculateMatchScore("github.com", "example.net")
+        assertEquals(0.0f, score.score)
+        assertTrue(score.reason == "no_match")
+    }
+
+    // ---- Finding C: getDisplayName must not duplicate a digit-initial word ----
+
+    @Test
+    fun `a digit-initial domain name is not duplicated`() {
+        assertEquals("1password", WebsiteMatchingUtil.getDisplayName("1password.com"))
+        assertEquals("9gag", WebsiteMatchingUtil.getDisplayName("9gag.com"))
+    }
+
+    @Test
+    fun `known brand display names are unaffected`() {
+        assertEquals("GitHub", WebsiteMatchingUtil.getDisplayName("github.com"))
+        assertEquals("Google", WebsiteMatchingUtil.getDisplayName("google.com"))
+    }
+
+    @Test
+    fun `hyphenated generic domains are still title-cased per word`() {
+        assertEquals("Example Site", WebsiteMatchingUtil.getDisplayName("example-site.com"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WebsiteMatchingUtilTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WebsiteMatchingUtilTest.kt
@@ -1,17 +1,37 @@
 package ai.rever.boss.utils
 
+import ai.rever.boss.services.supabase.models.SecretEntry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
  * Pins [WebsiteMatchingUtil.calculateMatchScore] and [WebsiteMatchingUtil.getDisplayName]
- * against the over-broad matching BossConsole#460 reports: an unanchored `contains` check
- * that let a secret for one site surface on an unrelated one sharing a substring, and a
- * token-overlap fallback that let any shared TLD label ("com", "org", ...) count as a match.
+ * against the over-broad matching BossConsole#460 reports.
+ *
+ * The scorer now recognizes exactly two shapes - exact registrable-domain equality and a real
+ * subdomain boundary - matching what a password manager keys on. Two earlier tiers are gone
+ * rather than patched: an unanchored `contains` check (a secret for `apple.com` matched the
+ * unrelated site `snapple.com`), and a token-overlap "partial" fallback that matched any shared
+ * word after splitting on `.`/`-`/`_`. Excluding bare TLD labels from that fallback closed the
+ * "every .com secret matches every .com site" case, but it still matched two different
+ * registrable domains sharing a brand-ish label (`apple.com` vs `apple.org`, `google.com` vs
+ * `google-workspace.com`) - the same wrong-site-credential problem, just narrower. Precision
+ * wins over recall on a credentials surface: a missed suggestion is an inconvenience, a wrong
+ * one hands the user someone else's password.
  */
 class WebsiteMatchingUtilTest {
-    // ---- Finding A: unanchored substring must not match ----
+    private fun secret(website: String) =
+        SecretEntry(
+            id = "1",
+            website = website,
+            username = "user",
+            password = "pass",
+            createdAt = "2026-01-01T00:00:00Z",
+            updatedAt = "2026-01-01T00:00:00Z",
+        )
+
+    // ---- An unanchored substring must not match ----
 
     @Test
     fun `a secret for apple does not match a site that merely contains the word as a substring`() {
@@ -20,7 +40,17 @@ class WebsiteMatchingUtilTest {
         assertEquals("no_match", score.reason)
     }
 
-    // ---- Finding B: a bare TLD/public-suffix label must not count as a shared token ----
+    @Test
+    fun `a secret for apple does not match a hyphenated site that contains it as a whole word`() {
+        // Would have scored 0.5 "partial" under the old token-overlap fallback (shared word
+        // "apple") - still the wrong-site-credential problem the unanchored contains check had,
+        // just reached a different way.
+        val score = WebsiteMatchingUtil.calculateMatchScore("apple.com", "login-apple.com")
+        assertEquals(0.0f, score.score)
+        assertEquals("no_match", score.reason)
+    }
+
+    // ---- A bare TLD label must not count as a shared token ----
 
     @Test
     fun `a dot-com secret does not match an unrelated dot-com site`() {
@@ -33,6 +63,24 @@ class WebsiteMatchingUtilTest {
     fun `a dot-org secret does not match an unrelated dot-org site`() {
         val score = WebsiteMatchingUtil.calculateMatchScore("wikipedia.org", "example.org")
         assertEquals(0.0f, score.score)
+    }
+
+    // ---- Two different registrable domains sharing a brand label must not match ----
+
+    @Test
+    fun `apple dot com and apple dot org are different registrable domains and do not match`() {
+        val score = WebsiteMatchingUtil.calculateMatchScore("apple.com", "apple.org")
+        assertEquals(0.0f, score.score)
+        assertEquals("no_match", score.reason)
+    }
+
+    @Test
+    fun `google dot com and google-workspace dot com are different registrable domains and do not match`() {
+        // The exact case the old "partial" tier's own docstring cited as intentional - a shared
+        // brand word is not the same domain, and this surface must not offer one for the other.
+        val score = WebsiteMatchingUtil.calculateMatchScore("google.com", "google-workspace.com")
+        assertEquals(0.0f, score.score)
+        assertEquals("no_match", score.reason)
     }
 
     // ---- Legitimate matches must survive the fix ----
@@ -52,10 +100,28 @@ class WebsiteMatchingUtilTest {
     }
 
     @Test
-    fun `a shared non-TLD label still partially matches`() {
-        val score = WebsiteMatchingUtil.calculateMatchScore("google.com", "google-workspace.com")
-        assertEquals(0.5f, score.score)
-        assertEquals("partial", score.reason)
+    fun `a www-prefixed secret still exact-matches the bare domain`() {
+        // matchSecretsForDomain strips a leading www. from the page domain, and
+        // extractMainDomain does the same for the secret's stored website - a secret saved as
+        // "www.google.com" must still resolve to an exact match on "google.com", not merely
+        // a subdomain match.
+        val matches =
+            WebsiteMatchingUtil.matchSecretsForDomain(
+                domain = "google.com",
+                secrets = listOf(secret("www.google.com")),
+            )
+        assertEquals(1, matches.size)
+        assertEquals("exact", matches.single().matchReason)
+    }
+
+    @Test
+    fun `www normalization does not turn a shared-TLD pair into a match`() {
+        val matches =
+            WebsiteMatchingUtil.matchSecretsForDomain(
+                domain = "www.example.com",
+                secrets = listOf(secret("www.google.com")),
+            )
+        assertTrue(matches.isEmpty())
     }
 
     @Test
@@ -65,7 +131,42 @@ class WebsiteMatchingUtilTest {
         assertTrue(score.reason == "no_match")
     }
 
-    // ---- Finding C: getDisplayName must not duplicate a digit-initial word ----
+    @Test
+    fun `blank sides do not vacuously exact-match each other`() {
+        assertEquals(0.0f, WebsiteMatchingUtil.calculateMatchScore("", "").score)
+        assertEquals(0.0f, WebsiteMatchingUtil.calculateMatchScore("", "example.com").score)
+    }
+
+    // ---- End to end: the actual suggestion path a user sees ----
+
+    @Test
+    fun `matchSecretsForDomain offers the exact-match secret and nothing else`() {
+        val matches =
+            WebsiteMatchingUtil.matchSecretsForDomain(
+                domain = "google.com",
+                secrets =
+                    listOf(
+                        secret("google.com"),
+                        secret("apple.org"),
+                        secret("google-workspace.com"),
+                    ),
+            )
+        assertEquals(1, matches.size)
+        assertEquals("google.com", matches.single().secret.website)
+        assertEquals("exact", matches.single().matchReason)
+    }
+
+    @Test
+    fun `matchSecretsForDomain offers nothing for a site with no related saved secret`() {
+        val matches =
+            WebsiteMatchingUtil.matchSecretsForDomain(
+                domain = "snapple.com",
+                secrets = listOf(secret("apple.com"), secret("apple.org")),
+            )
+        assertTrue(matches.isEmpty())
+    }
+
+    // ---- getDisplayName must not duplicate a digit-initial word ----
 
     @Test
     fun `a digit-initial domain name is not duplicated`() {

--- a/docs/SECRET_BROWSER_INTEGRATION.md
+++ b/docs/SECRET_BROWSER_INTEGRATION.md
@@ -13,7 +13,7 @@ This feature integrates BOSS's secret management system with the Fluck browser, 
 ### 1. Context Menu Integration
 - **Right-click detection** on form fields (username, password, email)
 - **Intelligent field detection** using multiple heuristics
-- **Domain-based secret matching** with fuzzy scoring
+- **Domain-based secret matching** with exact and dot-boundary scoring
 - **Visual indicators** for matched secrets
 
 ### 2. Auto-Fill Capabilities
@@ -58,16 +58,23 @@ suspend fun getCurrentFocusedField(browser: Browser): FormFieldInfo?
 
 Handles domain extraction and secret matching:
 - **Domain normalization** (removes www, common subdomains)
-- **Fuzzy matching** with confidence scores
-- **TLD handling** (co.uk, com.au, etc.)
+- **Exact and dot-boundary matching** with confidence scores
+- **Limited suffix handling** using six hardcoded two-part suffixes, not a public-suffix list
 
 **Scoring System**:
 ```
 Exact match (google.com == google.com):      1.0
 Subdomain match (login.google.com):          0.9
-Domain contains (google):                    0.7
-Partial match (keywords):                    0.5
+Blank or unrelated domains:                  0.0
 ```
+
+The scorer rejects substring and shared-token matches. The extractor can still collapse
+unrelated domains under unlisted public or private suffixes; these scores do not establish
+a complete registrable-domain or hosted-tenant isolation policy.
+
+This section describes the host utility. Current Fluck plugin matching is implemented in
+the separate `boss-plugin-fluck-browser` repository; the host ViewModel construction below
+is an integration example, not evidence that the current plugin uses this utility.
 
 **Key Methods**:
 ```kotlin


### PR DESCRIPTION
Addresses the host utility in #460. Consolidates #467.

The host utility scored `apple.com` against `snapple.com`, and every `.com` secret could match an unrelated `.com` page. The scorer now accepts only exact equality or a dot-delimited subdomain relationship, rejects blank inputs, and removes both substring and shared-token heuristics. Digit-initial display names now render `1password` and `9gag` without duplication.

Contributors:
- @Antriksh1984 (#461): matcher and display-name fixes, blank-input guard, 17 regression tests; adopted the stricter matcher after feedback.
- @Rushikeshiitb: #460 report, strict-matching design and end-to-end test guidance incorporated by @Antriksh1984.
- @Sahvendra7 (#467): independently implemented the same matcher/display fixes; both original regression test methods are retained as WebsiteMatchingBoundaryRegressionTest, including reverse subdomain, multipart suffix and underscore cases.
- Review agent: integrated current dev, consolidated the tests, and corrected documentation that overstated the existing URL extractor. No contributor credit is claimed for those integration edits.

Validation: all 19 consolidated matcher/display tests passed, zero failures/errors/skips; root ktlintCheck and detekt passed through the shared build lock. Both original heads had green multi-platform CI. All hosted checks passed on code/test head `2abee38e82d466e96386a23ef316aaa1c4d3d9ad`; Claude reviewed it with no blockers. The follow-up only corrects the integration guide, addressing the valid stale-scoring-table finding. Final documentation-head checks may still be pending.

Runtime provenance: current host source does not construct BrowserSecretIntegrationViewModel (the only construction example is documentation). The independently maintained Fluck plugin already fixed its active matcher in [boss-plugin-fluck-browser#26](https://github.com/risa-labs-inc/boss-plugin-fluck-browser/pull/26), verified against current upstream source. This PR hardens the remaining host utility and adds regression coverage; it does not ship that earlier plugin fix again.

Scope: the existing URL extractor uses limited suffix heuristics, not a complete public-suffix parser. This change removes the two unsafe scorer heuristics; it does not claim universal isolation for hosted tenants or redesign URL normalization.

Manual checks for any future integration of this host utility (not claimed as current UI validation): with synthetic credentials, confirm apple.com is absent on snapple.com, login-apple.com and apple.org; same-site/subdomain suggestions remain; display names show 1password and 9gag once. No app was launched or stopped for this review.
