### PR TITLE
fix(browser): suppress unsafe context menus on Compose surfaces

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/auth/forms/DesktopAuthBrandSite.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/auth/forms/DesktopAuthBrandSite.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.auth.forms
 
+import ai.rever.boss.plugin.browser.BrowserContextMenuFallback
 import ai.rever.boss.plugin.browser.FluckEngine
 import ai.rever.boss.plugin.browser.LocalAwtWindow
 import ai.rever.boss.utils.logging.BossLogger
@@ -118,6 +119,7 @@ internal actual fun AuthBrandSite(
             // first-ever launch, when no browser profile exists yet, and mid-prewarm this would block on
             // the same lock.
             created = withContext(Dispatchers.IO) { FluckEngine.engine.newBrowser() }
+            BrowserContextMenuFallback.installOn(created)
             created.navigation().on(LoadFinished::class.java) {
                 scope.launch(Dispatchers.Main) { loaded = true }
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/auth/screens/DesktopPasskeyBrowserView.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/auth/screens/DesktopPasskeyBrowserView.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.auth.screens
 
+import ai.rever.boss.plugin.browser.BrowserContextMenuFallback
 import ai.rever.boss.plugin.browser.FluckEngine
 import ai.rever.boss.plugin.browser.LocalAwtWindow
 import ai.rever.boss.plugin.ui.BossTheme
@@ -49,6 +50,7 @@ actual fun PasskeyBrowserView(
 
             // Create new browser instance for WebAuthn
             val newBrowser = engine.newBrowser()
+            BrowserContextMenuFallback.installOn(newBrowser)
             browser = newBrowser
 
             logger.debug(LogCategory.BROWSER, "JxBrowser initialized successfully")

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin.tab_types.fluck
 
+import ai.rever.boss.plugin.browser.BrowserContextMenuFallback
 import ai.rever.boss.plugin.browser.BrowserFindController
 import ai.rever.boss.plugin.browser.BrowserSettings
 import ai.rever.boss.plugin.browser.EngineInitError
@@ -334,6 +335,7 @@ private fun configureBrowserPopupHandler(
 
 actual fun createBrowser(): Any {
     val browser = FluckEngine.engine.newBrowser()
+    BrowserContextMenuFallback.installOn(browser)
     browser.settings().enableOverscrollHistoryNavigation()
     FluckEngine.setupBrowserDownloadHandler(browser as com.teamdev.jxbrowser.browser.Browser)
     FluckEngine.setupCaptureSessionHandler(browser)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserContextMenuFallback.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserContextMenuFallback.kt
@@ -1,0 +1,40 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import com.teamdev.jxbrowser.browser.callback.BrowserCallback
+import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
+import com.teamdev.jxbrowser.callback.Advisable
+
+/**
+ * Claims JxBrowser's context-menu callback on Compose-hosted browsers that have no native menu.
+ *
+ * Without an explicit callback, the view installs JxBrowser's Swing menu. That menu can ask a
+ * detached heavyweight component for its screen location and throw on the EDT. Full browser tabs
+ * and popup windows install richer menus elsewhere; this fallback exists for auth and plugin-owned
+ * Compose surfaces that have no Swing component to anchor one to.
+ */
+object BrowserContextMenuFallback {
+    private val logger = BossLogger.forComponent("BrowserContextMenuFallback")
+
+    /** Install before constructing the Compose BrowserView. Safe to call more than once. */
+    @Suppress("TooGenericExceptionCaught")
+    fun installOn(browser: Advisable<BrowserCallback>) {
+        try {
+            registerOn(browser)
+        } catch (e: Exception) {
+            logger.warn(LogCategory.BROWSER, "Could not install context-menu fallback", error = e)
+        }
+    }
+
+    /** Ungated registration seam for headless tests. */
+    internal fun registerOn(target: Advisable<BrowserCallback>) {
+        if (target.get(ShowContextMenuCallback::class.java).isPresent) return
+        target.set(
+            ShowContextMenuCallback::class.java,
+            ShowContextMenuCallback { _, action ->
+                action.close()
+            },
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserContextMenuFallbackTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserContextMenuFallbackTest.kt
@@ -1,0 +1,66 @@
+package ai.rever.boss.plugin.browser
+
+import com.teamdev.jxbrowser.browser.callback.BrowserCallback
+import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
+import com.teamdev.jxbrowser.callback.Advisable
+import com.teamdev.jxbrowser.callback.Callback
+import java.lang.reflect.Proxy
+import java.util.Optional
+import kotlin.test.Test
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class BrowserContextMenuFallbackTest {
+    private class RecordingAdvisable : Advisable<BrowserCallback> {
+        val callbacks = mutableMapOf<Class<out Callback>, BrowserCallback>()
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <C : BrowserCallback> set(
+            type: Class<C>,
+            callback: C,
+        ): C? = callbacks.put(type, callback) as C?
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <C : BrowserCallback> get(type: Class<C>): Optional<C> = Optional.ofNullable(callbacks[type] as C?)
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <C : BrowserCallback> remove(type: Class<C>): C? = callbacks.remove(type) as C?
+    }
+
+    @Test
+    fun `fallback claims the context menu before the view can install its default`() {
+        val target = RecordingAdvisable()
+
+        BrowserContextMenuFallback.registerOn(target)
+
+        assertTrue(target.get(ShowContextMenuCallback::class.java).isPresent)
+    }
+
+    @Test
+    fun `fallback does not replace a richer context menu`() {
+        val target = RecordingAdvisable()
+        val rich = ShowContextMenuCallback { _, action -> action.close() }
+        target.set(ShowContextMenuCallback::class.java, rich)
+
+        BrowserContextMenuFallback.registerOn(target)
+
+        assertSame(rich, target.get(ShowContextMenuCallback::class.java).orElse(null))
+    }
+
+    @Test
+    fun `fallback always answers Chromium's menu request`() {
+        val target = RecordingAdvisable()
+        BrowserContextMenuFallback.registerOn(target)
+        val callback = target.get(ShowContextMenuCallback::class.java).orElseThrow()
+        val params =
+            Proxy.newProxyInstance(
+                ShowContextMenuCallback.Params::class.java.classLoader,
+                arrayOf(ShowContextMenuCallback.Params::class.java),
+            ) { _, _, _ -> null } as ShowContextMenuCallback.Params
+        val action = ShowContextMenuCallback.Action { }
+
+        callback.on(params, action)
+
+        assertTrue(action.isClosed)
+    }
+}


### PR DESCRIPTION
# 📋 Pull Request

## Description
Installs an explicit JxBrowser context-menu callback before constructing Compose-hosted browser views that do not provide a native menu. This prevents JxBrowser's default Swing menu from querying screen coordinates on a detached heavyweight component and crashing the EDT.

## 🔄 Type of Change
- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (non-breaking change that adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 **Configuration change** (changes to build scripts, CI/CD, or project configuration)
- [ ] 📚 **Documentation** (documentation only changes)
- [ ] 🧹 **Refactoring** (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ **Performance improvement** (code change that improves performance)
- [x] 🧪 **Tests** (adding missing tests or correcting existing tests)

## 📦 Version Impact
- [x] **No version change needed**
- [ ] **Patch version** (bug fixes, small improvements) - `x.x.+1`
- [ ] **Minor version** (new features, enhancements) - `x.+1.0`
- [ ] **Major version** (breaking changes) - `+1.0.0`

## ✅ Testing Checklist

### 🧪 **Local Testing**
- [x] I have tested this change locally on my development machine
- [ ] All existing tests pass with my changes (focused test run; full suite left to CI)
- [x] I have added new tests for new functionality (if applicable)
- [x] I have verified the fix/feature works as intended

### 🖥️ **Platform Testing**
- [x] 🍎 **macOS** - Desktop compilation and callback tests pass
- [ ] 🪟 **Windows** - Not run locally
- [ ] 🐧 **Linux** - Not run locally
- [ ] 📱 **Mobile** (iOS/Android) - Not applicable
- [ ] 🌐 **Web** (WASM) - Not applicable

### 🏗️ **Build Verification**
- [x] Project builds successfully with my changes
- [x] No new build warnings introduced
- [ ] Distribution packages (DMG/MSI/JAR) can be created successfully (not run locally)
- [ ] Version system integration tested (not applicable)

## 🔍 Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation (fallback lifecycle documented)
- [x] My changes generate no new warnings or errors

## 🚀 CI/CD Integration
- [x] This PR will trigger appropriate CI/CD workflows
- [x] I understand that all status checks must pass before merging
- [x] I have considered the impact on our centralized version management system

## 📸 Screenshots/Media

### Before
Right-clicking an embedded Compose browser without an application menu could fall through to JxBrowser's Swing menu and crash on an unshowing component.

### After
Auth, passkey, and plugin-owned Compose browser surfaces explicitly close unsupported menu requests before the default view callback can be installed.

## 🔗 Related Issues
Addresses #91

## 📝 Additional Context

### 🎯 **Motivation and Context**
The crash originates in UI-toolkit mismatch rather than page content. The safe boundary is browser construction: every menu request must have a callback before a Compose `BrowserView` exists.

### 🧠 **Implementation Details**
Adds an idempotent fallback that leaves any existing richer `ShowContextMenuCallback` untouched. The fallback is installed immediately after browser creation on three Compose-hosted paths. Headless tests verify registration, preservation of existing callbacks, and completion of Chromium's menu action.

### ⚠️ **Breaking Changes**
None. Surfaces with their own richer callback retain it.

### 🔮 **Future Considerations**
Future Compose-hosted browser factories should install this fallback at construction time unless they synchronously register a full application menu.

## 👀 Review Focus Areas
- [x] **Logic and Algorithm**: Callback ownership before view construction
- [ ] **Performance**: One callback registration per browser
- [x] **Security**: No page data or permissions are changed
- [x] **Platform Compatibility**: Compose/JxBrowser heavyweight interaction
- [x] **User Experience**: Prevents a right-click crash on affected surfaces
- [x] **Documentation**: Factory invariant is documented

## 🚨 Pre-merge Checklist
- [ ] All conversations have been resolved
- [x] Code has been rebased on latest main branch
- [x] Commit messages are clear and descriptive
- [x] PR title accurately describes the change
- [ ] Ready for production deployment (draft pending CI/review)

---

**Thank you for contributing to BOSS! 🎉**
