### PR TITLE
feat(mcp): let an operator persist an Allow/Deny tool policy from the approval dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1035,8 +1035,11 @@ plugins. Unknown tool names default to ALLOW. Known mutations default to ASK wit
 a 45-second timeout. Each queued prompt is delivered to exactly one window and
 window teardown denies its owned request. Session trust is process-wide and can
 be cleared using “Revoke MCP session trust” in the bottom bar; restore the bar if
-it is hidden. Persistent rules currently require editing ~/.boss/mcp-tool-policy.json
-and restarting. Preserve a backup before manual recovery of a damaged policy;
+it is hidden. The approval dialog offers Always Allow and Always Deny, which save
+a tool-wide rule for all agents and arguments across restarts. Changing a saved rule
+still requires editing ~/.boss/mcp-tool-policy.json and restarting. Failed writes
+record POLICY_PERSIST_FAILED and withhold the current execution. A queued approval
+cannot replace a newer DENY. Preserve a backup before manual recovery of a damaged policy;
 the fault flow withholds all tools until recovery. No automatic quarantine UI is
 provided. Ledger redaction is bounded and best effort, not a guarantee for secrets
 under arbitrary keys. Queue overflow and cancellation before/after dispatch have

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1102,11 +1102,14 @@ be cleared using “Revoke MCP session trust” in the bottom bar; restore the b
 it is hidden. The approval dialog offers Always Allow and Always Deny, which save
 a tool-wide rule for all agents and arguments across restarts. Saved rules can be
 reviewed and reset from “Persisted MCP policies” in the bottom bar; a reset removes
-the rule rather than rewriting it, so the tool falls back through session trust to
-the configured default policy. Failed writes record POLICY_PERSIST_FAILED and
-withhold the current execution. A queued approval cannot replace a newer DENY, but
-a queued approval resolved after a manual reset of that same rule can still
-reinstate it - the preserve check only looks for DENY, not "was just reset."
+the rule and clears that tool's session trust, so the tool uses the configured default
+policy (ASK for known mutations in the shipped defaults). Unrelated DENYs remain intact.
+A failed reset keeps the previous durable rule visible and clears the selected session
+trust; it does not promise ASK if a saved ALLOW remains. Failed approval writes record
+POLICY_PERSIST_FAILED and withhold the current execution. A queued approval cannot
+replace a newer DENY or reset: each reset invalidates older authorizations before their
+final approval boundary, including queued once/session/persistent grants. Calls already
+authorized to execute are not cancelled. Reset remains host UI only, not an MCP tool.
 Preserve a backup before manual recovery of a damaged policy;
 the fault flow withholds all tools until recovery. No automatic quarantine UI is
 provided. Ledger redaction is bounded and best effort, not a guarantee for secrets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1036,10 +1036,14 @@ a 45-second timeout. Each queued prompt is delivered to exactly one window and
 window teardown denies its owned request. Session trust is process-wide and can
 be cleared using “Revoke MCP session trust” in the bottom bar; restore the bar if
 it is hidden. The approval dialog offers Always Allow and Always Deny, which save
