### PR TITLE
fix(deep-link): report whether a plugin action link actually ran, not a blind OK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -798,6 +798,15 @@ Linux) or a loopback port (Windows). Every request must present the token,
 "another instance is running" means something answered on the channel rather than
 a pid existing, and a descriptor nobody answers on is reclaimed.
 
+A forwarded plugin action (`boss://plugin?id=...&action=...`) is acknowledged
+only when its handler reports true. Missing ids, missing handlers, declined
+and throwing handlers report failure. The channel waits up to five seconds;
+a timeout reports an unknown outcome and cancels dispatch if it is still queued.
+An already-running synchronous handler cannot be interrupted. Startup therefore
+never retries plugin actions automatically, even after a lost response; auth and
+other open requests retain their existing retries. Panel-open links still only
+acknowledge queuing. The wire verdict does not change OS/CLI callers that ignore it.
+
 ## Every OS open request becomes a `boss://` link
 
 Links and files arrive through four different doors and all four normalise to one

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -480,31 +480,20 @@ fun main(args: Array<String>) {
             // Try to send with retry logic (important for auth deep links during sign-in)
             // Note: runBlocking is acceptable here as this runs during pre-UI initialization,
             // before the Compose application starts. No UI thread exists yet to block.
-            val maxRetries = 3
-
-            fun forward(link: String): Boolean {
-                for (attempt in 1..maxRetries) {
-                    if (SingleInstanceManager.sendToExistingInstance(link, DeepLinkOrigin.EXTERNAL)) {
-                        logger.info(LogCategory.SYSTEM, "URL sent successfully", mapOf("attempt" to attempt))
-                        return true
-                    }
-                    logger.warn(
-                        LogCategory.SYSTEM,
-                        "Failed to send URL",
-                        mapOf(
-                            "attempt" to attempt,
-                            "maxRetries" to maxRetries,
-                        ),
-                    )
-                    if (attempt < maxRetries) {
-                        // Use coroutine delay instead of Thread.sleep to avoid blocking
-                        kotlinx.coroutines.runBlocking {
-                            kotlinx.coroutines.delay(500)
-                        }
-                    }
-                }
-                return false
-            }
+            fun forward(link: String): Boolean =
+                ai.rever.boss.utils.forwardDeepLinkWithRetry(
+                    link = link,
+                    send = { attempt ->
+                        val accepted = SingleInstanceManager.sendToExistingInstance(link, DeepLinkOrigin.EXTERNAL)
+                        logger.info(
+                            LogCategory.SYSTEM,
+                            "Open request forwarding completed",
+                            mapOf("attempt" to attempt, "accepted" to accepted),
+                        )
+                        accepted
+                    },
+                    pause = { kotlinx.coroutines.runBlocking { kotlinx.coroutines.delay(500) } },
+                )
 
             // Every link is attempted, and success means every one landed.
             // `fold` rather than `all`, which would short-circuit and silently
@@ -514,14 +503,11 @@ fun main(args: Array<String>) {
             if (success) {
                 exitProcess(0)
             } else {
-                // IPC failed after retries - DO NOT create new window
+                // Forwarding failed or the action did not report success - DO NOT create a new window.
                 // This prevents duplicate windows during sign-in
                 logger.error(
                     LogCategory.SYSTEM,
-                    "Could not send URL to existing instance after retries",
-                    mapOf(
-                        "maxRetries" to maxRetries,
-                    ),
+                    "An open request did not report success in the existing instance",
                 )
                 exitProcess(1)
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkForwarding.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkForwarding.kt
@@ -1,0 +1,47 @@
+package ai.rever.boss.utils
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Action handlers may have side effects even when their verdict is false or
+ * unknown. Never replay an action automatically, including after a lost reply.
+ * Other open requests retain the startup retry policy used by auth callbacks.
+ */
+internal fun forwardDeepLinkWithRetry(
+    link: String,
+    send: (attempt: Int) -> Boolean,
+    pause: () -> Unit,
+): Boolean {
+    // Match the same raw action key accepted by DeepLinkHandler's query parser.
+    val isAction =
+        routedDeepLinkHost(link) == DeepLinkHost.PLUGIN &&
+            link.substringAfter("?", "").split("&").any { it.startsWith("action=") }
+    val attempts = if (isAction) 1 else 3
+    for (attempt in 1..attempts) {
+        if (send(attempt)) return true
+        if (attempt < attempts) pause()
+    }
+    return false
+}
+
+/** Null means unknown at the deadline; false includes a cancelled dispatch. */
+internal suspend fun awaitPluginAction(
+    verdict: Deferred<Boolean>,
+    timeoutMillis: Long,
+): Boolean? {
+    val result =
+        try {
+            withTimeoutOrNull(timeoutMillis) { verdict.await() }
+        } catch (_: CancellationException) {
+            // A cancelled dispatch is a negative verdict, but cancellation of
+            // this waiter itself must still propagate to its caller.
+            currentCoroutineContext().ensureActive()
+            false
+        }
+    if (result == null) verdict.cancel()
+    return result
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
@@ -12,7 +12,9 @@ import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.utils.logging.LogSanitizer
 import ai.rever.boss.window.MenuActionsHandler
 import ai.rever.boss.window.Project
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -331,11 +333,19 @@ actual object DeepLinkHandler {
      * [origin] reaches the handlers that need it (currently `boss://terminal`)
      * because no later stage can tell an operator's request apart from one some
      * other program asked the OS to open.
+     *
+     * @return a [Deferred] resolving to whether the link was actually acted on,
+     *   for the one route that can answer that question today
+     *   ([DeepLinkHost.PLUGIN] with an `action`) — null for every other route,
+     *   which stays fire-and-forget exactly as before. A caller with no use for
+     *   the verdict (the OS-delivered flow, the CLI) can ignore the return value
+     *   unchanged; [SingleInstanceManager] is the one caller that awaits it, so a
+     *   forwarded action link no longer reports success it never delivered.
      */
     fun processDeepLink(
         uri: String,
         origin: DeepLinkOrigin,
-    ) {
+    ): Deferred<Boolean>? {
         logger.info(
             LogCategory.SYSTEM,
             "Processing deep link",
@@ -357,7 +367,7 @@ actual object DeepLinkHandler {
                 mapOf("uri" to LogSanitizer.maskUriParams(uri)),
             )
             _deepLinkFlow.value = uri
-            return
+            return null
         }
 
         // Single resolution point for every host that acts on a window here.
@@ -367,7 +377,7 @@ actual object DeepLinkHandler {
         // window is plainly registered. Resolving here instead of inside each
         // handler is what keeps the window-targeting links from diverging again.
         // Safe on this thread: resolveActionableWindowId reads volatile state.
-        dispatch(host, uri, targetWindowIdFor(host) { WindowFocusManager.resolveActionableWindowId() }, origin)
+        return dispatch(host, uri, targetWindowIdFor(host) { WindowFocusManager.resolveActionableWindowId() }, origin)
     }
 
     /**
@@ -380,16 +390,17 @@ actual object DeepLinkHandler {
         uri: String,
         targetWindowId: String?,
         origin: DeepLinkOrigin,
-    ) {
+    ): Deferred<Boolean>? {
         when (host) {
             DeepLinkHost.URL -> handleUrlLink(uri)
             DeepLinkHost.WORKSPACE -> handleWorkspaceLink(uri)
             DeepLinkHost.FILE -> handleFileLink(uri)
             DeepLinkHost.TERMINAL -> handleTerminalLink(uri, origin)
             DeepLinkHost.FOLDER -> handleFolderLink(uri, targetWindowId)
-            DeepLinkHost.PLUGIN -> handlePluginLink(uri, targetWindowId)
+            DeepLinkHost.PLUGIN -> return handlePluginLink(uri, targetWindowId)
             DeepLinkHost.SPLIT -> handleSplitLink(uri, targetWindowId)
         }
+        return null
     }
 
     actual fun clearDeepLink() {
@@ -537,11 +548,19 @@ actual object DeepLinkHandler {
      *
      * [targetWindowId] is already resolved by [processDeepLink]; the panel event
      * and the action dispatch are emitted on the UI thread.
+     *
+     * @return for an action link, a [Deferred] resolving to
+     *   [ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl.dispatch]'s
+     *   own verdict (false for an unregistered handler id, a handler that
+     *   declines the action, or one that throws — that function never lets an
+     *   exception escape). Null for a panel-open link and for the missing-`id`
+     *   case, both of which stay fire-and-forget: there is no wire caller today
+     *   that needs to know whether a panel actually opened.
      */
     private fun handlePluginLink(
         uri: String,
         targetWindowId: String?,
-    ) {
+    ): Deferred<Boolean>? {
         logger.debug(LogCategory.UI, "Handling plugin link")
 
         val params = parseQueryParams(uri)
@@ -549,7 +568,7 @@ actual object DeepLinkHandler {
 
         if (panelIdStr == null) {
             logger.warn(LogCategory.UI, "Missing 'id' parameter in plugin deep link")
-            return
+            return null
         }
 
         // Action links dispatch to the plugin's DeepLinkActionHandler and do
@@ -557,18 +576,39 @@ actual object DeepLinkHandler {
         // sharing the `plugin` scheme. Unhandled actions just log (registry
         // warns); external input, so handlers own validation.
         val action = params["action"]?.urlDecode()
-        if (action != null) {
-            val actionParams =
-                params
-                    .filterKeys { it != "id" && it != "action" }
-                    .mapValues { (_, value) -> value.urlDecode() }
-            scope.launch(Dispatchers.Main) {
-                ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
-                    .dispatch(panelIdStr, action, actionParams)
-            }
-            return
+        return if (action != null) {
+            dispatchPluginAction(panelIdStr, action, params)
+        } else {
+            openPluginPanel(panelIdStr, targetWindowId)
+            null
         }
+    }
 
+    /** Runs a `boss://plugin?id=…&action=…` link's action and hands back its real outcome. */
+    private fun dispatchPluginAction(
+        handlerId: String,
+        action: String,
+        params: Map<String, String>,
+    ): Deferred<Boolean> {
+        val actionParams =
+            params
+                .filterKeys { it != "id" && it != "action" }
+                .mapValues { (_, value) -> value.urlDecode() }
+        val verdict = CompletableDeferred<Boolean>()
+        scope.launch(Dispatchers.Main) {
+            val handled =
+                ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
+                    .dispatch(handlerId, action, actionParams)
+            verdict.complete(handled)
+        }
+        return verdict
+    }
+
+    /** Opens a `boss://plugin?id=…` link's panel. Fire-and-forget: nothing awaits this today. */
+    private fun openPluginPanel(
+        panelIdStr: String,
+        targetWindowId: String?,
+    ) {
         if (targetWindowId == null) {
             logger.warn(
                 LogCategory.UI,
@@ -578,7 +618,6 @@ actual object DeepLinkHandler {
             return
         }
 
-        // Emit panel open event
         scope.launch(Dispatchers.Main) {
             // Create PanelId with panelId string
             // The event handler in BossApp will look it up in the registry

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -553,9 +554,8 @@ actual object DeepLinkHandler {
      *   [ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl.dispatch]'s
      *   own verdict (false for an unregistered handler id, a handler that
      *   declines the action, or one that throws — that function never lets an
-     *   exception escape). Null for a panel-open link and for the missing-`id`
-     *   case, both of which stay fire-and-forget: there is no wire caller today
-     *   that needs to know whether a panel actually opened.
+     *   exception escape). Null for a panel-open link, which stays fire-and-forget. An action
+     *   without a usable id is rejected with a false verdict.
      */
     private fun handlePluginLink(
         uri: String,
@@ -566,9 +566,9 @@ actual object DeepLinkHandler {
         val params = parseQueryParams(uri)
         val panelIdStr = params["id"]?.urlDecode()
 
-        if (panelIdStr == null) {
+        if (panelIdStr.isNullOrBlank()) {
             logger.warn(LogCategory.UI, "Missing 'id' parameter in plugin deep link")
-            return null
+            return if (params.containsKey("action")) CompletableDeferred(false) else null
         }
 
         // Action links dispatch to the plugin's DeepLinkActionHandler and do
@@ -594,14 +594,10 @@ actual object DeepLinkHandler {
             params
                 .filterKeys { it != "id" && it != "action" }
                 .mapValues { (_, value) -> value.urlDecode() }
-        val verdict = CompletableDeferred<Boolean>()
-        scope.launch(Dispatchers.Main) {
-            val handled =
-                ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
-                    .dispatch(handlerId, action, actionParams)
-            verdict.complete(handled)
+        return scope.async(Dispatchers.Main) {
+            ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
+                .dispatch(handlerId, action, actionParams)
         }
-        return verdict
     }
 
     /** Opens a `boss://plugin?id=…` link's panel. Fire-and-forget: nothing awaits this today. */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
@@ -92,6 +92,11 @@ private const val CONNECTION_TIMEOUT_MS = 10000L // 10 seconds - important for a
 private const val LLM_TOKEN_TIMEOUT_MS = 90000L
 private const val MCP_INVOKE_TIMEOUT_MS = 60000L
 
+// Well under CONNECTION_TIMEOUT_MS: VERB_OPEN gets the default socket budget (it is
+// not a longer-budget candidate), so this wait must leave room for that budget to
+// still close a genuinely wedged connection rather than race it.
+private const val OPEN_ACTION_TIMEOUT_MS = 5000L
+
 /**
  * Ceiling on a single request. Bounds what one caller can make the app buffer,
  * sized to accommodate Base64-encoded tool arguments and payloads.
@@ -1111,8 +1116,27 @@ object SingleInstanceManager {
                 // The forwarding instance states the URL's provenance; it is not
                 // inferred from the caller having held the token, which says
                 // nothing about where the URL came from.
-                DeepLinkHandler.processDeepLink(requireNotNull(request.url), request.origin)
-                RESPONSE_OK
+                val verdict = DeepLinkHandler.processDeepLink(requireNotNull(request.url), request.origin)
+                // Every route but a plugin action link returns null here and
+                // keeps today's fire-and-forget behaviour: RESPONSE_OK means
+                // only "queued". An action link is the one case with a real
+                // answer to await, so its OK/ERROR reflects whether the
+                // registered handler actually ran the action, not just that a
+                // coroutine was launched for it.
+                if (verdict == null) {
+                    RESPONSE_OK
+                } else {
+                    val handled =
+                        kotlinx.coroutines.runBlocking {
+                            kotlinx.coroutines.withTimeoutOrNull(OPEN_ACTION_TIMEOUT_MS) { verdict.await() }
+                        }
+                    if (handled == true) {
+                        RESPONSE_OK
+                    } else {
+                        RESPONSE_ERROR_PREFIX +
+                            "Plugin action was not handled (unknown handler, declined, or timed out)"
+                    }
+                }
             }
 
             request.verb == VERB_LLM_TOKEN -> {
@@ -1333,7 +1357,11 @@ object SingleInstanceManager {
      * @param origin what the caller knows about where [url] came from. Defaults to
      *   [DeepLinkOrigin.EXTERNAL], because a forwarded URL normally reached this
      *   process from the OS.
-     * @return true if the running instance acknowledged it.
+     * @return true if the running instance acknowledged it. For most links this
+     *   still means only "queued" (fire-and-forget, as before); for a
+     *   `boss://plugin?id=…&action=…` link it now means the registered handler
+     *   actually ran the action — an unregistered handler id, a declined action,
+     *   or a timeout all return false instead of a blind acknowledgement.
      */
     fun sendToExistingInstance(
         url: String,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
@@ -881,6 +881,20 @@ private fun acceptNextClient(
         null
     }
 
+private fun pluginActionResponse(verdict: kotlinx.coroutines.Deferred<Boolean>?): String {
+    if (verdict == null) return RESPONSE_OK
+    val handled = kotlinx.coroutines.runBlocking { awaitPluginAction(verdict, OPEN_ACTION_TIMEOUT_MS) }
+    return when (handled) {
+        true -> RESPONSE_OK
+
+        false -> RESPONSE_ERROR_PREFIX + "Plugin action was not handled"
+
+        // The deadline cancels queued dispatch; an already-running synchronous
+        // handler cannot be interrupted, so its outcome remains unknown.
+        null -> RESPONSE_ERROR_PREFIX + "Plugin action outcome unknown (timed out); do not retry automatically"
+    }
+}
+
 /**
  * Manages single-instance application behavior.
  *
@@ -1123,29 +1137,7 @@ object SingleInstanceManager {
                 // answer to await, so its OK/ERROR reflects whether the
                 // registered handler reported the action handled, not just that a
                 // coroutine was launched for it.
-                if (verdict == null) {
-                    RESPONSE_OK
-                } else {
-                    val handled =
-                        kotlinx.coroutines.runBlocking {
-                            awaitPluginAction(verdict, OPEN_ACTION_TIMEOUT_MS)
-                        }
-                    when (handled) {
-                        true -> {
-                            RESPONSE_OK
-                        }
-
-                        false -> {
-                            RESPONSE_ERROR_PREFIX + "Plugin action was not handled"
-                        }
-
-                        null -> {
-                            // Cancels an action still queued on Main. A synchronous handler
-                            // already running cannot be interrupted, so its outcome is unknown.
-                            RESPONSE_ERROR_PREFIX + "Plugin action outcome unknown (timed out); do not retry automatically"
-                        }
-                    }
-                }
+                pluginActionResponse(verdict)
             }
 
             request.verb == VERB_LLM_TOKEN -> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
@@ -1121,20 +1121,29 @@ object SingleInstanceManager {
                 // keeps today's fire-and-forget behaviour: RESPONSE_OK means
                 // only "queued". An action link is the one case with a real
                 // answer to await, so its OK/ERROR reflects whether the
-                // registered handler actually ran the action, not just that a
+                // registered handler reported the action handled, not just that a
                 // coroutine was launched for it.
                 if (verdict == null) {
                     RESPONSE_OK
                 } else {
                     val handled =
                         kotlinx.coroutines.runBlocking {
-                            kotlinx.coroutines.withTimeoutOrNull(OPEN_ACTION_TIMEOUT_MS) { verdict.await() }
+                            awaitPluginAction(verdict, OPEN_ACTION_TIMEOUT_MS)
                         }
-                    if (handled == true) {
-                        RESPONSE_OK
-                    } else {
-                        RESPONSE_ERROR_PREFIX +
-                            "Plugin action was not handled (unknown handler, declined, or timed out)"
+                    when (handled) {
+                        true -> {
+                            RESPONSE_OK
+                        }
+
+                        false -> {
+                            RESPONSE_ERROR_PREFIX + "Plugin action was not handled"
+                        }
+
+                        null -> {
+                            // Cancels an action still queued on Main. A synchronous handler
+                            // already running cannot be interrupted, so its outcome is unknown.
+                            RESPONSE_ERROR_PREFIX + "Plugin action outcome unknown (timed out); do not retry automatically"
+                        }
                     }
                 }
             }
@@ -1360,8 +1369,9 @@ object SingleInstanceManager {
      * @return true if the running instance acknowledged it. For most links this
      *   still means only "queued" (fire-and-forget, as before); for a
      *   `boss://plugin?id=…&action=…` link it now means the registered handler
-     *   actually ran the action — an unregistered handler id, a declined action,
-     *   or a timeout all return false instead of a blind acknowledgement.
+     *   reported the action handled. An unregistered handler id, a declined
+     *   action, or an unknown outcome at timeout returns false. This is not a
+     *   guarantee that asynchronous work started by a handler has completed.
      */
     fun sendToExistingInstance(
         url: String,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DeepLinkForwardingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DeepLinkForwardingTest.kt
@@ -1,0 +1,60 @@
+package ai.rever.boss.utils
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DeepLinkForwardingTest {
+    @Test
+    fun `a deadline gives an unknown outcome and cancels the pending dispatch`() =
+        runBlocking {
+            val verdict = CompletableDeferred<Boolean>()
+            assertNull(awaitPluginAction(verdict, 1))
+            assertTrue(verdict.isCancelled)
+        }
+
+    @Test
+    fun `a cancelled dispatch returns a negative verdict without escaping to the socket handler`() =
+        runBlocking {
+            val verdict = CompletableDeferred<Boolean>()
+            verdict.cancel()
+            assertEquals(false, awaitPluginAction(verdict, 5000))
+        }
+
+    @Test
+    fun `an unsuccessful action is submitted only once even if a retry would succeed`() {
+        for (link in listOf("boss://plugin?id=x&action=run", "BOSS://PLUGIN?action=run", "boss://plugin?id=x&action=")) {
+            var sends = 0
+            var pauses = 0
+            val accepted = forwardDeepLinkWithRetry(link, { ++sends > 1 }, { pauses++ })
+            assertFalse(accepted)
+            assertEquals(1, sends)
+            assertEquals(0, pauses)
+        }
+    }
+
+    @Test
+    fun `auth and panel opens retain bounded retries and stop at success`() {
+        for (link in listOf("boss://auth/verify?token=test", "boss://plugin?id=x", "boss://plugins?action=run")) {
+            var sends = 0
+            var pauses = 0
+            assertTrue(forwardDeepLinkWithRetry(link, { ++sends == 2 }, { pauses++ }))
+            assertEquals(2, sends)
+            assertEquals(1, pauses)
+            sends = 0
+            pauses = 0
+            assertFalse(
+                forwardDeepLinkWithRetry(link, {
+                    sends++
+                    false
+                }, { pauses++ }),
+            )
+            assertEquals(3, sends)
+            assertEquals(2, pauses)
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DeepLinkForwardingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DeepLinkForwardingTest.kt
@@ -27,7 +27,8 @@ class DeepLinkForwardingTest {
 
     @Test
     fun `an unsuccessful action is submitted only once even if a retry would succeed`() {
-        for (link in listOf("boss://plugin?id=x&action=run", "BOSS://PLUGIN?action=run", "boss://plugin?id=x&action=")) {
+        val links = listOf("boss://plugin?id=x&action=run", "BOSS://PLUGIN?action=run", "boss://plugin?id=x&action=")
+        for (link in links) {
             var sends = 0
             var pauses = 0
             val accepted = forwardDeepLinkWithRetry(link, { ++sends > 1 }, { pauses++ })

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DeepLinkRoutingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DeepLinkRoutingTest.kt
@@ -1,8 +1,13 @@
 package ai.rever.boss.utils
 
+import ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
+import ai.rever.boss.plugin.api.DeepLinkActionHandler
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Guards deep-link dispatch: hosts match exactly (so a longer host is never
@@ -111,6 +116,57 @@ class DeepLinkRoutingTest {
 
         DeepLinkHandler.clearDeepLink()
         assertNull(DeepLinkHandler.deepLinkFlow.value)
+    }
+
+    @Test
+    fun `a plugin action link reports whether the registered handler actually ran it`() {
+        // boss://plugin?id=X&action=Y used to fire-and-forget into a coroutine
+        // whose result nobody read, so a caller forwarding the link over the
+        // single-instance channel got RESPONSE_OK regardless of whether a
+        // handler for X even existed. processDeepLink now hands back a Deferred
+        // for exactly this route, so SingleInstanceManager can await the real
+        // outcome instead.
+        val handlerId = "test-deep-link-handler-${System.nanoTime()}"
+        DeepLinkActionRegistryImpl.register(
+            object : DeepLinkActionHandler {
+                override val handlerId = handlerId
+
+                override fun handle(
+                    action: String,
+                    params: Map<String, String>,
+                ): Boolean = action == "ping"
+            },
+        )
+        try {
+            val handled = awaitPluginActionVerdict("boss://plugin?id=$handlerId&action=ping")
+            assertTrue(handled, "a registered handler that returns true must be reported as handled")
+
+            val declined = awaitPluginActionVerdict("boss://plugin?id=$handlerId&action=unknown")
+            assertFalse(declined, "a registered handler that declines the action must be reported as not handled")
+        } finally {
+            DeepLinkActionRegistryImpl.unregister(handlerId)
+        }
+
+        val noHandler = awaitPluginActionVerdict("boss://plugin?id=no-such-handler&action=ping")
+        assertFalse(noHandler, "an unregistered handler id must be reported as not handled, never a blind success")
+    }
+
+    private fun awaitPluginActionVerdict(uri: String): Boolean =
+        runBlocking {
+            requireNotNull(DeepLinkHandler.processDeepLink(uri, DeepLinkOrigin.EXTERNAL)).await()
+        }
+
+    @Test
+    fun `every route but a plugin action link stays fire-and-forget`() {
+        // The Deferred verdict is new surface area added for exactly one route;
+        // every other route must keep returning null so a caller with no use
+        // for the verdict (the OS-delivered flow, the CLI) sees no behaviour
+        // change at all.
+        assertNull(DeepLinkHandler.processDeepLink("boss://url?url=https%3A%2F%2Fexample.com", DeepLinkOrigin.EXTERNAL))
+        assertNull(DeepLinkHandler.processDeepLink("boss://terminal", DeepLinkOrigin.EXTERNAL))
+        assertNull(DeepLinkHandler.processDeepLink("boss://split?orientation=horizontal", DeepLinkOrigin.EXTERNAL))
+        // A plugin link with no action (opens a panel) is also still fire-and-forget.
+        assertNull(DeepLinkHandler.processDeepLink("boss://plugin?id=bookmarks", DeepLinkOrigin.EXTERNAL))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DeepLinkRoutingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DeepLinkRoutingTest.kt
@@ -134,7 +134,10 @@ class DeepLinkRoutingTest {
                 override fun handle(
                     action: String,
                     params: Map<String, String>,
-                ): Boolean = action == "ping"
+                ): Boolean {
+                    check(action != "throw") { "test failure" }
+                    return action == "ping"
+                }
             },
         )
         try {
@@ -143,6 +146,7 @@ class DeepLinkRoutingTest {
 
             val declined = awaitPluginActionVerdict("boss://plugin?id=$handlerId&action=unknown")
             assertFalse(declined, "a registered handler that declines the action must be reported as not handled")
+            assertFalse(awaitPluginActionVerdict("boss://plugin?id=$handlerId&action=throw"))
         } finally {
             DeepLinkActionRegistryImpl.unregister(handlerId)
         }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/SingleInstanceChannelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/SingleInstanceChannelTest.kt
@@ -237,6 +237,42 @@ class SingleInstanceChannelTest {
     }
 
     @Test
+    fun `forwarding a plugin action link reports the handler's real outcome, not a blind OK`() {
+        // A boss://plugin?id=X&action=Y link used to be fire-and-forget: the
+        // forwarding instance always got RESPONSE_OK, whether or not a handler
+        // for X was even registered. Now the response reflects what actually
+        // happened, so an automation or CLI caller forwarding the link over
+        // this channel can tell a genuine success from a silent no-op.
+        assertTrue(SingleInstanceManager.acquireLock())
+
+        val handlerId = "channel-test-handler-${System.nanoTime()}"
+        ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
+            .register(
+                object : ai.rever.boss.plugin.api.DeepLinkActionHandler {
+                    override val handlerId = handlerId
+
+                    override fun handle(
+                        action: String,
+                        params: Map<String, String>,
+                    ): Boolean = action == "ping"
+                },
+            )
+        try {
+            assertTrue(SingleInstanceManager.sendToExistingInstance("boss://plugin?id=$handlerId&action=ping"))
+            assertFalse(SingleInstanceManager.sendToExistingInstance("boss://plugin?id=$handlerId&action=unknown"))
+        } finally {
+            ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
+                .unregister(handlerId)
+        }
+
+        assertFalse(SingleInstanceManager.sendToExistingInstance("boss://plugin?id=no-such-handler&action=ping"))
+
+        // A plugin link that just opens a panel (no action) is unaffected: still
+        // reported as acknowledged, exactly like before this change.
+        assertTrue(SingleInstanceManager.sendToExistingInstance("boss://plugin?id=bookmarks"))
+    }
+
+    @Test
     fun `a credential helper receives a token from the signed-in running instance`() {
         SingleInstanceManager.llmTokenProviderOverride = { Result.success("sk-short-lived-pilot") }
         assertTrue(SingleInstanceManager.acquireLock())

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/SingleInstanceChannelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/SingleInstanceChannelTest.kt
@@ -273,6 +273,53 @@ class SingleInstanceChannelTest {
     }
 
     @Test
+    fun `a plugin action without a usable id is refused`() {
+        assertTrue(SingleInstanceManager.acquireLock())
+        assertFalse(SingleInstanceManager.sendToExistingInstance("boss://plugin?action=ping"))
+        assertFalse(SingleInstanceManager.sendToExistingInstance("boss://plugin?id=&action=ping"))
+    }
+
+    @Test
+    fun `a timed out queued action never runs after the UI thread becomes available`() {
+        assertTrue(SingleInstanceManager.acquireLock())
+        val entered = java.util.concurrent.CountDownLatch(1)
+        val release = java.util.concurrent.CountDownLatch(1)
+        val calls =
+            java.util.concurrent.atomic
+                .AtomicInteger()
+        val handlerId = "timeout-test-handler"
+        ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
+            .register(
+                object : ai.rever.boss.plugin.api.DeepLinkActionHandler {
+                    override val handlerId = handlerId
+
+                    override fun handle(
+                        action: String,
+                        params: Map<String, String>,
+                    ): Boolean {
+                        calls.incrementAndGet()
+                        return true
+                    }
+                },
+            )
+        javax.swing.SwingUtilities.invokeLater {
+            entered.countDown()
+            release.await(15, java.util.concurrent.TimeUnit.SECONDS)
+        }
+        try {
+            assertTrue(entered.await(5, java.util.concurrent.TimeUnit.SECONDS))
+            assertFalse(SingleInstanceManager.sendToExistingInstance("boss://plugin?id=$handlerId&action=run"))
+        } finally {
+            release.countDown()
+            // Drain the queued dispatch before inspecting its observable side effect.
+            javax.swing.SwingUtilities.invokeAndWait {}
+            ai.rever.boss.components.plugin.registries.DeepLinkActionRegistryImpl
+                .unregister(handlerId)
+        }
+        assertEquals(0, calls.get(), "a timed out action must not execute later from the Main queue")
+    }
+
+    @Test
     fun `a credential helper receives a token from the signed-in running instance`() {
         SingleInstanceManager.llmTokenProviderOverride = { Result.success("sk-short-lived-pilot") }
         assertTrue(SingleInstanceManager.acquireLock())


### PR DESCRIPTION
## Problem and behavior

Forwarded `boss://plugin?id=<handler>&action=<action>` links previously received OK as soon as dispatch was queued, even when no handler existed or the handler declined the action. The channel now waits for the handler's Boolean verdict, bounded at five seconds. Missing/blank ids and rejected or throwing handlers report failure. Panel opens and other deep-link routes retain their queued acknowledgement.

A timeout reports an unknown outcome. Pending dispatch is cancelled so it cannot run later from the UI queue; a synchronous handler already running cannot be interrupted. The launcher therefore submits plugin actions only once, including after a lost reply. Auth callbacks and ordinary open requests retain their bounded retries. A true verdict means the handler reported the action handled, not that asynchronous work it launched has finished.

## Contributor provenance

Original implementation and initial routing/socket tests: **Antriksh (@Antriksh1984)**. The motivating report is **Devansh (@Devx228)**'s [issue #332 discussion](https://github.com/risa-labs-inc/BossConsole/issues/332), from development of the separate agent-warden plugin. That plugin is not being consolidated into this PR.

Review-agent follow-up: reject malformed action targets; make dispatch cancellable; handle cancelled dispatch without losing the socket response; distinguish unknown timeout outcomes; prevent automatic replay of action links; add timeout, cancellation, throwing-handler, malformed-id and forwarding-policy regression tests; document the contract in AGENTS.md. These repairs are separate from the original contributor's work.

## Validation

Original head 0baf5b9e2 passed all nine hosted Build & Test checks. Claude review identified retry amplification, malformed-id acknowledgement and cancellation gaps; the follow-up addresses those findings. Final local validation on `ca0a9318af106bdea7a423c13f55d64da0d1d98c`: **50 tests pass**, zero failures/errors/skips (10 routing, 36 socket/channel, 4 forwarding/cancellation); full root `ktlintCheck` and `detekt` pass through the shared build lock. Current-dev merge-tree is conflict-free. Hosted CI on this final head is pending.

No app instance was launched or stopped. Native/manual checks remain: forward an accepted and a declined action from a second process, confirm one handler invocation each, exercise a handler slower than five seconds and confirm an unknown outcome without automatic replay, then smoke-test auth callbacks and panel opens. Cold-start and direct CLI routes that ignore the returned verdict remain outside this wire-result guarantee.
