### PR TITLE
fix(secrets): prevent cross-domain website matches

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
@@ -179,21 +179,14 @@ object WebsiteMatchingUtil {
             }
 
             // Domain contains other (google.com contains google)
-            secretNorm.contains(domainNorm) || domainNorm.contains(secretNorm) -> {
-                MatchScore(0.7f, "domain")
-            }
+            // REMOVED (Issue #460): Unanchored substring matches cause false positives
+            // e.g., snapple.com contains apple.com.
 
             // Partial match (same keywords)
-            else -> {
-                val secretParts = secretNorm.split(".", "-", "_")
-                val domainParts = domainNorm.split(".", "-", "_")
-                val commonParts = secretParts.intersect(domainParts.toSet())
+            // REMOVED (Issue #460): Splitting on TLDs causes every .com site to match.
 
-                if (commonParts.isNotEmpty()) {
-                    MatchScore(0.5f, "partial")
-                } else {
-                    MatchScore(0.0f, "no_match")
-                }
+            else -> {
+                MatchScore(0.0f, "no_match")
             }
         }
     }
@@ -265,7 +258,11 @@ object WebsiteMatchingUtil {
                 // Generic formatting: example-site → Example Site
                 nameWithoutTld
                     .split("-", "_")
-                    .joinToString(" ") { it.replaceFirstChar { c -> if (c.isLowerCase()) c.titlecase() else it } }
+                    .joinToString(" ") {
+                        it.replaceFirstChar { c ->
+                            if (c.isLowerCase()) c.titlecase() else c.toString()
+                        }
+                    }
             }
         }
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WebsiteMatchingUtilTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WebsiteMatchingUtilTest.kt
@@ -1,0 +1,60 @@
+package ai.rever.boss.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WebsiteMatchingUtilTest {
+    @Test
+    fun `calculateMatchScore enforces domain boundaries and rejects substrings`() {
+        // 1. Exact match
+        var match = WebsiteMatchingUtil.calculateMatchScore("apple.com", "apple.com")
+        assertEquals(1.0f, match.score)
+        assertEquals("exact", match.reason)
+
+        // 2. Legitimate subdomain match in both directions
+        match = WebsiteMatchingUtil.calculateMatchScore("apple.com", "login.apple.com")
+        assertEquals(0.9f, match.score)
+        assertEquals("subdomain", match.reason)
+
+        match = WebsiteMatchingUtil.calculateMatchScore("login.apple.com", "apple.com")
+        assertEquals(0.9f, match.score)
+        assertEquals("subdomain", match.reason)
+
+        // 3. Substring collision rejection
+        match = WebsiteMatchingUtil.calculateMatchScore("apple.com", "snapple.com")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+
+        match = WebsiteMatchingUtil.calculateMatchScore("snapple.com", "apple.com")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+
+        match = WebsiteMatchingUtil.calculateMatchScore("apple.com", "login-apple.com")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+
+        // 4. Same-TLD rejection
+        match = WebsiteMatchingUtil.calculateMatchScore("google.com", "example.com")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+
+        // 5. Multi-part TLD/domain rejection
+        match = WebsiteMatchingUtil.calculateMatchScore("google.co.uk", "example.co.uk")
+        assertEquals(0.0f, match.score)
+        assertEquals("no_match", match.reason)
+    }
+
+    @Test
+    fun `getDisplayName formats domain names correctly`() {
+        // Base case
+        assertEquals("Google", WebsiteMatchingUtil.getDisplayName("google.com"))
+
+        // 6. Digit-initial display names (regression test for the duplication bug)
+        assertEquals("1password", WebsiteMatchingUtil.getDisplayName("1password.com"))
+        assertEquals("9gag", WebsiteMatchingUtil.getDisplayName("9gag.com"))
+
+        // 7. Existing hyphen/underscore formatting regression
+        assertEquals("Example Site", WebsiteMatchingUtil.getDisplayName("example-site.com"))
+        assertEquals("Some Example Site", WebsiteMatchingUtil.getDisplayName("some_example-site.com"))
+    }
+}


### PR DESCRIPTION
Fixes #460

### Security/Correctness Bug Fix
This PR removes the unsafe heuristic branches in `WebsiteMatchingUtil.calculateMatchScore()` that caused false-positive domain matches:
* **Substring matches**: An unanchored `contains` check previously caused `snapple.com` to suggest secrets for `apple.com`.
* **TLD overlap**: Splitting domains by `.` and intersecting the tokens previously caused all `.com` secrets to be suggested on all `.com` pages because they shared the `com` token.

These checks have been removed. The matcher now correctly relies solely on `extractMainDomain()` (which already reduces domains to their registrable eTLD+1) along with a strict equality check and a leading-dot bounded subdomain check.

### Display Name Fix
This PR also fixes the bug in `getDisplayName()` where digit-initial domains (like `1password`) duplicated their names (e.g. `1passwordpassword`). The `replaceFirstChar` fallback now correctly returns the original character as a string rather than the entire token.

### Validation
Added `WebsiteMatchingUtilTest.kt` covering:
* Exact match
* Subdomain match (both directions)
* Substring collision rejection
* Same-TLD rejection
* Multi-part TLD rejection
* Digit-initial display names

All new and existing tests pass. ktlint and detekt pass.