-a tool-wide rule for all agents and arguments across restarts. Changing a saved rule
-still requires editing ~/.boss/mcp-tool-policy.json and restarting. Failed writes
-record POLICY_PERSIST_FAILED and withhold the current execution. A queued approval
-cannot replace a newer DENY. Preserve a backup before manual recovery of a damaged policy;
+a tool-wide rule for all agents and arguments across restarts. Saved rules can be
+reviewed and reset from “Persisted MCP policies” in the bottom bar; a reset removes
+the rule rather than rewriting it, so the tool falls back through session trust to
+the configured default policy. Failed writes record POLICY_PERSIST_FAILED and
+withhold the current execution. A queued approval cannot replace a newer DENY, but
+a queued approval resolved after a manual reset of that same rule can still
+reinstate it - the preserve check only looks for DENY, not "was just reset."
+Preserve a backup before manual recovery of a damaged policy;
 the fault flow withholds all tools until recovery. No automatic quarantine UI is
 provided. Ledger redaction is bounded and best effort, not a guarantee for secrets
 under arbitrary keys. Queue overflow and cancellation before/after dispatch have

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -808,11 +808,11 @@ internal fun BossAppDialogs(state: BossAppState) {
         McpApprovalDialog(
             request = approvalRequest,
             pendingQueueSize = pendingList.size,
-            onApprove = { trustForSession ->
-                McpToolRegistryImpl.approvalBus.approve(approvalRequest.id, trustForSession)
+            onApprove = { trustForSession, persistPolicy ->
+                McpToolRegistryImpl.approvalBus.approve(approvalRequest.id, trustForSession, persistPolicy)
             },
-            onDeny = { reason ->
-                McpToolRegistryImpl.approvalBus.deny(approvalRequest.id, reason)
+            onDeny = { reason, persistPolicy ->
+                McpToolRegistryImpl.approvalBus.deny(approvalRequest.id, reason, persistPolicy)
             },
         )
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.components.bars.getBarScrollbarConfig
 import ai.rever.boss.components.bars.horizontalScrollWithScrollbar
 import ai.rever.boss.components.bars.rememberBarContextMenuItems
 import ai.rever.boss.components.buttons.BossActionButton
+import ai.rever.boss.components.dialogs.McpPolicyManagerDialog
 import ai.rever.boss.components.events.PanelEventBus
 import ai.rever.boss.components.overlays.contextMenu
 import ai.rever.boss.components.plugin.registries.StatusBarRegistryImpl
@@ -230,6 +231,27 @@ fun BossRightBottomBar() {
         androidx.compose.material.TextButton(onClick = { McpToolRegistryImpl.policyEngine.clearSessionTrusts() }) {
             Text("Revoke MCP session trust (${trustedTools.size})", color = BossTheme.colors.alert)
         }
+    }
+
+    // Inspection/revocation for a rule saved via the approval dialog's "Always Allow"/"Always
+    // Deny" - the gap AGENTS.md's governance section names as reachable only by hand-editing
+    // ~/.boss/mcp-tool-policy.json and restarting.
+    val persistedPolicyConfig by McpToolRegistryImpl.policyEngine.config.collectAsState()
+    var showPolicyManager by remember { mutableStateOf(false) }
+    if (persistedPolicyConfig.rules.isNotEmpty()) {
+        androidx.compose.material.TextButton(onClick = { showPolicyManager = true }) {
+            Text(
+                "Persisted MCP policies (${persistedPolicyConfig.rules.size})",
+                color = BossTheme.colors.textSecondary,
+            )
+        }
+    }
+    if (showPolicyManager) {
+        McpPolicyManagerDialog(
+            rules = persistedPolicyConfig.rules,
+            onRevoke = { toolName -> McpToolRegistryImpl.policyEngine.revokePersistedPolicy(toolName) },
+            onDismiss = { showPolicyManager = false },
+        )
     }
 
     val policyFault by McpToolRegistryImpl.policyFault.collectAsState()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
@@ -47,7 +47,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun BossBottomBar(tabsComponent: BossTabsComponent? = null) {
@@ -249,7 +251,16 @@ fun BossRightBottomBar() {
     if (showPolicyManager) {
         McpPolicyManagerDialog(
             rules = persistedPolicyConfig.rules,
-            onRevoke = { toolName -> McpToolRegistryImpl.policyEngine.revokePersistedPolicy(toolName) },
+            // Dispatchers.IO: revokePersistedPolicy does a synchronized atomicWriteText disk
+            // write, and setToolPolicy already made the equivalent invocation-path write take
+            // this same dispatcher (McpToolRegistryImpl) - this call site was the one still
+            // running it on the UI thread, where a click could block behind another write
+            // holding the same lock from a slow, networked or AV-scanned home directory.
+            onRevoke = { toolName ->
+                withContext(Dispatchers.IO) {
+                    McpToolRegistryImpl.policyEngine.revokePersistedPolicy(toolName)
+                }
+            },
             onDismiss = { showPolicyManager = false },
         )
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpApprovalDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpApprovalDialog.kt
@@ -48,14 +48,21 @@ import androidx.compose.ui.window.DialogProperties
 /**
  * Interactive dialog prompted when an AI agent attempts to execute a tool
  * governed by an ASK policy.
+ *
+ * Four scopes an operator can choose, in increasing durability: approve or deny just this one
+ * call, trust it for the rest of this session only, or persist a rule to
+ * `~/.boss/mcp-tool-policy.json` so the same tool never asks again - across restarts, not just
+ * this run. The engine behind the persisted scope ([ai.rever.boss.mcp.McpPolicyEngine
+ * .setToolPolicy]) already existed and was already tested; this dialog was the only thing
+ * standing between it and an operator who wanted to use it without hand-editing that file.
  */
 @Composable
 @Suppress("LongMethod") // Declarative Compose layout.
 fun McpApprovalDialog(
     request: McpApprovalRequest,
     pendingQueueSize: Int = 1,
-    onApprove: (trustForSession: Boolean) -> Unit,
-    onDeny: (reason: String) -> Unit,
+    onApprove: (trustForSession: Boolean, persistPolicy: Boolean) -> Unit,
+    onDeny: (reason: String, persistPolicy: Boolean) -> Unit,
 ) {
     val colors = BossTheme.colors
     val radii = BossTheme.radius
@@ -66,7 +73,7 @@ fun McpApprovalDialog(
     BossDialog(
         // onDismissRequest is required by BossDialog; outside-click and back-press are disabled below
         // to enforce deliberate operator approval or denial.
-        onDismissRequest = { onDeny("Dismissed by operator") },
+        onDismissRequest = { onDeny("Dismissed by operator", false) },
         properties =
             DialogProperties(
                 dismissOnClickOutside = false,
@@ -222,7 +229,37 @@ fun McpApprovalDialog(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(20.dp))
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Persistent-scope actions: a rule written to disk, surviving a restart - kept
+                // visually secondary to the actions below since they are the more consequential,
+                // less common choice.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(
+                        onClick = {
+                            val reason = rejectionReason.ifBlank { "Operator declined this action" }
+                            onDeny(reason, true)
+                        },
+                        colors = ButtonDefaults.textButtonColors(contentColor = colors.alert),
+                    ) {
+                        Text("Always Deny", fontSize = 11.sp)
+                    }
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    TextButton(
+                        onClick = { onApprove(false, true) },
+                        colors = ButtonDefaults.textButtonColors(contentColor = colors.textSecondary),
+                    ) {
+                        Text("Always Allow", fontSize = 11.sp)
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
 
                 // Actions
                 Row(
@@ -243,7 +280,7 @@ fun McpApprovalDialog(
                     Button(
                         onClick = {
                             val reason = rejectionReason.ifBlank { "Operator declined this action" }
-                            onDeny(reason)
+                            onDeny(reason, false)
                         },
                         colors = ButtonDefaults.buttonColors(backgroundColor = colors.alert),
                     ) {
@@ -253,7 +290,7 @@ fun McpApprovalDialog(
                     Spacer(modifier = Modifier.width(8.dp))
 
                     OutlinedButton(
-                        onClick = { onApprove(true) },
+                        onClick = { onApprove(true, false) },
                         border = ButtonDefaults.outlinedBorder,
                         colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.textPrimary),
                     ) {
@@ -263,7 +300,7 @@ fun McpApprovalDialog(
                     Spacer(modifier = Modifier.width(8.dp))
 
                     Button(
-                        onClick = { onApprove(false) },
+                        onClick = { onApprove(false, false) },
                         colors = ButtonDefaults.buttonColors(backgroundColor = colors.signal),
                     ) {
                         Text("Approve Once", color = colors.onSignal, fontSize = 12.sp)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpApprovalDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpApprovalDialog.kt
@@ -234,7 +234,7 @@ fun McpApprovalDialog(
                 Text(
                     "Always choices apply to this tool name for all agents and arguments, across restarts " +
                         "and replacement plugins. " +
-                        "To change a saved rule, edit ~/.boss/mcp-tool-policy.json and restart BOSS.",
+                        "Saved rules can be reviewed and reset from \"Persisted MCP policies\" in the bottom bar.",
                     color = colors.textSecondary,
                     fontSize = 11.sp,
                 )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpApprovalDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpApprovalDialog.kt
@@ -231,6 +231,14 @@ fun McpApprovalDialog(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
+                Text(
+                    "Always choices apply to this tool name for all agents and arguments, across restarts " +
+                        "and replacement plugins. " +
+                        "To change a saved rule, edit ~/.boss/mcp-tool-policy.json and restart BOSS.",
+                    color = colors.textSecondary,
+                    fontSize = 11.sp,
+                )
+
                 // Persistent-scope actions: a rule written to disk, surviving a restart - kept
                 // visually secondary to the actions below since they are the more consequential,
                 // less common choice.
@@ -253,7 +261,7 @@ fun McpApprovalDialog(
 
                     TextButton(
                         onClick = { onApprove(false, true) },
-                        colors = ButtonDefaults.textButtonColors(contentColor = colors.textSecondary),
+                        colors = ButtonDefaults.textButtonColors(contentColor = colors.warn),
                     ) {
                         Text("Always Allow", fontSize = 11.sp)
                     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpPolicyManagerDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpPolicyManagerDialog.kt
@@ -1,0 +1,152 @@
+package ai.rever.boss.components.dialogs
+
+import ai.rever.boss.mcp.McpPolicyAction
+import ai.rever.boss.plugin.ui.BossDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * Lets an operator see and undo every persistent MCP tool policy rule saved from the approval
+ * dialog's "Always Allow"/"Always Deny" actions ([McpApprovalDialog]) - the inspection and
+ * revocation path this repo's own AGENTS.md names as reachable only by hand-editing
+ * `~/.boss/mcp-tool-policy.json` and restarting, until this dialog existed.
+ *
+ * [rules] is a snapshot the caller re-derives from [ai.rever.boss.mcp.McpPolicyEngine.config] on
+ * every recomposition, not a copy this dialog owns - a revoke calls back into [onRevoke] and
+ * waits for the same state flow to reflect it, rather than mutating a local list that could drift
+ * from what is actually on disk.
+ */
+@Composable
+@Suppress("LongMethod") // Declarative Compose layout.
+fun McpPolicyManagerDialog(
+    rules: Map<String, McpPolicyAction>,
+    onRevoke: (toolName: String) -> Boolean,
+    onDismiss: () -> Unit,
+) {
+    val colors = BossTheme.colors
+    val radii = BossTheme.radius
+    // Which tool's revoke most recently failed to persist - cleared on the next attempt for that
+    // tool, so a stale error does not linger once retried.
+    var failedRevoke by remember { mutableStateOf<String?>(null) }
+
+    BossDialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(),
+    ) {
+        Surface(
+            modifier = Modifier.width(480.dp).wrapContentHeight(),
+            shape = RoundedCornerShape(radii.dialog),
+            color = colors.panel,
+        ) {
+            Column(modifier = Modifier.padding(24.dp)) {
+                Text(
+                    text = "Persistent MCP Tool Policies",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = colors.textPrimary,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text =
+                        "Saved from \"Always Allow\" / \"Always Deny\" in the tool approval dialog. " +
+                            "Resetting a tool returns it to Ask - the next mutating call prompts again.",
+                    fontSize = 12.sp,
+                    color = colors.textSecondary,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+
+                if (rules.isEmpty()) {
+                    Text(
+                        text = "No persistent rules saved. Every tool still asks on each mutating call.",
+                        fontSize = 13.sp,
+                        color = colors.textSecondary,
+                    )
+                } else {
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 320.dp)
+                                .verticalScroll(rememberScrollState()),
+                    ) {
+                        rules.toSortedMap().forEach { (toolName, action) ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = toolName,
+                                        fontSize = 13.sp,
+                                        fontFamily = FontFamily.Monospace,
+                                        color = colors.textPrimary,
+                                    )
+                                    Text(
+                                        text = action.name,
+                                        fontSize = 11.sp,
+                                        fontWeight = FontWeight.Medium,
+                                        color = if (action == McpPolicyAction.DENY) colors.alert else colors.signal,
+                                    )
+                                    if (failedRevoke == toolName) {
+                                        Text(
+                                            text = "Could not save - see the host log for the reason.",
+                                            fontSize = 11.sp,
+                                            color = colors.alert,
+                                        )
+                                    }
+                                }
+                                Spacer(modifier = Modifier.width(8.dp))
+                                TextButton(
+                                    onClick = {
+                                        failedRevoke = if (onRevoke(toolName)) null else toolName
+                                    },
+                                ) {
+                                    Text("Reset to Ask", fontSize = 12.sp)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    Button(
+                        onClick = onDismiss,
+                        colors = ButtonDefaults.buttonColors(backgroundColor = colors.signal),
+                    ) {
+                        Text("Close", color = colors.onSignal, fontSize = 12.sp)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpPolicyManagerDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpPolicyManagerDialog.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.launch
 
 /**
  * Lets an operator see and undo every persistent MCP tool policy rule saved from the approval
@@ -49,14 +51,22 @@ import androidx.compose.ui.window.DialogProperties
 @Suppress("LongMethod") // Declarative Compose layout.
 fun McpPolicyManagerDialog(
     rules: Map<String, McpPolicyAction>,
-    onRevoke: (toolName: String) -> Boolean,
+    onRevoke: suspend (toolName: String) -> Boolean,
     onDismiss: () -> Unit,
 ) {
     val colors = BossTheme.colors
     val radii = BossTheme.radius
-    // Which tool's revoke most recently failed to persist - cleared on the next attempt for that
-    // tool, so a stale error does not linger once retried.
+    val scope = rememberCoroutineScope()
+    // Which tool's revoke most recently failed to persist. A single slot, not a set: a
+    // SUCCESSFUL revoke of any tool clears it, not only a retry of the same one, so two failures
+    // in quick succession show only the most recent - accepted, since this is diagnostic rather
+    // than an audit trail (the host log has that).
     var failedRevoke by remember { mutableStateOf<String?>(null) }
+    // A DENY row asked to confirm once before it resets: resetting an ALLOW reduces standing
+    // privilege, but resetting a DENY raises it, removing the one rule that beats session trust
+    // (McpPolicyEngine.policyFor). Tracks at most one row at a time - switching to a different
+    // row's button, or dismissing, drops any pending confirmation rather than carrying it silently.
+    var confirmingDeny by remember { mutableStateOf<String?>(null) }
 
     BossDialog(
         onDismissRequest = onDismiss,
@@ -78,7 +88,9 @@ fun McpPolicyManagerDialog(
                 Text(
                     text =
                         "Saved from \"Always Allow\" / \"Always Deny\" in the tool approval dialog. " +
-                            "Resetting a tool returns it to Ask - the next mutating call prompts again.",
+                            "Resetting a tool removes its saved rule - the next mutating call is " +
+                            "governed by the default policy again, asking unless that default is " +
+                            "itself Allow or Deny.",
                     fontSize = 12.sp,
                     color = colors.textSecondary,
                 )
@@ -118,19 +130,42 @@ fun McpPolicyManagerDialog(
                                     )
                                     if (failedRevoke == toolName) {
                                         Text(
-                                            text = "Could not save - see the host log for the reason.",
+                                            // The write failing is not "nothing happened": revokeSessionTrust
+                                            // already ran (McpPolicyEngine.revokePersistedPolicy), so the tool
+                                            // genuinely asks again for the rest of this session even though the
+                                            // saved rule itself could not be cleared.
+                                            text =
+                                                "Saved rule unchanged; session trust cleared until restart. " +
+                                                    "See the host log.",
                                             fontSize = 11.sp,
                                             color = colors.alert,
                                         )
                                     }
                                 }
                                 Spacer(modifier = Modifier.width(8.dp))
-                                TextButton(
-                                    onClick = {
+
+                                fun revoke() {
+                                    confirmingDeny = null
+                                    scope.launch {
                                         failedRevoke = if (onRevoke(toolName)) null else toolName
-                                    },
-                                ) {
-                                    Text("Reset to Ask", fontSize = 12.sp)
+                                    }
+                                }
+                                // Removing an ALLOW is a de-escalation and needs no confirmation.
+                                // Removing a DENY is the one control in this dialog that INCREASES
+                                // what the tool is allowed to do, so it gets a second tap instead of
+                                // firing on the first click like every other row's button does.
+                                if (action == McpPolicyAction.DENY && confirmingDeny != toolName) {
+                                    TextButton(onClick = { confirmingDeny = toolName }) {
+                                        Text("Remove denial", fontSize = 12.sp, color = colors.alert)
+                                    }
+                                } else if (action == McpPolicyAction.DENY) {
+                                    TextButton(onClick = { revoke() }) {
+                                        Text("Confirm remove?", fontSize = 12.sp, color = colors.alert)
+                                    }
+                                } else {
+                                    TextButton(onClick = { revoke() }) {
+                                        Text("Reset", fontSize = 12.sp)
+                                    }
                                 }
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpPolicyManagerDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/McpPolicyManagerDialog.kt
@@ -98,7 +98,7 @@ fun McpPolicyManagerDialog(
 
                 if (rules.isEmpty()) {
                     Text(
-                        text = "No persistent rules saved. Every tool still asks on each mutating call.",
+                        text = "No saved rules. Default policies and session trust still apply.",
                         fontSize = 13.sp,
                         color = colors.textSecondary,
                     )
@@ -130,12 +130,10 @@ fun McpPolicyManagerDialog(
                                     )
                                     if (failedRevoke == toolName) {
                                         Text(
-                                            // The write failing is not "nothing happened": revokeSessionTrust
-                                            // already ran (McpPolicyEngine.revokePersistedPolicy), so the tool
-                                            // genuinely asks again for the rest of this session even though the
-                                            // saved rule itself could not be cleared.
+                                            // Session trust clears even on failure, but a saved ALLOW still
+                                            // permits calls. Do not promise ASK while that durable rule remains.
                                             text =
-                                                "Saved rule unchanged; session trust cleared until restart. " +
+                                                "Saved rule unchanged; this tool's session trust was cleared. " +
                                                     "See the host log.",
                                             fontSize = 11.sp,
                                             color = colors.alert,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpApprovalBus.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpApprovalBus.kt
@@ -22,10 +22,20 @@ import java.util.concurrent.ConcurrentHashMap
 sealed interface McpApprovalDecision {
     data class Approved(
         val trustForSession: Boolean = false,
+        /**
+         * Write this tool's policy to `~/.boss/mcp-tool-policy.json` as ALLOW, so it never
+         * suspends for approval again - across restarts, not just this session. Independent
+         * of [trustForSession]: a persisted ALLOW makes session trust redundant (`policyFor`
+         * checks the configured rule first), so the registry does not also call
+         * `trustForSession` when this is true.
+         */
+        val persistPolicy: Boolean = false,
     ) : McpApprovalDecision
 
     data class Denied(
         val reason: String = "Operator rejected tool execution",
+        /** Write this tool's policy to disk as DENY, so it is refused automatically from now on. */
+        val persistPolicy: Boolean = false,
     ) : McpApprovalDecision
 
     data object Timeout : McpApprovalDecision
@@ -147,14 +157,15 @@ open class McpApprovalBus(
     fun approve(
         requestId: String,
         trustForSession: Boolean = false,
+        persistPolicy: Boolean = false,
     ): Boolean {
         val req = activeRequests[requestId] ?: return false
-        val completed = req.deferred.complete(McpApprovalDecision.Approved(trustForSession))
+        val completed = req.deferred.complete(McpApprovalDecision.Approved(trustForSession, persistPolicy))
         if (completed) {
             logger.info(
                 LogCategory.SYSTEM,
                 "Operator approved tool execution",
-                mapOf("tool" to req.toolName, "trustForSession" to trustForSession),
+                mapOf("tool" to req.toolName, "trustForSession" to trustForSession, "persistPolicy" to persistPolicy),
             )
         }
         return completed
@@ -166,14 +177,15 @@ open class McpApprovalBus(
     fun deny(
         requestId: String,
         reason: String = "Operator rejected tool execution",
+        persistPolicy: Boolean = false,
     ): Boolean {
         val req = activeRequests[requestId] ?: return false
-        val completed = req.deferred.complete(McpApprovalDecision.Denied(reason))
+        val completed = req.deferred.complete(McpApprovalDecision.Denied(reason, persistPolicy))
         if (completed) {
             logger.info(
                 LogCategory.SYSTEM,
                 "Operator denied tool execution",
-                mapOf("tool" to req.toolName),
+                mapOf("tool" to req.toolName, "persistPolicy" to persistPolicy),
             )
         }
         return completed

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpApprovalBus.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpApprovalBus.kt
@@ -25,8 +25,7 @@ sealed interface McpApprovalDecision {
         /**
          * Write this tool's policy to `~/.boss/mcp-tool-policy.json` as ALLOW, so it never
          * suspends for approval again - across restarts, not just this session. Independent
-         * of [trustForSession]: a persisted ALLOW makes session trust redundant (`policyFor`
-         * checks the configured rule first), so the registry does not also call
+         * of [trustForSession]: a persisted ALLOW makes session trust redundant, so the registry does not also call
          * `trustForSession` when this is true.
          */
         val persistPolicy: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicy.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicy.kt
@@ -29,6 +29,7 @@ enum class McpApprovalDisposition {
     // scopes (once, session, persistent) the operator actually chose.
     PERSISTENTLY_ALLOWED,
     PERSISTENTLY_DENIED,
+    POLICY_PERSIST_FAILED,
     DENIED_BY_OPERATOR,
     TIMEOUT,
     POLICY_DENIED,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicy.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicy.kt
@@ -23,6 +23,12 @@ enum class McpApprovalDisposition {
     AUTO_ALLOWED,
     APPROVED_ONCE,
     SESSION_TRUSTED,
+
+    // A persisted decision, in the same [McpApprovalDecision] shape as SESSION_TRUSTED /
+    // DENIED_BY_OPERATOR - distinct dispositions so the ledger records which of the three
+    // scopes (once, session, persistent) the operator actually chose.
+    PERSISTENTLY_ALLOWED,
+    PERSISTENTLY_DENIED,
     DENIED_BY_OPERATOR,
     TIMEOUT,
     POLICY_DENIED,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicyEngine.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicyEngine.kt
@@ -159,6 +159,28 @@ class McpPolicyEngine(
             }
         }
 
+    /**
+     * The operator-facing undo for [setToolPolicy]'s persistent scope: returns [toolName] to
+     * ASK, so the next mutating call prompts again rather than silently reusing a stale ALLOW
+     * or DENY someone saved earlier and no longer means.
+     *
+     * Clears session trust for the same tool too, not only the persisted rule. [policyFor]
+     * checks session trust *before* a non-DENY configured rule, so a tool that happens to hold
+     * both (session-trusted, then separately given a persistent rule) would otherwise keep
+     * answering ALLOW from the session-trust check alone even after its persisted rule was
+     * reset - "revoke" has to mean the call asks again, not "asks again unless it also had the
+     * other kind of standing grant."
+     *
+     * Returns whether the persisted half succeeded, via the same disk-write path
+     * [setToolPolicy] uses - a caller surfaces `false` as a real failure, not a silent no-op,
+     * since a revoke that did not actually take effect on disk is worse than useless: the UI
+     * would show the tool as reset while the file, and the next restart, still say otherwise.
+     */
+    fun revokePersistedPolicy(toolName: String): Boolean {
+        revokeSessionTrust(toolName)
+        return setToolPolicy(toolName, McpPolicyAction.ASK)
+    }
+
     // An absent file uses defaults; I/O and JSON failures withhold tools.
     @Suppress("ReturnCount", "TooGenericExceptionCaught")
     private fun loadConfig(): McpToolPolicyConfig {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicyEngine.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicyEngine.kt
@@ -125,6 +125,34 @@ class McpPolicyEngine(
     }
 
     /**
+     * Replaces the rule map and persists it, publishing the result the same way for every
+     * caller - [setToolPolicy]'s add/replace and [revokePersistedPolicy]'s remove both go
+     * through this, so a future change to how a persist failure is reported (or logged, or
+     * faulted) cannot update one path and silently miss the other.
+     */
+    private fun applyRules(
+        toolName: String,
+        updatedRules: Map<String, McpPolicyAction>,
+        successMessage: String,
+        failureMessage: String,
+    ): Boolean {
+        val updated = _config.value.copy(rules = updatedRules)
+        val error = persistConfig(updated)
+        return if (error != null) {
+            val faultObj = McpPolicyFault.PolicyPersistFailed(toolName, error)
+            if (_fault.value !is McpPolicyFault.PersistedPolicyUnreadable) _fault.value = faultObj
+            notifyFault(faultObj)
+            logger.warn(LogCategory.SYSTEM, failureMessage, mapOf("tool" to toolName, "error" to error))
+            false
+        } else {
+            _config.value = updated
+            _fault.value = null
+            logger.info(LogCategory.SYSTEM, successMessage, mapOf("tool" to toolName))
+            true
+        }
+    }
+
+    /**
      * Set a persistent policy rule for [toolName], returning whether it was saved.
      * [preserveDeny] keeps a queued approval from replacing a newer denial.
      */
@@ -135,34 +163,30 @@ class McpPolicyEngine(
     ): Boolean =
         synchronized(lock) {
             if (preserveDeny && policyFor(toolName) == McpPolicyAction.DENY) return@synchronized false
-            val updated = _config.value.copy(rules = _config.value.rules + (toolName to action))
-            val error = persistConfig(updated)
-            if (error != null) {
-                val faultObj = McpPolicyFault.PolicyPersistFailed(toolName, error)
-                if (_fault.value !is McpPolicyFault.PersistedPolicyUnreadable) _fault.value = faultObj
-                notifyFault(faultObj)
-                logger.warn(
-                    LogCategory.SYSTEM,
-                    "Failed to persist MCP policy update",
-                    mapOf("tool" to toolName, "error" to error),
-                )
-                false
-            } else {
-                _config.value = updated
-                _fault.value = null
-                logger.info(
-                    LogCategory.SYSTEM,
-                    "Updated tool policy",
-                    mapOf("tool" to toolName, "action" to action.name),
-                )
-                true
-            }
+            applyRules(
+                toolName,
+                _config.value.rules + (toolName to action),
+                successMessage = "Updated tool policy: ${action.name}",
+                failureMessage = "Failed to persist MCP policy update",
+            )
         }
 
     /**
-     * The operator-facing undo for [setToolPolicy]'s persistent scope: returns [toolName] to
-     * ASK, so the next mutating call prompts again rather than silently reusing a stale ALLOW
-     * or DENY someone saved earlier and no longer means.
+     * The operator-facing undo for [setToolPolicy]'s persistent scope: removes [toolName]'s rule
+     * entirely, so the next call falls through to whatever [McpToolPolicyConfig.defaultMutatingAction]
+     * / `defaultReadOnlyAction` actually say - not to a hardcoded ASK.
+     *
+     * **Removes the key rather than rewriting it to ASK.** An earlier version did the latter by
+     * calling `setToolPolicy(toolName, ASK)`, which - because [setToolPolicy] always writes
+     * `rules + (toolName to action)` - left the key in the map forever, just holding ASK instead
+     * of its old value. Three consequences that all trace back to that one line: the bottom bar's
+     * "Persisted MCP policies (n)" count never dropped after a revoke, because the row was still
+     * there; the policy manager dialog kept listing the "revoked" tool with a Reset button that
+     * rewrote the same value and reported success; and on a config with `defaultMutatingAction =
+     * DENY`, the explicit ASK a revoke left behind was *weaker* than the operator's own configured
+     * default - the opposite of what "reset to default" should mean. `rules - toolName` fixes all
+     * three: [policyFor] sees no configured rule and falls through to the real default, and the
+     * row genuinely disappears everywhere that reads [config] directly.
      *
      * Clears session trust for the same tool too, not only the persisted rule. [policyFor]
      * checks session trust *before* a non-DENY configured rule, so a tool that happens to hold
@@ -178,7 +202,14 @@ class McpPolicyEngine(
      */
     fun revokePersistedPolicy(toolName: String): Boolean {
         revokeSessionTrust(toolName)
-        return setToolPolicy(toolName, McpPolicyAction.ASK)
+        return synchronized(lock) {
+            applyRules(
+                toolName,
+                _config.value.rules - toolName,
+                successMessage = "Revoked persisted tool policy",
+                failureMessage = "Failed to persist MCP policy revocation",
+            )
+        }
     }
 
     // An absent file uses defaults; I/O and JSON failures withhold tools.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicyEngine.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicyEngine.kt
@@ -125,13 +125,16 @@ class McpPolicyEngine(
     }
 
     /**
-     * Set a persistent policy rule for [toolName].
+     * Set a persistent policy rule for [toolName], returning whether it was saved.
+     * [preserveDeny] keeps a queued approval from replacing a newer denial.
      */
     fun setToolPolicy(
         toolName: String,
         action: McpPolicyAction,
-    ) {
+        preserveDeny: Boolean = false,
+    ): Boolean =
         synchronized(lock) {
+            if (preserveDeny && policyFor(toolName) == McpPolicyAction.DENY) return@synchronized false
             val updated = _config.value.copy(rules = _config.value.rules + (toolName to action))
             val error = persistConfig(updated)
             if (error != null) {
@@ -143,6 +146,7 @@ class McpPolicyEngine(
                     "Failed to persist MCP policy update",
                     mapOf("tool" to toolName, "error" to error),
                 )
+                false
             } else {
                 _config.value = updated
                 _fault.value = null
@@ -151,9 +155,9 @@ class McpPolicyEngine(
                     "Updated tool policy",
                     mapOf("tool" to toolName, "action" to action.name),
                 )
+                true
             }
         }
-    }
 
     // An absent file uses defaults; I/O and JSON failures withhold tools.
     @Suppress("ReturnCount", "TooGenericExceptionCaught")

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicyEngine.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpPolicyEngine.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Fault explaining why the MCP policy state is degraded or cannot be persisted.
@@ -46,12 +47,14 @@ sealed interface McpPolicyFault {
  * In-memory session trust ([trustForSession]) allows an operator to approve a tool
  * for the duration of the current application run without writing a permanent rule.
  */
+@Suppress("TooManyFunctions") // Policy resolution, approval guards and durable updates share one state and lock.
 class McpPolicyEngine(
     private val policyFile: File? = null,
     private val onFault: (McpPolicyFault) -> Unit = {},
 ) {
     private val logger = BossLogger.forComponent("McpPolicyEngine")
     private val lock = Any()
+    private val revocations = ConcurrentHashMap<String, Long>()
     private val json =
         Json {
             ignoreUnknownKeys = true
@@ -66,6 +69,24 @@ class McpPolicyEngine(
 
     private val _sessionTrustedTools = MutableStateFlow<Set<String>>(emptySet())
     val sessionTrustedTools: StateFlow<Set<String>> = _sessionTrustedTools.asStateFlow()
+
+    /** Capture before reading policy; a reset invalidates every older authorization. */
+    internal fun revocationVersion(toolName: String): Long = revocations[toolName] ?: 0L
+
+    /** Final authorization boundary. Session grants and operator resets use the same lock. */
+    internal fun confirmInvocation(
+        toolName: String,
+        expectedRevocation: Long,
+        grantSessionTrust: Boolean,
+    ): Boolean =
+        synchronized(lock) {
+            if (revocationVersion(toolName) != expectedRevocation || policyFor(toolName) == McpPolicyAction.DENY) {
+                false
+            } else {
+                if (grantSessionTrust) trustForSession(toolName)
+                true
+            }
+        }
 
     /**
      * Resolve the effective policy action for [toolName].
@@ -160,8 +181,12 @@ class McpPolicyEngine(
         toolName: String,
         action: McpPolicyAction,
         preserveDeny: Boolean = false,
+        expectedRevocation: Long? = null,
     ): Boolean =
         synchronized(lock) {
+            if (expectedRevocation != null && revocationVersion(toolName) != expectedRevocation) {
+                return@synchronized false
+            }
             if (preserveDeny && policyFor(toolName) == McpPolicyAction.DENY) return@synchronized false
             applyRules(
                 toolName,
@@ -200,17 +225,23 @@ class McpPolicyEngine(
      * since a revoke that did not actually take effect on disk is worse than useless: the UI
      * would show the tool as reset while the file, and the next restart, still say otherwise.
      */
-    fun revokePersistedPolicy(toolName: String): Boolean {
-        revokeSessionTrust(toolName)
-        return synchronized(lock) {
-            applyRules(
-                toolName,
-                _config.value.rules - toolName,
-                successMessage = "Revoked persisted tool policy",
-                failureMessage = "Failed to persist MCP policy revocation",
-            )
+    fun revokePersistedPolicy(toolName: String): Boolean =
+        synchronized(lock) {
+            // Even a failed reset invalidates queued answers. The previous durable rule remains
+            // visible on failure, but an older answer cannot restore trust behind this reset.
+            revokeSessionTrust(toolName)
+            val saved =
+                applyRules(
+                    toolName,
+                    _config.value.rules - toolName,
+                    successMessage = "Revoked persisted tool policy",
+                    failureMessage = "Failed to persist MCP policy revocation",
+                )
+            // Publish last: a caller observing this version must also see the reset policy.
+            // Calls that captured the previous version cannot pass the locked approval guard.
+            revocations[toolName] = revocationVersion(toolName) + 1
+            saved
         }
-    }
 
     // An absent file uses defaults; I/O and JSON failures withhold tools.
     @Suppress("ReturnCount", "TooGenericExceptionCaught")

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
@@ -829,17 +829,35 @@ internal class McpToolRegistryCore(
                 ) {
                     is McpApprovalDecision.Approved -> {
                         val disposition =
-                            if (decision.trustForSession) {
-                                McpApprovalDisposition.SESSION_TRUSTED
-                            } else {
-                                McpApprovalDisposition.APPROVED_ONCE
+                            when {
+                                // Persisted takes precedence over session trust when both are
+                                // somehow set: a rule on disk survives restarts, session trust
+                                // does not, and there's nothing left for the weaker scope to add.
+                                decision.persistPolicy -> {
+                                    policyEngine.setToolPolicy(tool.definition.name, McpPolicyAction.ALLOW)
+                                    McpApprovalDisposition.PERSISTENTLY_ALLOWED
+                                }
+
+                                decision.trustForSession -> {
+                                    McpApprovalDisposition.SESSION_TRUSTED
+                                }
+
+                                else -> {
+                                    McpApprovalDisposition.APPROVED_ONCE
+                                }
                             }
                         disposition to null
                     }
 
                     is McpApprovalDecision.Denied -> {
-                        McpApprovalDisposition.DENIED_BY_OPERATOR to
-                            "MCP tool rejected by operator: ${decision.reason}"
+                        val disposition =
+                            if (decision.persistPolicy) {
+                                policyEngine.setToolPolicy(tool.definition.name, McpPolicyAction.DENY)
+                                McpApprovalDisposition.PERSISTENTLY_DENIED
+                            } else {
+                                McpApprovalDisposition.DENIED_BY_OPERATOR
+                            }
+                        disposition to "MCP tool rejected by operator: ${decision.reason}"
                     }
 
                     McpApprovalDecision.QueueFull -> {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
@@ -803,6 +803,60 @@ internal class McpToolRegistryCore(
         }
     }
 
+    /** Recheck access before saving a queued ALLOW; a failed write never authorizes execution. */
+    @Suppress("ReturnCount") // Ordered denial, access revocation, persistence and write-failure outcomes.
+    private suspend fun validateApproval(
+        tool: RegisteredMcpTool,
+        authorization: Pair<McpApprovalDisposition, String?>,
+    ): Pair<McpApprovalDisposition, String?> =
+        withContext(Dispatchers.IO) {
+            if (authorization.second != null) return@withContext authorization
+            val toolName = tool.definition.name
+            if (_tools.value.none { it.providerId == tool.providerId && it.definition === tool.definition } ||
+                policyEngine.policyFor(toolName) == McpPolicyAction.DENY
+            ) {
+                return@withContext McpApprovalDisposition.POLICY_DENIED to
+                    "MCP tool access revoked while awaiting approval"
+            }
+            if (authorization.first != McpApprovalDisposition.PERSISTENTLY_ALLOWED ||
+                policyEngine.setToolPolicy(toolName, McpPolicyAction.ALLOW, preserveDeny = true)
+            ) {
+                return@withContext authorization
+            }
+            val disposition =
+                if (policyEngine.policyFor(toolName) == McpPolicyAction.DENY) {
+                    McpApprovalDisposition.POLICY_DENIED
+                } else {
+                    McpApprovalDisposition.POLICY_PERSIST_FAILED
+                }
+            disposition to "MCP persistent approval was not saved; tool execution withheld"
+        }
+
+    private suspend fun approvedAuthorization(
+        tool: RegisteredMcpTool,
+        decision: McpApprovalDecision.Approved,
+    ): Pair<McpApprovalDisposition, String?> {
+        if (decision.persistPolicy) {
+            return validateApproval(tool, McpApprovalDisposition.PERSISTENTLY_ALLOWED to null)
+        }
+        val disposition =
+            if (decision.trustForSession) {
+                McpApprovalDisposition.SESSION_TRUSTED
+            } else {
+                McpApprovalDisposition.APPROVED_ONCE
+            }
+        return disposition to null
+    }
+
+    private suspend fun persistentDenialDisposition(toolName: String): McpApprovalDisposition =
+        withContext(Dispatchers.IO) {
+            if (policyEngine.setToolPolicy(toolName, McpPolicyAction.DENY)) {
+                McpApprovalDisposition.PERSISTENTLY_DENIED
+            } else {
+                McpApprovalDisposition.POLICY_PERSIST_FAILED
+            }
+        }
+
     private suspend fun authorizeInvocation(
         tool: RegisteredMcpTool,
         args: McpToolArgs,
@@ -828,32 +882,13 @@ internal class McpToolRegistryCore(
                         )
                 ) {
                     is McpApprovalDecision.Approved -> {
-                        val disposition =
-                            when {
-                                // Persisted takes precedence over session trust when both are
-                                // somehow set: a rule on disk survives restarts, session trust
-                                // does not, and there's nothing left for the weaker scope to add.
-                                decision.persistPolicy -> {
-                                    policyEngine.setToolPolicy(tool.definition.name, McpPolicyAction.ALLOW)
-                                    McpApprovalDisposition.PERSISTENTLY_ALLOWED
-                                }
-
-                                decision.trustForSession -> {
-                                    McpApprovalDisposition.SESSION_TRUSTED
-                                }
-
-                                else -> {
-                                    McpApprovalDisposition.APPROVED_ONCE
-                                }
-                            }
-                        disposition to null
+                        approvedAuthorization(tool, decision)
                     }
 
                     is McpApprovalDecision.Denied -> {
                         val disposition =
                             if (decision.persistPolicy) {
-                                policyEngine.setToolPolicy(tool.definition.name, McpPolicyAction.DENY)
-                                McpApprovalDisposition.PERSISTENTLY_DENIED
+                                persistentDenialDisposition(tool.definition.name)
                             } else {
                                 McpApprovalDisposition.DENIED_BY_OPERATOR
                             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
@@ -803,7 +803,19 @@ internal class McpToolRegistryCore(
         }
     }
 
-    /** Recheck access before saving a queued ALLOW; a failed write never authorizes execution. */
+    /**
+     * Recheck access before saving a queued ALLOW; a failed write never authorizes execution.
+     *
+     * **Known limitation, not fixed here**: `preserveDeny = true` guards only against a newer
+     * *DENY* written while this approval sat queued - it does not know about a newer *revocation*
+     * ([ai.rever.boss.mcp.McpPolicyEngine.revokePersistedPolicy]), which also lands after this
+     * approval was queued but is not itself a DENY. An operator who revokes a persisted ALLOW
+     * while an older "Always Allow" is still waiting to be answered can have that older answer
+     * re-persist the very rule they just removed. Closing it needs a revocation generation/
+     * timestamp compared inside [McpPolicyEngine]'s lock, which is a larger change than this
+     * recheck; see AGENTS.md's "Governed MCP invocation" section, which documents the same gap
+     * for an operator debugging "I revoked it and it came back".
+     */
     @Suppress("ReturnCount") // Ordered denial, access revocation, persistence and write-failure outcomes.
     private suspend fun validateApproval(
         tool: RegisteredMcpTool,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
@@ -744,13 +744,14 @@ internal class McpToolRegistryCore(
             _tools.value.firstOrNull { it.definition.name == toolName }
                 ?: return McpToolResult("Unknown or disabled MCP tool: $toolName", isError = true)
         val args = parseArgs(arguments)
+        val revocation = policyEngine.revocationVersion(toolName)
         val policy = policyEngine.policyFor(toolName)
         val startTime = System.nanoTime()
         var disposition = McpApprovalDisposition.AUTO_ALLOWED
         var result: McpToolResult? = null
         var executionStarted = false
         try {
-            val authorization = authorizeInvocation(tool, args, policy)
+            val authorization = authorizeInvocation(tool, args, policy, revocation)
             disposition = authorization.first
             val denial = authorization.second
             result =
@@ -759,16 +760,12 @@ internal class McpToolRegistryCore(
                         McpToolResult(denial, isError = true)
                     }
 
-                    _tools.value.none { it.providerId == tool.providerId && it.definition === tool.definition } ||
-                        policyEngine.policyFor(toolName) == McpPolicyAction.DENY -> {
+                    !confirmApproval(tool, revocation, disposition) || !isAvailable(tool) -> {
                         disposition = McpApprovalDisposition.POLICY_DENIED
                         McpToolResult("MCP tool access revoked while awaiting approval", isError = true)
                     }
 
                     else -> {
-                        if (disposition == McpApprovalDisposition.SESSION_TRUSTED) {
-                            policyEngine.trustForSession(toolName)
-                        }
                         executionStarted = true
                         executeAuthorized(tool, args)
                     }
@@ -803,40 +800,54 @@ internal class McpToolRegistryCore(
         }
     }
 
-    /**
-     * Recheck access before saving a queued ALLOW; a failed write never authorizes execution.
-     *
-     * **Known limitation, not fixed here**: `preserveDeny = true` guards only against a newer
-     * *DENY* written while this approval sat queued - it does not know about a newer *revocation*
-     * ([ai.rever.boss.mcp.McpPolicyEngine.revokePersistedPolicy]), which also lands after this
-     * approval was queued but is not itself a DENY. An operator who revokes a persisted ALLOW
-     * while an older "Always Allow" is still waiting to be answered can have that older answer
-     * re-persist the very rule they just removed. Closing it needs a revocation generation/
-     * timestamp compared inside [McpPolicyEngine]'s lock, which is a larger change than this
-     * recheck; see AGENTS.md's "Governed MCP invocation" section, which documents the same gap
-     * for an operator debugging "I revoked it and it came back".
-     */
+    private fun isAvailable(tool: RegisteredMcpTool): Boolean =
+        _tools.value.any { it.providerId == tool.providerId && it.definition === tool.definition }
+
+    private suspend fun confirmApproval(
+        tool: RegisteredMcpTool,
+        revocation: Long,
+        disposition: McpApprovalDisposition,
+    ): Boolean =
+        withContext(Dispatchers.IO) {
+            isAvailable(tool) &&
+                policyEngine.confirmInvocation(
+                    tool.definition.name,
+                    revocation,
+                    grantSessionTrust = disposition == McpApprovalDisposition.SESSION_TRUSTED,
+                )
+        }
+
+    /** Recheck access before saving a queued ALLOW; resets invalidate older answers under the policy lock. */
     @Suppress("ReturnCount") // Ordered denial, access revocation, persistence and write-failure outcomes.
     private suspend fun validateApproval(
         tool: RegisteredMcpTool,
         authorization: Pair<McpApprovalDisposition, String?>,
+        revocation: Long,
     ): Pair<McpApprovalDisposition, String?> =
         withContext(Dispatchers.IO) {
             if (authorization.second != null) return@withContext authorization
             val toolName = tool.definition.name
-            if (_tools.value.none { it.providerId == tool.providerId && it.definition === tool.definition } ||
+            if (!isAvailable(tool) ||
+                policyEngine.revocationVersion(toolName) != revocation ||
                 policyEngine.policyFor(toolName) == McpPolicyAction.DENY
             ) {
                 return@withContext McpApprovalDisposition.POLICY_DENIED to
                     "MCP tool access revoked while awaiting approval"
             }
             if (authorization.first != McpApprovalDisposition.PERSISTENTLY_ALLOWED ||
-                policyEngine.setToolPolicy(toolName, McpPolicyAction.ALLOW, preserveDeny = true)
+                policyEngine.setToolPolicy(
+                    toolName,
+                    McpPolicyAction.ALLOW,
+                    preserveDeny = true,
+                    expectedRevocation = revocation,
+                )
             ) {
                 return@withContext authorization
             }
             val disposition =
-                if (policyEngine.policyFor(toolName) == McpPolicyAction.DENY) {
+                if (policyEngine.revocationVersion(toolName) != revocation ||
+                    policyEngine.policyFor(toolName) == McpPolicyAction.DENY
+                ) {
                     McpApprovalDisposition.POLICY_DENIED
                 } else {
                     McpApprovalDisposition.POLICY_PERSIST_FAILED
@@ -847,9 +858,10 @@ internal class McpToolRegistryCore(
     private suspend fun approvedAuthorization(
         tool: RegisteredMcpTool,
         decision: McpApprovalDecision.Approved,
+        revocation: Long,
     ): Pair<McpApprovalDisposition, String?> {
         if (decision.persistPolicy) {
-            return validateApproval(tool, McpApprovalDisposition.PERSISTENTLY_ALLOWED to null)
+            return validateApproval(tool, McpApprovalDisposition.PERSISTENTLY_ALLOWED to null, revocation)
         }
         val disposition =
             if (decision.trustForSession) {
@@ -860,10 +872,15 @@ internal class McpToolRegistryCore(
         return disposition to null
     }
 
-    private suspend fun persistentDenialDisposition(toolName: String): McpApprovalDisposition =
+    private suspend fun persistentDenialDisposition(
+        toolName: String,
+        revocation: Long,
+    ): McpApprovalDisposition =
         withContext(Dispatchers.IO) {
-            if (policyEngine.setToolPolicy(toolName, McpPolicyAction.DENY)) {
+            if (policyEngine.setToolPolicy(toolName, McpPolicyAction.DENY, expectedRevocation = revocation)) {
                 McpApprovalDisposition.PERSISTENTLY_DENIED
+            } else if (policyEngine.revocationVersion(toolName) != revocation) {
+                McpApprovalDisposition.POLICY_DENIED
             } else {
                 McpApprovalDisposition.POLICY_PERSIST_FAILED
             }
@@ -873,6 +890,7 @@ internal class McpToolRegistryCore(
         tool: RegisteredMcpTool,
         args: McpToolArgs,
         policy: McpPolicyAction,
+        revocation: Long,
     ): Pair<McpApprovalDisposition, String?> =
         when (policy) {
             McpPolicyAction.DENY -> {
@@ -894,13 +912,13 @@ internal class McpToolRegistryCore(
                         )
                 ) {
                     is McpApprovalDecision.Approved -> {
-                        approvedAuthorization(tool, decision)
+                        approvedAuthorization(tool, decision, revocation)
                     }
 
                     is McpApprovalDecision.Denied -> {
                         val disposition =
                             if (decision.persistPolicy) {
-                                persistentDenialDisposition(tool.definition.name)
+                                persistentDenialDisposition(tool.definition.name, revocation)
                             } else {
                                 McpApprovalDisposition.DENIED_BY_OPERATOR
                             }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpGovernedInvocationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpGovernedInvocationTest.kt
@@ -255,4 +255,112 @@ class McpGovernedInvocationTest {
                 assertFalse(called, change)
             }
         }
+
+    @Test
+    fun `approving with persistPolicy writes an ALLOW rule that survives past this one call`() =
+        runBlocking {
+            val approvalBus = McpApprovalBus(defaultTimeoutMs = 5000L)
+            val policyEngine = McpPolicyEngine(policyFile = null)
+            val ledger = McpOperationLedger(ledgerFile = null)
+            var callCount = 0
+            val core =
+                McpToolRegistryCore(
+                    disabledFile = null,
+                    policyEngine = policyEngine,
+                    approvalBus = approvalBus,
+                    ledger = ledger,
+                )
+            core.registerProvider(
+                provider(
+                    "p1",
+                    echoTool(
+                        "helm_uninstall",
+                        handler =
+                            McpToolHandler {
+                                callCount++
+                                McpToolResult("ok")
+                            },
+                    ),
+                ),
+            )
+
+            // First call: the tool has no configured rule, so DefaultMcpRiskEvaluator's
+            // mutating-tool default routes it to ASK.
+            val first = async { core.invoke("helm_uninstall", "{}") }
+            val req = approvalBus.pendingList.first { it.isNotEmpty() }.first()
+            approvalBus.approve(req.id, trustForSession = false, persistPolicy = true)
+            assertFalse(first.await().isError)
+            assertEquals(1, callCount)
+            assertEquals(McpPolicyAction.ALLOW, policyEngine.policyFor("helm_uninstall"))
+            assertEquals(
+                McpApprovalDisposition.PERSISTENTLY_ALLOWED,
+                ledger.recentOperations.value
+                    .first()
+                    .approvalDisposition,
+            )
+
+            // Second call: the persisted rule means it never suspends for approval again.
+            val second = core.invoke("helm_uninstall", "{}")
+            assertFalse(second.isError)
+            assertEquals(2, callCount)
+            assertEquals(
+                McpApprovalDisposition.AUTO_ALLOWED,
+                ledger.recentOperations.value
+                    .first()
+                    .approvalDisposition,
+            )
+        }
+
+    @Test
+    fun `denying with persistPolicy writes a DENY rule that survives past this one call`() =
+        runBlocking {
+            val approvalBus = McpApprovalBus(defaultTimeoutMs = 5000L)
+            val policyEngine = McpPolicyEngine(policyFile = null)
+            val ledger = McpOperationLedger(ledgerFile = null)
+            var callCount = 0
+            val core =
+                McpToolRegistryCore(
+                    disabledFile = null,
+                    policyEngine = policyEngine,
+                    approvalBus = approvalBus,
+                    ledger = ledger,
+                )
+            core.registerProvider(
+                provider(
+                    "p1",
+                    echoTool(
+                        "docker_rm",
+                        handler =
+                            McpToolHandler {
+                                callCount++
+                                McpToolResult("ok")
+                            },
+                    ),
+                ),
+            )
+
+            val first = async { core.invoke("docker_rm", "{}") }
+            val req = approvalBus.pendingList.first { it.isNotEmpty() }.first()
+            approvalBus.deny(req.id, "not today", persistPolicy = true)
+            assertTrue(first.await().isError)
+            assertEquals(0, callCount)
+            assertEquals(McpPolicyAction.DENY, policyEngine.policyFor("docker_rm"))
+            assertEquals(
+                McpApprovalDisposition.PERSISTENTLY_DENIED,
+                ledger.recentOperations.value
+                    .first()
+                    .approvalDisposition,
+            )
+
+            // Second call: refused by policy before the handler is ever reached, no new prompt.
+            val second = core.invoke("docker_rm", "{}")
+            assertTrue(second.isError)
+            assertEquals(0, callCount)
+            assertEquals(
+                McpApprovalDisposition.POLICY_DENIED,
+                ledger.recentOperations.value
+                    .first()
+                    .approvalDisposition,
+            )
+        }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpPersistentApprovalTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpPersistentApprovalTest.kt
@@ -1,0 +1,181 @@
+package ai.rever.boss.mcp
+
+import ai.rever.boss.plugin.api.McpToolDefinition
+import ai.rever.boss.plugin.api.McpToolHandler
+import ai.rever.boss.plugin.api.McpToolProvider
+import ai.rever.boss.plugin.api.McpToolResult
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Exercises durable operator choices, failed writes and revoked access at the registry boundary. */
+class McpPersistentApprovalTest {
+    private fun provider(
+        id: String,
+        vararg defs: McpToolDefinition,
+    ) = object : McpToolProvider {
+        override val providerId = id
+
+        override fun tools() = defs.toList()
+    }
+
+    private fun echoTool(
+        name: String,
+        handler: McpToolHandler = McpToolHandler { McpToolResult("ok:$name") },
+    ) = McpToolDefinition(name = name, description = "test tool $name", handler = handler)
+
+    @Test
+    fun `guarded update refuses a deny without changing persisted bytes`() {
+        val dir = Files.createTempDirectory("mcp-policy-deny").toFile()
+        try {
+            val file = dir.resolve("policy.json")
+            val engine = McpPolicyEngine(file)
+            assertTrue(engine.setToolPolicy("run_command", McpPolicyAction.DENY))
+            val before = file.readText()
+            assertFalse(engine.setToolPolicy("run_command", McpPolicyAction.ALLOW, preserveDeny = true))
+            assertEquals(before, file.readText())
+            assertEquals(McpPolicyAction.DENY, engine.policyFor("run_command"))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `persistent choices survive a fresh engine reading the same file`() =
+        runBlocking {
+            for (allow in listOf(true, false)) {
+                val dir = Files.createTempDirectory("mcp-policy-reload").toFile()
+                try {
+                    val file = dir.resolve("policy.json")
+                    val bus = McpApprovalBus()
+                    val engine = McpPolicyEngine(file)
+                    val core = McpToolRegistryCore(disabledFile = null, policyEngine = engine, approvalBus = bus)
+                    core.registerProvider(provider("p", echoTool("run_command")))
+                    val call = async { core.invoke("run_command", "{}") }
+                    val request = bus.pendingList.first { it.isNotEmpty() }.first()
+                    if (allow) {
+                        bus.approve(request.id, persistPolicy = true)
+                    } else {
+                        bus.deny(request.id, persistPolicy = true)
+                    }
+                    assertEquals(!allow, call.await().isError)
+                    val expected = if (allow) McpPolicyAction.ALLOW else McpPolicyAction.DENY
+                    assertEquals(expected, McpPolicyEngine(file).policyFor("run_command"))
+                    assertTrue(engine.sessionTrustedTools.value.isEmpty())
+                } finally {
+                    dir.deleteRecursively()
+                }
+            }
+        }
+
+    @Test
+    fun `failed persistent choices withhold execution and never claim a saved rule`() =
+        runBlocking {
+            for (allow in listOf(true, false)) {
+                val dir = Files.createTempDirectory("mcp-policy-failure").toFile()
+                try {
+                    val parent = dir.resolve("parent")
+                    val file = parent.resolve("policy.json")
+                    val bus = McpApprovalBus()
+                    val engine = McpPolicyEngine(file)
+                    parent.writeText("blocks directory creation")
+                    val ledger = McpOperationLedger()
+                    var calls = 0
+                    val core =
+                        McpToolRegistryCore(
+                            disabledFile = null,
+                            policyEngine = engine,
+                            approvalBus = bus,
+                            ledger = ledger,
+                        )
+                    core.registerProvider(
+                        provider(
+                            "p",
+                            echoTool(
+                                "run_command",
+                                handler =
+                                    McpToolHandler {
+                                        calls++
+                                        McpToolResult("unexpected")
+                                    },
+                            ),
+                        ),
+                    )
+                    val call = async { core.invoke("run_command", "{}") }
+                    val request = bus.pendingList.first { it.isNotEmpty() }.first()
+                    if (allow) {
+                        bus.approve(request.id, persistPolicy = true)
+                    } else {
+                        bus.deny(request.id, persistPolicy = true)
+                    }
+                    assertTrue(call.await().isError)
+                    assertEquals(0, calls)
+                    assertEquals(McpPolicyAction.ASK, engine.policyFor("run_command"))
+                    assertTrue(engine.fault.value is McpPolicyFault.PolicyPersistFailed)
+                    assertEquals(
+                        McpApprovalDisposition.POLICY_PERSIST_FAILED,
+                        ledger.recentOperations.value
+                            .single()
+                            .approvalDisposition,
+                    )
+                    assertFalse(file.exists())
+                } finally {
+                    dir.deleteRecursively()
+                }
+            }
+        }
+
+    @Test
+    fun `persistent approval cannot change policy after access is revoked`() =
+        runBlocking {
+            for (change in listOf("deny", "disable", "unload")) {
+                val bus = McpApprovalBus()
+                val engine = McpPolicyEngine()
+                val ledger = McpOperationLedger()
+                var calls = 0
+                val core =
+                    McpToolRegistryCore(
+                        disabledFile = null,
+                        policyEngine = engine,
+                        approvalBus = bus,
+                        ledger = ledger,
+                    )
+                core.registerProvider(
+                    provider(
+                        "p",
+                        echoTool(
+                            "run_command",
+                            handler =
+                                McpToolHandler {
+                                    calls++
+                                    McpToolResult("unexpected")
+                                },
+                        ),
+                    ),
+                )
+                val call = async { core.invoke("run_command", "{}") }
+                val request = bus.pendingList.first { it.isNotEmpty() }.first()
+                when (change) {
+                    "deny" -> engine.setToolPolicy("run_command", McpPolicyAction.DENY)
+                    "disable" -> core.setToolEnabled("run_command", false)
+                    "unload" -> core.unregisterProvider("p")
+                }
+                bus.approve(request.id, persistPolicy = true)
+                assertTrue(call.await().isError, change)
+                assertEquals(0, calls, change)
+                val expected = if (change == "deny") McpPolicyAction.DENY else McpPolicyAction.ASK
+                assertEquals(expected, engine.policyFor("run_command"), change)
+                assertEquals(
+                    McpApprovalDisposition.POLICY_DENIED,
+                    ledger.recentOperations.value
+                        .single()
+                        .approvalDisposition,
+                )
+            }
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpPolicyEngineTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpPolicyEngineTest.kt
@@ -4,6 +4,7 @@ import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -92,6 +93,88 @@ class McpPolicyEngineTest {
         assertEquals(McpPolicyAction.DENY, engine.policyFor("git_status"))
         engine.setToolPolicy("run_command", McpPolicyAction.ASK)
         assertEquals(McpPolicyAction.DENY, engine.policyFor("git_status"))
+    }
+
+    @Test
+    fun `revoking a persisted ALLOW returns the tool to ASK and survives reload`() {
+        val file = createTempPolicyFile()
+        val engine = McpPolicyEngine(policyFile = file)
+
+        engine.setToolPolicy("helm_upgrade", McpPolicyAction.ALLOW)
+        assertEquals(McpPolicyAction.ALLOW, engine.policyFor("helm_upgrade"))
+
+        assertTrue(engine.revokePersistedPolicy("helm_upgrade"))
+        assertEquals(McpPolicyAction.ASK, engine.policyFor("helm_upgrade"))
+
+        // The reset itself is a persisted write, not just an in-memory clear - a fresh engine
+        // reading the same file must see ASK too, or a restart would quietly resurrect the ALLOW
+        // this operator just revoked.
+        val reloaded = McpPolicyEngine(policyFile = file)
+        assertEquals(McpPolicyAction.ASK, reloaded.policyFor("helm_upgrade"))
+    }
+
+    @Test
+    fun `revoking a persisted DENY also returns the tool to ASK`() {
+        val file = createTempPolicyFile()
+        val engine = McpPolicyEngine(policyFile = file)
+
+        engine.setToolPolicy("k8s_delete", McpPolicyAction.DENY)
+        assertEquals(McpPolicyAction.DENY, engine.policyFor("k8s_delete"))
+
+        assertTrue(engine.revokePersistedPolicy("k8s_delete"))
+        assertEquals(McpPolicyAction.ASK, engine.policyFor("k8s_delete"))
+    }
+
+    @Test
+    fun `revoking clears session trust too, so the call asks again even with both grants held`() {
+        val file = createTempPolicyFile()
+        val engine = McpPolicyEngine(policyFile = file)
+
+        // A tool that ended up with both a persisted ALLOW and separate session trust - policyFor
+        // checks session trust before a non-DENY configured rule, so without also clearing trust
+        // here, revoking only the persisted half would leave the call silently still auto-allowed.
+        engine.setToolPolicy("run_command", McpPolicyAction.ALLOW)
+        engine.trustForSession("run_command")
+        assertEquals(McpPolicyAction.ALLOW, engine.policyFor("run_command"))
+
+        assertTrue(engine.revokePersistedPolicy("run_command"))
+        assertEquals(McpPolicyAction.ASK, engine.policyFor("run_command"))
+    }
+
+    @Test
+    fun `revoking one tool's policy leaves an unrelated DENY rule untouched`() {
+        val file = createTempPolicyFile()
+        val engine = McpPolicyEngine(policyFile = file)
+
+        engine.setToolPolicy("docker_rm", McpPolicyAction.DENY)
+        engine.setToolPolicy("helm_upgrade", McpPolicyAction.ALLOW)
+
+        engine.revokePersistedPolicy("helm_upgrade")
+
+        assertEquals(McpPolicyAction.ASK, engine.policyFor("helm_upgrade"))
+        assertEquals(McpPolicyAction.DENY, engine.policyFor("docker_rm"))
+    }
+
+    @Test
+    fun `a failed revocation write is reported, not silently swallowed`() {
+        val file = createTempPolicyFile()
+        var reportedFault: McpPolicyFault? = null
+        // Constructed while the path is still absent, so this load sees no fault at all - the
+        // write failure below has to be the only thing this test is actually exercising.
+        val engine = McpPolicyEngine(policyFile = file, onFault = { reportedFault = it })
+        engine.trustForSession("helm_upgrade")
+
+        // atomicWriteText creates missing parent directories, so the failure has to be at the
+        // target itself: turning the policy file's own path into a directory means the atomic
+        // move at the end of the write has nothing it can replace.
+        file.mkdirs()
+
+        assertFalse(engine.revokePersistedPolicy("helm_upgrade"))
+        assertIs<McpPolicyFault.PolicyPersistFailed>(reportedFault)
+        // Session trust still cleared (in-memory, cannot fail); with no persisted rule and no
+        // trust left, the tool falls back to its ordinary mutating default - ASK, not the DENY a
+        // stuck PersistedPolicyUnreadable fault would force, which this test deliberately avoids.
+        assertEquals(McpPolicyAction.ASK, engine.policyFor("helm_upgrade"))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpPolicyRevocationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/mcp/McpPolicyRevocationTest.kt
@@ -1,0 +1,194 @@
+package ai.rever.boss.mcp
+
+import ai.rever.boss.plugin.api.McpToolDefinition
+import ai.rever.boss.plugin.api.McpToolHandler
+import ai.rever.boss.plugin.api.McpToolProvider
+import ai.rever.boss.plugin.api.McpToolResult
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class McpPolicyRevocationTest {
+    private fun provider(onExecute: () -> Unit) =
+        object : McpToolProvider {
+            override val providerId = "revocation-test"
+
+            override fun tools() =
+                listOf(
+                    McpToolDefinition(
+                        name = "run_command",
+                        description = "Disposable test tool",
+                        handler =
+                            McpToolHandler {
+                                onExecute()
+                                McpToolResult("ok")
+                            },
+                    ),
+                )
+        }
+
+    @Test
+    fun `reset invalidates a queued one call approval`() = staleApproval("once")
+
+    @Test
+    fun `reset prevents a queued session approval from restoring trust`() = staleApproval("session")
+
+    @Test
+    fun `reset prevents a queued persistent approval from restoring ALLOW`() = staleApproval("persistent")
+
+    private fun staleApproval(scope: String) =
+        runBlocking {
+            withTimeout(5_000) {
+                val dir = Files.createTempDirectory("mcp-revoke-queued").toFile()
+                try {
+                    val file = dir.resolve("policy.json")
+                    val engine = McpPolicyEngine(file)
+                    val bus = McpApprovalBus()
+                    val ledger = McpOperationLedger()
+                    var executions = 0
+                    val core =
+                        McpToolRegistryCore(
+                            disabledFile = null,
+                            policyEngine = engine,
+                            approvalBus = bus,
+                            ledger = ledger,
+                        )
+                    core.registerProvider(provider { executions++ })
+                    val first = async { core.invoke("run_command", "{}") }
+                    val firstRequest = bus.pendingList.first { it.size == 1 }.single()
+                    val second = async { core.invoke("run_command", "{}") }
+                    val secondRequest = bus.pendingList.first { it.size == 2 }.first { it.id != firstRequest.id }
+                    bus.approve(firstRequest.id, persistPolicy = true)
+                    assertFalse(first.await().isError)
+                    engine.trustForSession("run_command")
+                    assertTrue(engine.setToolPolicy("docker_rm", McpPolicyAction.DENY))
+
+                    // Deliver the old answer, then reset before its invocation coroutine resumes.
+                    bus.approve(
+                        secondRequest.id,
+                        trustForSession = scope == "session",
+                        persistPolicy = scope == "persistent",
+                    )
+                    assertTrue(engine.revokePersistedPolicy("run_command"))
+                    assertTrue(second.await().isError, scope)
+                    assertEquals(1, executions, scope)
+                    assertTrue(engine.sessionTrustedTools.value.isEmpty(), scope)
+                    assertEquals(McpPolicyAction.ASK, engine.policyFor("run_command"), scope)
+                    assertFalse(
+                        engine.config.value.rules
+                            .containsKey("run_command"),
+                        scope,
+                    )
+                    assertEquals(McpPolicyAction.ASK, McpPolicyEngine(file).policyFor("run_command"), scope)
+                    assertEquals(McpPolicyAction.DENY, McpPolicyEngine(file).policyFor("docker_rm"), scope)
+                    assertEquals(
+                        McpApprovalDisposition.POLICY_DENIED,
+                        ledger.recentOperations.value
+                            .first()
+                            .approvalDisposition,
+                    )
+
+                    // A new invocation must actually prompt; reading policyFor alone cannot prove this.
+                    val fresh = async { core.invoke("run_command", "{}") }
+                    val freshRequest = bus.pendingList.first { it.isNotEmpty() }.single()
+                    bus.approve(freshRequest.id)
+                    assertFalse(fresh.await().isError)
+                    assertEquals(2, executions)
+                } finally {
+                    dir.deleteRecursively()
+                }
+            }
+        }
+
+    @Test
+    fun `failed resets retain existing durable rules and clear only the selected trust`() {
+        for (action in listOf(McpPolicyAction.ALLOW, McpPolicyAction.DENY)) {
+            val dir = Files.createTempDirectory("mcp-revoke-failed").toFile()
+            try {
+                val file = dir.resolve("policy.json")
+                val engine = McpPolicyEngine(file)
+                assertTrue(engine.setToolPolicy("run_command", action))
+                assertTrue(engine.setToolPolicy("docker_rm", McpPolicyAction.DENY))
+                engine.trustForSession("run_command")
+                engine.trustForSession("helm_upgrade")
+                val backup = dir.resolve("saved.json")
+                Files.move(file.toPath(), backup.toPath())
+                assertTrue(file.mkdir())
+                file.resolve("blocker").writeText("prevents replacing the directory")
+
+                assertFalse(engine.revokePersistedPolicy("run_command"))
+                assertIs<McpPolicyFault.PolicyPersistFailed>(engine.fault.value)
+                assertEquals(action, engine.config.value.rules["run_command"])
+                assertEquals(action, engine.policyFor("run_command"))
+                assertEquals(setOf("helm_upgrade"), engine.sessionTrustedTools.value)
+                assertEquals(McpPolicyAction.DENY, engine.policyFor("docker_rm"))
+                assertEquals(action, McpPolicyEngine(backup).policyFor("run_command"))
+                assertEquals(McpPolicyAction.DENY, McpPolicyEngine(backup).policyFor("docker_rm"))
+            } finally {
+                dir.deleteRecursively()
+            }
+        }
+    }
+
+    @Test
+    fun `reset removes the rule and restores permissive or hardened defaults on reload`() {
+        for (default in listOf(McpPolicyAction.ALLOW, McpPolicyAction.DENY)) {
+            val dir = Files.createTempDirectory("mcp-reset-default").toFile()
+            try {
+                val file = dir.resolve("policy.json")
+                file.writeText("""{"defaultMutatingAction":"$default","defaultReadOnlyAction":"$default"}""")
+                val engine = McpPolicyEngine(file)
+                for (tool in listOf("run_command", "git_status")) {
+                    assertTrue(engine.setToolPolicy(tool, McpPolicyAction.ALLOW))
+                    assertTrue(engine.revokePersistedPolicy(tool))
+                    assertFalse(
+                        engine.config.value.rules
+                            .containsKey(tool),
+                    )
+                    assertEquals(default, engine.policyFor(tool))
+                    val reloaded = McpPolicyEngine(file)
+                    assertFalse(
+                        reloaded.config.value.rules
+                            .containsKey(tool),
+                    )
+                    assertEquals(default, reloaded.policyFor(tool))
+                }
+            } finally {
+                dir.deleteRecursively()
+            }
+        }
+    }
+
+    @Test
+    fun `stale persistent decisions cannot write after reset even when no DENY remains`() {
+        val dir = Files.createTempDirectory("mcp-reset-guard").toFile()
+        try {
+            val file = dir.resolve("policy.json")
+            val engine = McpPolicyEngine(file)
+            assertTrue(engine.setToolPolicy("run_command", McpPolicyAction.ALLOW))
+            val version = engine.revocationVersion("run_command")
+            assertTrue(engine.revokePersistedPolicy("run_command"))
+            val resetBytes = file.readText()
+            for (action in listOf(McpPolicyAction.ALLOW, McpPolicyAction.DENY)) {
+                assertFalse(engine.setToolPolicy("run_command", action, expectedRevocation = version))
+                assertEquals(resetBytes, file.readText())
+            }
+            assertTrue(
+                engine.setToolPolicy(
+                    "run_command",
+                    McpPolicyAction.ALLOW,
+                    expectedRevocation = engine.revocationVersion("run_command"),
+                ),
+            )
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
Operators previously had to edit mcp-tool-policy.json to create a durable MCP rule, and the first approval-dialog implementation had no UI path to inspect or revoke it. This PR adds Always Allow / Always Deny and a bottom-bar Persisted MCP policies dialog. Reset removes the selected rule and its session trust, so the configured default applies again (ASK for known mutations with shipped defaults); unrelated DENYs survive. Removing a DENY requires confirmation.

Rules apply by tool name to every agent and argument, survive restarts and follow that name across replacement providers. RBAC and tool kill switches retain precedence. Policy management remains host UI only.

Antriksh (@Antriksh1984) contributed the original UI/bus/registry wiring, persistent audit dispositions and two second-invocation tests in 6054511b8, inspection/revocation UI plus five engine tests in 07647584, and actual rule removal, IO dispatch, guidance, DENY confirmation and partial-failure text in 3a1efe34. Existing policy/audit infrastructure comes from #371 by @InfoSage05 and risk classification from #336 by @Nightingale2494. All author commits are preserved; no other implementation was consolidated.

Prior review-agent repair 598ea854 makes failed approval writes withhold execution and record POLICY_PERSIST_FAILED, preserves newer DENYs, rechecks disable/unload, and adds real-file/failure regressions. The current review-agent repair separately invalidates older authorizations on reset: once/session/persistent answers cannot execute or recreate a grant after a reset. Reset and session-grant checks share the policy lock. Added regressions cover queued calls and a fresh prompt, existing-rule failed reset writes in both directions, unrelated DENYs, reset-to-default on reload, and stale guarded writes.

A failed reset leaves the old durable rule in force and reports failure while clearing that tool's session trust; it does not imply ASK while a saved ALLOW remains. Calls already past final authorization are not cancelled. Already-queued prompts are not automatically removed, but their stale grants are rejected. Provider-scoped keys and separate policy-management ledger events are outside this change. Reset events are recorded in the host log.

Validation: 342 focused MCP/app/dialog desktop tests passed with zero failures/errors/skips. A subsequent test-fixture extraction changed no production code; all six affected revocation tests were rerun and passed. Root ktlintCheck and detekt pass under the shared build lock. Current dev 9f141405 is included. Author head 3a1efe34 passed all nine hosted Build & Test jobs; final-head hosted checks remain pending at publication. Claude completed the requested review of 07647584: https://github.com/risa-labs-inc/BossConsole/pull/469#issuecomment-5617284332 . The author follow-up addresses the UI/persistence findings; separate agent repair 06ea5e52c closes the queued-reset race; no independent Claude approval of the final head is claimed.

Manual checks remain: light/dark and short-window layout; all five approval choices against disposable tools; saved-rule counts and disappearance after reset; DENY confirmation; session trust and configured-default behavior; user-driven restart; a visible failed-reset write with the previous rule retained; two queued prompts with a reset/newer DENY/disable before the older answer. No app instances were launched/stopped, no live database changes or plugin deployment were performed. API pin remains 1.0.88. No merge or auto-merge is authorized.
