### PR TITLE
fix(supabase): coerce null response fields to client defaults

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.Json
  * through it as well, so that "never the `Json` default here" is a rule with no exceptions
  * to remember. `SupabaseWiringTest` enforces exactly that.
  *
- * `ignoreUnknownKeys` is not a convenience, it is a requirement of how BOSS ships.
+ * `ignoreUnknownKeys` and `coerceInputValues` are not conveniences, they are requirements of how BOSS ships.
  * The database is migrated ahead of the desktop app and installed copies keep talking
  * to it, so a client will meet columns it does not model. The kotlinx default is strict
  * and treats those as a hard error - and because these RPCs return LISTS, one unmodelled
@@ -29,9 +29,10 @@ import kotlinx.serialization.json.Json
  *
  * ## What this buys, and what it costs
  *
- * Additive schema changes become safe. In exchange, **renames become silent** for any
- * field carrying a default: rename `metadata` server-side and decoding now succeeds with
- * the 2FA metadata quietly missing, rather than failing loudly.
+ * Additive schema changes and nulls in fields with client defaults become safe. In exchange,
+ * **renames and unexpected nulls become silent** for any field carrying a default: rename
+ * `metadata` server-side, or return null for `tags`, and decoding succeeds with the client
+ * default rather than failing loudly. Required fields without defaults remain strict.
  *
  * That is the right trade here - a loud failure means every secret vanishes - but it makes
  * "additive only, never rename" a contract the database side has to keep. Renaming a
@@ -39,7 +40,11 @@ import kotlinx.serialization.json.Json
  * as an alias until those builds age out. Do not read this instance as blanket tolerance
  * of schema drift.
  */
-internal val supabaseJson = Json { ignoreUnknownKeys = true }
+internal val supabaseJson =
+    Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
 
 /**
  * The marker kotlinx puts before the offending document in a parse failure.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseJsonTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseJsonTest.kt
@@ -83,6 +83,29 @@ class SupabaseJsonTest {
     }
 
     @Test
+    fun `null defaulted fields use their client defaults`() {
+        val body =
+            """[{"id":"1","website":"w","username":"u","password":"p","tags":null,""" +
+                """"created_at":"x","updated_at":"x"}]"""
+
+        val secret = supabaseJson.decodeFromString<List<SecretEntry>>(body).single()
+
+        assertEquals(emptyList(), secret.tags)
+    }
+
+    @Test
+    fun `null required fields remain a schema error`() {
+        val body =
+            """[{"id":"1","website":"w","username":"u","password":null,"tags":[],""" +
+                """"created_at":"x","updated_at":"x"}]"""
+
+        val error = runCatching { supabaseJson.decodeFromString<List<SecretEntry>>(body) }.exceptionOrNull()
+
+        assertTrue(error is SerializationException)
+        assertTrue(error.message.orEmpty().contains("password"))
+    }
+
+    @Test
     fun `a non-serialization failure passes through untouched`() {
         // Network and auth failures are not ours to rewrite, and losing their type would
         // break any caller that distinguishes them.


### PR DESCRIPTION
# 📋 Pull Request

## Description
Makes Supabase payload decoding tolerate explicit `null` values for fields that already define safe client defaults, while keeping required fields strict. This prevents one nullable/defaulted column from emptying an otherwise usable response.

## 🔄 Type of Change
- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (non-breaking change that adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 **Configuration change** (changes to build scripts, CI/CD, or project configuration)
- [ ] 📚 **Documentation** (documentation only changes)
- [ ] 🧹 **Refactoring** (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ **Performance improvement** (code change that improves performance)
- [x] 🧪 **Tests** (adding missing tests or correcting existing tests)

## 📦 Version Impact
- [x] **No version change needed**
- [ ] **Patch version** (bug fixes, small improvements) - `x.x.+1`
- [ ] **Minor version** (new features, enhancements) - `x.+1.0`
- [ ] **Major version** (breaking changes) - `+1.0.0`

## ✅ Testing Checklist

### 🧪 **Local Testing**
- [x] I have tested this change locally on my development machine
- [ ] All existing tests pass with my changes (focused suite run; full suite left to CI)
- [x] I have added new tests for new functionality (if applicable)
- [x] I have verified the fix/feature works as intended

### 🖥️ **Platform Testing**
- [x] 🍎 **macOS** - Desktop compilation and focused tests pass
- [ ] 🪟 **Windows** - Not run locally
- [ ] 🐧 **Linux** - Not run locally
- [ ] 📱 **Mobile** (iOS/Android) - Not applicable
- [ ] 🌐 **Web** (WASM) - Not applicable

### 🏗️ **Build Verification**
- [x] Project builds successfully with my changes
- [x] No new build warnings introduced
- [ ] Distribution packages (DMG/MSI/JAR) can be created successfully (not run locally)
- [ ] Version system integration tested (not applicable)

## 🔍 Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation (shared JSON contract updated)
- [x] My changes generate no new warnings or errors

## 🚀 CI/CD Integration
- [x] This PR will trigger appropriate CI/CD workflows
- [x] I understand that all status checks must pass before merging
- [x] I have considered the impact on our centralized version management system

## 📸 Screenshots/Media

### Before
An explicit `null` for a defaulted response field such as `tags` failed the whole decoded response.

### After
Defaulted fields use their declared client default; a required field such as `password` still fails loudly.

## 🔗 Related Issues
Addresses part of #147

## 📝 Additional Context

### 🎯 **Motivation and Context**
Installed desktop clients can encounter database rows produced by newer schema versions. A safe default already expresses the client's fallback, but kotlinx serialization does not use it for explicit nulls unless input coercion is enabled.

### 🧠 **Implementation Details**
Enables `coerceInputValues` on the package's single shared Supabase `Json` instance. Tests cover both sides of the boundary: nullable/defaulted `tags` becomes an empty list, while nullable input for required `password` remains a serialization failure. The KDoc records the compatibility benefit and the risk of silently defaulting unexpected nulls.

### ⚠️ **Breaking Changes**
None.

### 🔮 **Future Considerations**
Server migrations should remain additive and preserve aliases during client rollout windows.

## 👀 Review Focus Areas
- [x] **Logic and Algorithm**: Coercion applies only where model defaults exist
- [ ] **Performance**: No material impact
- [x] **Security**: Required credential fields remain strict
- [x] **Platform Compatibility**: Shared Supabase decoder behavior
- [x] **User Experience**: Avoids empty secret views from benign null/default drift
- [x] **Documentation**: Tradeoff is documented in `SupabaseJson`

## 🚨 Pre-merge Checklist
- [ ] All conversations have been resolved
- [x] Code has been rebased on latest main branch
- [x] Commit messages are clear and descriptive
- [x] PR title accurately describes the change
- [ ] Ready for production deployment (draft pending CI/review)

---

**Thank you for contributing to BOSS! 🎉**
