### PR TITLE
fix(logging): stop a sensitive URL param's colon from leaking a token fragment

### DIFF
--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/logging/LogSanitizerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/logging/LogSanitizerTest.kt
@@ -553,6 +553,54 @@ class LogSanitizerTest {
         assertFalse(result.contains("api.risaboss.com"), "hostname leaked through a URL: $result")
     }
 
+    // BossConsole#109 (review comment): filePathPattern's `[^\s:]+` stops at a colon, so a
+    // sensitive query/fragment value containing one is only partly consumed and the tail
+    // survives verbatim - a genuine token-fragment leak, not a cosmetic gap.
+    @Test
+    fun `sanitizeExceptionMessage does not leak a token fragment when its value contains a colon`() {
+        val result =
+            LogSanitizer.sanitizeExceptionMessage(
+                "Failed: [url=https://api.example.com/cb?token=abc:def]",
+            )
+        assertFalse(result.contains("abc"), "token fragment leaked before the colon: $result")
+        assertFalse(result.contains("def"), "token fragment leaked after the colon: $result")
+        assertFalse(result.contains(":def"), "the exact reported leak shape: $result")
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage redacts a colon-bearing secret in a URL fragment too`() {
+        val result =
+            LogSanitizer.sanitizeExceptionMessage(
+                "Deep link boss://auth#access_token=abc:def&type=recovery rejected",
+            )
+        assertFalse(result.contains("abc"), "fragment token leaked: $result")
+        assertFalse(result.contains(":def"), "fragment token leaked after colon: $result")
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage leaves a non-sensitive query param untouched by the new pass`() {
+        // The new pre-pass only fires for names nameMarksSecret recognises. A non-sensitive
+        // param's colon is not this fix's scope - it must still hit filePathPattern's
+        // pre-existing colon boundary exactly as before, unchanged by this fix.
+        assertEquals(
+            "Redirected to https:[PATH]:b",
+            LogSanitizer.sanitizeExceptionMessage("Redirected to https://api.example.com/go?next=a:b"),
+        )
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage still keeps a colon-free token carried in a URL redacted exactly as before`() {
+        // Regression guard: the new pre-pass must not change the already-pinned output for
+        // the ordinary (no-colon) case in `sanitizeExceptionMessage keeps a token carried in a
+        // URL redacted` above.
+        assertEquals(
+            "Request to https:[PATH] failed",
+            LogSanitizer.sanitizeExceptionMessage(
+                "Request to https://api.example.com/auth/v1/verify?access_token=eyJhbGciOiJIUzI1NiJ9.abc.def failed",
+            ),
+        )
+    }
+
     @Test
     fun `sanitizeExceptionMessage does not mistake a fully-qualified class name for a hostname`() {
         // The exact false-positive risk a naive hostname pattern would create: Kotlin/Java

--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
@@ -319,6 +319,30 @@ object LogSanitizer {
      */
     private val assignmentPattern = Regex("""(?<![A-Za-z0-9_.])([A-Za-z][A-Za-z0-9_.-]*)=([^\s\[][^\s]*)""")
 
+    /**
+     * A sensitive-named query or fragment parameter inside a URL — `?token=…`,
+     * `&access_token=…`, `#access_token=…` — redacted before [filePathPattern]
+     * gets a chance to see it.
+     *
+     * BossConsole#109 (review comment): [filePathPattern]'s `[^\s:]+` stops at
+     * the first colon, on the (correct, elsewhere) assumption that a colon
+     * there marks a `host:port` boundary worth preserving. A value that
+     * happens to contain one — `token=abc:def` — is only partly consumed, so
+     * the tail survives the later replace verbatim: `[url=https://…?token=
+     * abc:def]` became `[url=https:[PATH]:def]`, leaking a fragment of the
+     * token. Measured, not hypothetical.
+     *
+     * Running this first removes the value entirely wherever [nameMarksSecret]
+     * says the name is sensitive, so there is nothing containing a colon left
+     * by the time [filePathPattern] runs — the fix is in what reaches that
+     * pass, not in loosening its own boundary (which exists for the
+     * `host:port` case this pass does not touch: no `?`/`&`/`#` precedes it).
+     * The value is terminated at the next `&`, `#`, closing bracket/paren/
+     * quote, or whitespace — deliberately not at `:`, which is exactly the
+     * character this pass exists to protect.
+     */
+    private val sensitiveQueryParamPattern = Regex("""([?&#])([A-Za-z][A-Za-z0-9_.-]*)=([^&#\s\])"'>]+)""")
+
     /** Inserts a word boundary into camelCase names, so `accessToken` splits like `access_token`. */
     private val camelCaseBoundary = Regex("""(?<=[a-z0-9])(?=[A-Z])""")
 
@@ -429,10 +453,25 @@ object LogSanitizer {
      * The passes compose in either order because [maskToken] is a fixed point on
      * its own output at these lengths (`ghp...345` masks to `ghp...345`), so a
      * value both of them match is masked once in effect.
+     *
+     * [sensitiveQueryParamPattern] runs before all of that, for a narrower
+     * reason: it is the one pass that must see the *original* text, since its
+     * whole job is removing a colon before [filePathPattern] can trip on it
+     * (BossConsole#109). Running it any later would be too late by definition.
      */
     private fun redactLocationsAndCredentials(text: String): String {
+        val withMaskedQueryParams =
+            sensitiveQueryParamPattern.replace(text) { match ->
+                val (prefix, name, value) = match.destructured
+                if (nameMarksSecret(name) && value.lowercase() !in nonSecretValues) {
+                    "$prefix$name=[REDACTED]"
+                } else {
+                    match.value
+                }
+            }
+
         val withoutLocations =
-            text
+            withMaskedQueryParams
                 .replace(filePathPattern, "[PATH]")
                 .replace(urlPattern, "[URL]")
                 .replace(emailPattern, "[EMAIL]")

--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
@@ -468,7 +468,8 @@ object LogSanitizer {
         val withMaskedQueryParams =
             sensitiveQueryParamPattern.replace(text) { match ->
                 val (prefix, name, value) = match.destructured
-                val sensitive = nameMarksSecret(name) || sensitiveUriParamNames.any { name.equals(it, ignoreCase = true) }
+                val sensitive =
+                    nameMarksSecret(name) || sensitiveUriParamNames.any { name.equals(it, ignoreCase = true) }
                 if (sensitive && value.lowercase() !in nonSecretValues) {
                     "$prefix$name=[REDACTED]"
                 } else {

--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
@@ -114,20 +114,6 @@ object LogSanitizer {
     fun maskUriParams(uri: String?): String {
         if (uri.isNullOrBlank()) return "[empty]"
 
-        val sensitiveParams =
-            setOf(
-                "token",
-                "access_token",
-                "refresh_token",
-                "code",
-                "error_description",
-                "id_token",
-                "session_token",
-                "api_key",
-                "key",
-                "secret",
-            )
-
         return try {
             // Handle both query params (?) and fragment params (#)
             var result = uri
@@ -135,13 +121,13 @@ object LogSanitizer {
             // Mask query parameters
             val queryStart = uri.indexOf('?')
             if (queryStart >= 0) {
-                result = maskParamsInSegment(result, queryStart + 1, '#', sensitiveParams)
+                result = maskParamsInSegment(result, queryStart + 1, '#', sensitiveUriParamNames)
             }
 
             // Mask fragment parameters
             val fragmentStart = result.indexOf('#')
             if (fragmentStart >= 0) {
-                result = maskParamsInSegment(result, fragmentStart + 1, '\u0000', sensitiveParams)
+                result = maskParamsInSegment(result, fragmentStart + 1, '\u0000', sensitiveUriParamNames)
             }
 
             result
@@ -320,9 +306,11 @@ object LogSanitizer {
     private val assignmentPattern = Regex("""(?<![A-Za-z0-9_.])([A-Za-z][A-Za-z0-9_.-]*)=([^\s\[][^\s]*)""")
 
     /**
-     * A sensitive-named query or fragment parameter inside a URL — `?token=…`,
+     * A sensitive-named query or fragment parameter shape — `?token=…`,
      * `&access_token=…`, `#access_token=…` — redacted before [filePathPattern]
-     * gets a chance to see it.
+     * gets a chance to see it. These shapes are redacted even without a full URL.
+     * Parameters use ampersand separators; legacy semicolon separators and
+     * percent-encoded parameter names are not interpreted by this text matcher.
      *
      * BossConsole#109 (review comment): [filePathPattern]'s `[^\s:]+` stops at
      * the first colon, on the (correct, elsewhere) assumption that a colon
@@ -347,6 +335,21 @@ object LogSanitizer {
 
     /** Inserts a word boundary into camelCase names, so `accessToken` splits like `access_token`. */
     private val camelCaseBoundary = Regex("""(?<=[a-z0-9])(?=[A-Z])""")
+
+    // Exact URL names stay separate: free-text exit_code and status_code are diagnostics.
+    private val sensitiveUriParamNames =
+        setOf(
+            "token",
+            "access_token",
+            "refresh_token",
+            "code",
+            "error_description",
+            "id_token",
+            "session_token",
+            "api_key",
+            "key",
+            "secret",
+        )
 
     /**
      * Names whose value is sensitive. Shared by [sanitizeMap] and the
@@ -465,7 +468,8 @@ object LogSanitizer {
         val withMaskedQueryParams =
             sensitiveQueryParamPattern.replace(text) { match ->
                 val (prefix, name, value) = match.destructured
-                if (nameMarksSecret(name) && value.lowercase() !in nonSecretValues) {
+                val sensitive = nameMarksSecret(name) || sensitiveUriParamNames.any { name.equals(it, ignoreCase = true) }
+                if (sensitive && value.lowercase() !in nonSecretValues) {
                     "$prefix$name=[REDACTED]"
                 } else {
                     match.value

--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
@@ -337,11 +337,13 @@ object LogSanitizer {
      * by the time [filePathPattern] runs — the fix is in what reaches that
      * pass, not in loosening its own boundary (which exists for the
      * `host:port` case this pass does not touch: no `?`/`&`/`#` precedes it).
-     * The value is terminated at the next `&`, `#`, closing bracket/paren/
-     * quote, or whitespace — deliberately not at `:`, which is exactly the
-     * character this pass exists to protect.
+     * Only parameter/fragment separators and whitespace terminate the value.
+     * Punctuation such as `)` and an apostrophe is legal inside a URI value;
+     * treating it as a log wrapper can leave a later colon and secret suffix
+     * exposed. Conservatively consume adjacent wrapper punctuation too, as
+     * the following path pass already does for colon-free URLs.
      */
-    private val sensitiveQueryParamPattern = Regex("""([?&#])([A-Za-z][A-Za-z0-9_.-]*)=([^&#\s\])"'>]+)""")
+    private val sensitiveQueryParamPattern = Regex("""([?&#])([A-Za-z][A-Za-z0-9_.-]*)=([^&#\s]+)""")
 
     /** Inserts a word boundary into camelCase names, so `accessToken` splits like `access_token`. */
     private val camelCaseBoundary = Regex("""(?<=[a-z0-9])(?=[A-Z])""")

--- a/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/QueryParameterSanitizerTest.kt
+++ b/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/QueryParameterSanitizerTest.kt
@@ -16,7 +16,7 @@ class QueryParameterSanitizerTest {
     @Test
     fun `query and fragment separators allow every sensitive value to be redacted`() {
         listOf("?", "&", "#").forEach { prefix ->
-            listOf("token", "ACCESS_TOKEN", "apiKey", "client-secret").forEach { name ->
+            listOf("token", "ACCESS_TOKEN", "apiKey", "client-secret", "code", "ERROR_DESCRIPTION").forEach { name ->
                 val message = "${prefix}$name=alpha:omega&next=a:b#password=gamma:delta"
                 assertEquals(
                     "${prefix}$name=[REDACTED]&next=a:b#password=[REDACTED]",
@@ -24,6 +24,22 @@ class QueryParameterSanitizerTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun `OAuth URL names redact without hiding free text diagnostic codes`() {
+        listOf("code", "error_description").forEach { name ->
+            val message = "Failed https://example.com/cb?$name=alpha:omega retry"
+            assertEquals("Failed https:[PATH] retry", LogSanitizer.sanitizeExceptionMessage(message))
+            assertEquals("Failed https:[PATH] retry", LogSanitizer.sanitizeStackTrace(message))
+            assertEquals(
+                "boss://auth?$name=[REDACTED]",
+                LogSanitizer.maskUriParams("boss://auth?$name=alpha:omega"),
+            )
+        }
+        val diagnostic = "code=404 exit_code=1 status_code=500 error_code=404"
+        assertEquals(diagnostic, LogSanitizer.sanitizeLogMessage(diagnostic))
+        assertEquals(mapOf("exit_code" to 1), LogSanitizer.sanitizeMap(mapOf("exit_code" to 1)))
     }
 
     @Test

--- a/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/QueryParameterSanitizerTest.kt
+++ b/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/QueryParameterSanitizerTest.kt
@@ -1,0 +1,40 @@
+package ai.rever.boss.plugin.logging
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class QueryParameterSanitizerTest {
+    @Test
+    fun `URL punctuation inside a secret cannot expose a colon suffix`() {
+        listOf("abc):tail", "abc':tail", "abc]:tail", "abc\":tail", "abc>:tail").forEach { value ->
+            val message = "Failed https://example.com/cb?token=$value retry"
+            assertEquals("Failed https:[PATH] retry", LogSanitizer.sanitizeExceptionMessage(message), value)
+            assertEquals("Failed https:[PATH] retry", LogSanitizer.sanitizeStackTrace(message), value)
+        }
+    }
+
+    @Test
+    fun `query and fragment separators allow every sensitive value to be redacted`() {
+        listOf("?", "&", "#").forEach { prefix ->
+            listOf("token", "ACCESS_TOKEN", "apiKey", "client-secret").forEach { name ->
+                val message = "${prefix}$name=alpha:omega&next=a:b#password=gamma:delta"
+                assertEquals(
+                    "${prefix}$name=[REDACTED]&next=a:b#password=[REDACTED]",
+                    LogSanitizer.sanitizeLogMessage(message),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `non secret values and diagnostic ports retain their meaning`() {
+        listOf("null", "true", "false").forEach { value ->
+            assertEquals("?token=$value", LogSanitizer.sanitizeExceptionMessage("?token=$value"))
+        }
+        assertEquals("?keyboard=a:b", LogSanitizer.sanitizeExceptionMessage("?keyboard=a:b"))
+        assertEquals(
+            "Connect to [HOST]:3128 failed",
+            LogSanitizer.sanitizeExceptionMessage("Connect to proxy.corp.internal:3128 failed"),
+        )
+    }
+}


### PR DESCRIPTION
A sensitive URL value containing a colon could leave a token suffix visible in logs and copyable crash errors: `?token=abc:def` became `https:[PATH]:def`. Redact sensitive query/fragment values before the path pass so it cannot split them at a colon. Reuse both existing sensitive-name vocabularies, including the URL-only OAuth `code` and `error_description` names, while preserving proxy ports and ordinary diagnostic codes.

The value boundary is conservative: only `&`, `#`, or whitespace ends it. Punctuation such as `)` and apostrophes can occur inside valid URI values, so stopping there could still leak `tail` from `?token=abc):tail`. Adjacent wrapper punctuation can be consumed too, consistent with the existing path pass.

Attribution: Antriksh (@Antriksh1984) authored the pre-pass and four host regression tests in 3aeac5c1f. Review-agent follow-up integrated current dev, repaired the punctuation boundary, shared the URL vocabulary with maskUriParams, and added module-owned coverage for punctuation, query/fragment separators, name variants, stack/log entry points, non-secret values and diagnostic ports. Original commit authorship is preserved.

This is the colon-bearing URL-value residual from #109, following #107 and the already integrated #404/#346 hostname work. It does not claim complete hostname redaction or close #109. Related MCP preview/ledger sanitizers serve distinct surfaces; no consolidation is needed.

Final head 38c4c52c9 passes **98 tests** (80 host sanitizer, 18 plugin-logging), root **ktlintCheck** and **detekt**, and git diff --check. All Gradle checks used the shared build lock. Claude reviewed once; substantive findings are addressed in [the review disposition](https://github.com/risa-labs-inc/BossConsole/pull/471#issuecomment-5613395092). [Final hosted CI](https://github.com/risa-labs-inc/BossConsole/actions/runs/34439129180) is still running; earlier green runs do not substitute for final-head validation.

Manual check pending: display and copy synthetic crash error/Technical Details text with query and fragment credentials containing colons and punctuation; confirm no token suffix survives while ordinary proxy ports and stack frames remain useful. No application instance or live service was started or modified.
