### PR TITLE
fix(updater): dismiss unsupported OS releases after refusal

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
@@ -416,6 +416,10 @@ class UpdateManager {
             if (outcome.succeeded) {
                 _updateState.value = UpdateState.RestartRequired
             } else {
+                versionToDismiss(outcome, _updateInfo.value)?.let { version ->
+                    UpdateSettings.lastDismissedVersion = version.toString()
+                    UpdateSettingsManager.saveSettings()
+                }
                 // Prefer the installer's own explanation. It is the only place that
                 // knows *why* — e.g. a release requiring a newer macOS than this
                 // Mac runs — and a generic string there is indistinguishable from
@@ -469,6 +473,18 @@ class UpdateManager {
         scope.cancel()
     }
 }
+
+/**
+ * Select the release an installer refusal made permanently inapplicable to this host.
+ *
+ * Kept pure so the dismissal policy can be tested without mounting an update image or writing
+ * settings. Ordinary install failures stay retryable; only a typed installer disposition hides
+ * the exact release that was staged.
+ */
+internal fun versionToDismiss(
+    outcome: InstallOutcome,
+    updateInfo: UpdateInfo?,
+): Version? = updateInfo?.latestVersion?.takeIf { !outcome.succeeded && outcome.dismissVersion }
 
 /**
  * Update state sealed class

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateService.kt
@@ -75,6 +75,7 @@ data class VersionInfo(
 data class InstallOutcome(
     val succeeded: Boolean,
     val errorMessage: String? = null,
+    val dismissVersion: Boolean = false,
 )
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/DesktopUpdateService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/DesktopUpdateService.kt
@@ -481,7 +481,11 @@ actual class UpdateService {
                 // refuses an OS-incompatible release here, and that reason has to
                 // reach the dialog or it reads as an unexplained failure.
                 logger.error(LogCategory.SYSTEM, "Update installation failed", mapOf("error" to result.message))
-                InstallOutcome(succeeded = false, errorMessage = result.message)
+                InstallOutcome(
+                    succeeded = false,
+                    errorMessage = result.message,
+                    dismissVersion = result.dismissVersion,
+                )
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -154,6 +154,7 @@ sealed class InstallResult {
 
     data class Error(
         val message: String,
+        val dismissVersion: Boolean = false,
     ) : InstallResult()
 }
 
@@ -547,7 +548,7 @@ object UpdateInstaller {
                     // (JxBrowser 9.4.0 took it 12.0 -> 13.0) and the release
                     // manifest carries no minimum-OS field, so nothing upstream
                     // stops the update being offered.
-                    unsupportedOsError(appBundle)?.let { return@withContext InstallResult.Error(it) }
+                    unsupportedOsInstallResult(appBundle)?.let { return@withContext it }
 
                     logger.info(LogCategory.SYSTEM, "DMG verified successfully", mapOf("appBundle" to appBundle.name))
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateOsFloor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateOsFloor.kt
@@ -38,6 +38,9 @@ internal fun unsupportedOsError(appBundle: File): String? {
     )
 }
 
+internal fun unsupportedOsInstallResult(appBundle: File): InstallResult.Error? =
+    unsupportedOsError(appBundle)?.let { InstallResult.Error(it, dismissVersion = true) }
+
 /**
  * The decision itself, separated from where the two versions come from.
  *

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UnsupportedUpdateDismissalTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UnsupportedUpdateDismissalTest.kt
@@ -1,0 +1,42 @@
+package ai.rever.boss.updater
+
+import ai.rever.boss.utils.Version
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UnsupportedUpdateDismissalTest {
+    private val update =
+        UpdateInfo(
+            available = true,
+            currentVersion = Version(9, 5, 8),
+            latestVersion = Version(9, 6, 0),
+            releaseNotes = "",
+        )
+
+    @Test
+    fun `unsupported release is dismissed after installer refuses it`() {
+        val outcome =
+            InstallOutcome(
+                succeeded = false,
+                errorMessage = "This update requires macOS 13.0 or later",
+                dismissVersion = true,
+            )
+
+        assertEquals(update.latestVersion, versionToDismiss(outcome, update))
+    }
+
+    @Test
+    fun `ordinary install failure remains retryable`() {
+        val outcome = InstallOutcome(succeeded = false, errorMessage = "DMG mounting failed")
+
+        assertNull(versionToDismiss(outcome, update))
+    }
+
+    @Test
+    fun `successful install never dismisses a release`() {
+        val outcome = InstallOutcome(succeeded = true, dismissVersion = true)
+
+        assertNull(versionToDismiss(outcome, update))
+    }
+}


### PR DESCRIPTION
# 📋 Pull Request

## Description
Prevents BOSS from repeatedly downloading and staging the same macOS release after the installer has determined that the host OS cannot run it. The installer now returns a typed dismissal signal, and the update manager persists only that exact release as dismissed while preserving the explanatory error state.

## 🔄 Type of Change
- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (non-breaking change that adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 **Configuration change** (changes to build scripts, CI/CD, or project configuration)
- [ ] 📚 **Documentation** (documentation only changes)
- [ ] 🧹 **Refactoring** (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ **Performance improvement** (code change that improves performance)
- [x] 🧪 **Tests** (adding missing tests or correcting existing tests)

## 📦 Version Impact
- [x] **No version change needed**
- [ ] **Patch version** (bug fixes, small improvements) - `x.x.+1`
- [ ] **Minor version** (new features, enhancements) - `x.+1.0`
- [ ] **Major version** (breaking changes) - `+1.0.0`

## ✅ Testing Checklist

### 🧪 **Local Testing**
- [x] I have tested this change locally on my development machine
- [ ] All existing tests pass with my changes (focused tests run; full suite left to CI)
- [x] I have added new tests for new functionality (if applicable)
- [x] I have verified the fix/feature works as intended

### 🖥️ **Platform Testing**
- [ ] 🍎 **macOS** - No manual installer run; pure policy and OS-floor tests pass
- [ ] 🪟 **Windows** - Not applicable; behavior is macOS-specific
- [ ] 🐧 **Linux** - Not applicable; behavior is macOS-specific
- [ ] 📱 **Mobile** (iOS/Android) - Not applicable
- [ ] 🌐 **Web** (WASM) - Not applicable

### 🏗️ **Build Verification**
- [x] Project builds successfully with my changes
- [x] No new build warnings introduced
- [ ] Distribution packages (DMG/MSI/JAR) can be created successfully (not run locally)
- [ ] Version system integration tested (not applicable)

## 🔍 Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation (KDoc updated where needed)
- [x] My changes generate no new warnings or errors

## 🚀 CI/CD Integration
- [x] This PR will trigger appropriate CI/CD workflows
- [x] I understand that all status checks must pass before merging
- [x] I have considered the impact on our centralized version management system

## 📸 Screenshots/Media

### Before
An OS-incompatible release could be offered and downloaded again after each automatic check.

### After
The exact refused release is dismissed; newer releases and ordinary transient failures remain eligible for retry.

## 🔗 Related Issues
Fixes #119

## 📝 Additional Context

### 🎯 **Motivation and Context**
The installer already detects `LSMinimumSystemVersion`, but that refusal previously looked like any other retryable installation failure. This created a download/refusal loop for hosts below the release's OS floor.

### 🧠 **Implementation Details**
`InstallResult.Error` and `InstallOutcome` carry an explicit `dismissVersion` disposition. Only the unsupported-OS path sets it. `UpdateManager` persists the current candidate version after that typed refusal, while continuing to show the installer's error message. Regression tests prove unsupported releases are selected for dismissal, ordinary failures remain retryable, and successful installs cannot dismiss a release.

### ⚠️ **Breaking Changes**
None.

### 🔮 **Future Considerations**
Publishing minimum-OS metadata in the release manifest would allow BOSS to avoid downloading incompatible artifacts entirely.

## 👀 Review Focus Areas
- [x] **Logic and Algorithm**: Typed failure disposition and exact-version selection
- [ ] **Performance**: No material impact
- [ ] **Security**: No security boundary changes
- [x] **Platform Compatibility**: macOS-only installer behavior
- [x] **User Experience**: Error remains visible without repeated downloads
- [x] **Documentation**: Dismissal policy is documented alongside the pure helper

## 🚨 Pre-merge Checklist
- [ ] All conversations have been resolved
- [x] Code has been rebased on latest main branch
- [x] Commit messages are clear and descriptive
- [x] PR title accurately describes the change
- [ ] Ready for production deployment (draft pending CI/review)

---

**Thank you for contributing to BOSS! 🎉**
