### PR TITLE
fix(supabase): preserve valid rows in malformed response arrays

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/DecodedSupabaseRows.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/DecodedSupabaseRows.kt
@@ -1,0 +1,48 @@
+package ai.rever.boss.services.supabase
+
+import ai.rever.boss.utils.logging.ComponentLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonArray
+
+internal data class DecodedSupabaseRows<T>(
+    val values: List<T>,
+    val droppedCount: Int,
+) {
+    val receivedCount: Int
+        get() = values.size + droppedCount
+}
+
+/**
+ * Decode a response array one row at a time, retaining valid rows when one record no longer
+ * matches the installed client's schema. Parsing the array itself remains strict: truncated JSON
+ * is a response failure, not a row that can safely be skipped.
+ */
+internal inline fun <reified T> decodeSupabaseRows(element: JsonElement): DecodedSupabaseRows<T> {
+    val values = mutableListOf<T>()
+    var droppedCount = 0
+    element.jsonArray.forEach { row ->
+        try {
+            values += supabaseJson.decodeFromJsonElement<T>(row)
+        } catch (_: SerializationException) {
+            droppedCount++
+        }
+    }
+    return DecodedSupabaseRows(values, droppedCount)
+}
+
+internal fun ComponentLogger.logDroppedSupabaseRows(
+    category: LogCategory,
+    message: String,
+    operation: String,
+    droppedCount: Int,
+) {
+    if (droppedCount == 0) return
+    warn(
+        category,
+        message,
+        data = mapOf("operation" to operation, "droppedRows" to droppedCount),
+    )
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleService.kt
@@ -185,7 +185,14 @@ object RoleService {
                 )
 
             val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
-            val roles = supabaseJson.decodeFromJsonElement<List<UserRole>>(jsonElement)
+            val decoded = decodeSupabaseRows<UserRole>(jsonElement)
+            logger.logDroppedSupabaseRows(
+                LogCategory.AUTH,
+                "Dropped malformed rows from role RPC response",
+                "getUserRoles",
+                decoded.droppedCount,
+            )
+            val roles = decoded.values
 
             Result.success(roles)
         } catch (e: Exception) {
@@ -310,7 +317,14 @@ object RoleService {
                 )
 
             val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
-            val permissions = supabaseJson.decodeFromJsonElement<List<RolePermission>>(jsonElement)
+            val decoded = decodeSupabaseRows<RolePermission>(jsonElement)
+            logger.logDroppedSupabaseRows(
+                LogCategory.AUTH,
+                "Dropped malformed rows from role RPC response",
+                "getRolePermissions",
+                decoded.droppedCount,
+            )
+            val permissions = decoded.values
 
             Result.success(permissions)
         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
@@ -85,8 +85,15 @@ object SecretService {
                 )
 
             val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
-            val secrets = supabaseJson.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
-            val hasMore = secrets.size >= limit
+            val decoded = decodeSupabaseRows<SecretEntry>(jsonElement)
+            logger.logDroppedSupabaseRows(
+                LogCategory.NETWORK,
+                "Dropped malformed rows from secret RPC response",
+                "getUserSecrets",
+                decoded.droppedCount,
+            )
+            val secrets = decoded.values
+            val hasMore = decoded.receivedCount >= limit
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
         } catch (e: Exception) {
@@ -127,10 +134,17 @@ object SecretService {
                 )
 
             val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
-            val secrets = supabaseJson.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
+            val decoded = decodeSupabaseRows<SecretEntry>(jsonElement)
+            logger.logDroppedSupabaseRows(
+                LogCategory.NETWORK,
+                "Dropped malformed rows from secret RPC response",
+                "searchSecrets",
+                decoded.droppedCount,
+            )
+            val secrets = decoded.values
 
             // Check if there might be more results
-            val hasMore = secrets.size >= limit
+            val hasMore = decoded.receivedCount >= limit
 
             Result.success(
                 PaginatedSecrets(
@@ -328,9 +342,16 @@ object SecretService {
                 )
 
             val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
-            val secretsWithSharing = supabaseJson.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
+            val decoded = decodeSupabaseRows<SecretEntryWithSharing>(jsonElement)
+            logger.logDroppedSupabaseRows(
+                LogCategory.NETWORK,
+                "Dropped malformed rows from secret RPC response",
+                "getUserSecretsWithShared",
+                decoded.droppedCount,
+            )
+            val secretsWithSharing = decoded.values
             val secrets = secretsWithSharing.map { it.toSecretEntry() }
-            val hasMore = secrets.size >= limit
+            val hasMore = decoded.receivedCount >= limit
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
         } catch (e: Exception) {
@@ -372,8 +393,15 @@ object SecretService {
                 )
 
             val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
-            val secretsWithSharing = supabaseJson.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
-            val hasMore = secretsWithSharing.size >= limit
+            val decoded = decodeSupabaseRows<SecretEntryWithSharing>(jsonElement)
+            logger.logDroppedSupabaseRows(
+                LogCategory.NETWORK,
+                "Dropped malformed rows from secret RPC response",
+                "getUserSecretsWithSharingInfo",
+                decoded.droppedCount,
+            )
+            val secretsWithSharing = decoded.values
+            val hasMore = decoded.receivedCount >= limit
 
             Result.success(PaginatedSecretsWithSharing(data = secretsWithSharing, hasMore = hasMore))
         } catch (e: Exception) {
@@ -504,7 +532,14 @@ object SecretService {
                 )
 
             val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
-            val shares = supabaseJson.decodeFromJsonElement<List<SecretShareEntry>>(jsonElement)
+            val decoded = decodeSupabaseRows<SecretShareEntry>(jsonElement)
+            logger.logDroppedSupabaseRows(
+                LogCategory.NETWORK,
+                "Dropped malformed rows from secret RPC response",
+                "getSecretShares",
+                decoded.droppedCount,
+            )
+            val shares = decoded.values
 
             Result.success(shares)
         } catch (e: Exception) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseRowRecoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseRowRecoveryTest.kt
@@ -1,0 +1,38 @@
+package ai.rever.boss.services.supabase
+
+import ai.rever.boss.services.supabase.models.SecretEntry
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SupabaseRowRecoveryTest {
+    @Test
+    fun `one malformed row does not discard valid siblings`() {
+        val body =
+            """
+            [
+                {"id":"1","website":"one","username":"u","password":"p","tags":[],"created_at":"x","updated_at":"x"},
+                {"id":"2","website":"broken","username":"u","password":null,"tags":[],"created_at":"x","updated_at":"x"},
+                {"id":"3","website":"three","username":"u","password":"p","tags":[],"created_at":"x","updated_at":"x"}
+            ]
+            """.trimIndent()
+
+        val decoded = decodeSupabaseRows<SecretEntry>(supabaseJson.parseToJsonElement(body))
+
+        assertEquals(listOf("1", "3"), decoded.values.map { it.id })
+        assertEquals(1, decoded.droppedCount)
+        assertEquals(3, decoded.receivedCount)
+    }
+
+    @Test
+    fun `a malformed array remains a response failure`() {
+        val body = """[{"id":"1"}"""
+
+        val error =
+            runCatching { decodeSupabaseRows<SecretEntry>(supabaseJson.parseToJsonElement(body)) }
+                .exceptionOrNull()
+
+        assertTrue(error is SerializationException)
+    }
+}


### PR DESCRIPTION
# 📋 Pull Request

## Description
Decodes Supabase list responses row by row so a single schema-incompatible record no longer discards valid sibling rows. Dropped rows are counted and logged, malformed response JSON still fails, and pagination continues to use the number of rows received from the server.

## 🔄 Type of Change
- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (non-breaking change that adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 **Configuration change** (changes to build scripts, CI/CD, or project configuration)
- [ ] 📚 **Documentation** (documentation only changes)
- [ ] 🧹 **Refactoring** (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ **Performance improvement** (code change that improves performance)
- [x] 🧪 **Tests** (adding missing tests or correcting existing tests)

## 📦 Version Impact
- [x] **No version change needed**
- [ ] **Patch version** (bug fixes, small improvements) - `x.x.+1`
- [ ] **Minor version** (new features, enhancements) - `x.+1.0`
- [ ] **Major version** (breaking changes) - `+1.0.0`

## ✅ Testing Checklist

### 🧪 **Local Testing**
- [x] I have tested this change locally on my development machine
- [ ] All existing tests pass with my changes (focused suites run; full suite left to CI)
- [x] I have added new tests for new functionality (if applicable)
- [x] I have verified the fix/feature works as intended

### 🖥️ **Platform Testing**
- [x] 🍎 **macOS** - Desktop compilation and focused tests pass
- [ ] 🪟 **Windows** - Not run locally
- [ ] 🐧 **Linux** - Not run locally
- [ ] 📱 **Mobile** (iOS/Android) - Not applicable
- [ ] 🌐 **Web** (WASM) - Not applicable

### 🏗️ **Build Verification**
- [x] Project builds successfully with my changes
- [x] No new build warnings introduced
- [ ] Distribution packages (DMG/MSI/JAR) can be created successfully (not run locally)
- [ ] Version system integration tested (not applicable)

## 🔍 Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation (row-recovery contract documented)
- [x] My changes generate no new warnings or errors

## 🚀 CI/CD Integration
- [x] This PR will trigger appropriate CI/CD workflows
- [x] I understand that all status checks must pass before merging
- [x] I have considered the impact on our centralized version management system

## 📸 Screenshots/Media

### Before
One incompatible row made the entire secret, sharing, role, or permission list unavailable.

### After
Valid rows remain available, skipped rows generate a structured warning, and invalid/truncated JSON remains a response failure.

## 🔗 Related Issues
Addresses part of #147

## 📝 Additional Context

### 🎯 **Motivation and Context**
Supabase RPCs return arrays. Whole-list decoding makes the blast radius of one legacy or partially migrated record equal to the entire response, including unrelated valid secrets.

### 🧠 **Implementation Details**
Adds a narrow row decoder that catches only serialization failures for individual array elements. It is wired into secret, sharing, role, and permission list calls. The decoder reports both retained and dropped counts; pagination uses their sum so a dropped row does not falsely signal the end of a page. Tests prove valid siblings survive and malformed array syntax still fails.

### ⚠️ **Breaking Changes**
None.

### 🔮 **Future Considerations**
Telemetry can aggregate the structured dropped-row warnings to identify server rows that need migration.

## 👀 Review Focus Areas
- [x] **Logic and Algorithm**: Per-row failure boundary and pagination accounting
- [x] **Performance**: Linear decoding with small per-row exception cost only on invalid data
- [x] **Security**: Logs include counts and operation names, never row payloads
- [x] **Platform Compatibility**: Common Supabase service code
- [x] **User Experience**: Valid data remains visible during partial schema drift
- [x] **Documentation**: Strict-array/lenient-row boundary is explicit

## 🚨 Pre-merge Checklist
- [ ] All conversations have been resolved
- [x] Code has been rebased on latest main branch
- [x] Commit messages are clear and descriptive
- [x] PR title accurately describes the change
- [ ] Ready for production deployment (draft pending CI/review)

---

**Thank you for contributing to BOSS! 🎉**
