### PR TITLE
fix(shortcuts): trigger key bindings on key release instead of key press

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
@@ -50,6 +52,13 @@ allprojects {
         // detekt at the whole src tree — it only picks up .kt/.kts files.
         source.setFrom(files("src"))
         parallel = true
+    }
+
+    tasks.withType<Detekt>().configureEach {
+        jvmTarget = "17"
+    }
+    tasks.withType<DetektCreateBaselineTask>().configureEach {
+        jvmTarget = "17"
     }
 
     extensions.configure<KtlintExtension> {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -858,6 +858,8 @@ jxbrowser {
 }
 
 kotlin {
+    jvmToolchain(17)
+
     // Suppress expect/actual classes beta warning (KT-61573)
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -44,6 +44,7 @@
     <ID>TooManyFunctions:EditorAPIAccess.kt$EditorAPIAccess</ID>
     <ID>LongParameterList:DownloadCenter.kt$DownloadCenter$( id: String, title: String, kind: TransferKind, detail: String? = null, onCancel: (() -&gt; Unit)? = null, owner: String? = null, )</ID>
     <ID>LongParameterList:StoreVersionInstaller.kt$StoreVersionInstaller$( store: PluginRepository, request: StoreVersionRequest, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, )</ID>
+    <ID>ComplexCondition:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$handled &amp;&amp; (binding.actionId == KeymapActions.TAB_NEXT || binding.actionId == KeymapActions.TAB_PREVIOUS) &amp;&amp; KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU</ID>
     <ID>ComplexCondition:BossAppEventBusEffects.kt$processingState.totalTabs == 0 &amp;&amp; !processingState.isProcessingURLs &amp;&amp; !processingState.isProcessingTerminals &amp;&amp; !processingState.isProcessingFiles &amp;&amp; processingState.isRestorationComplete</ID>
     <ID>ComplexCondition:BrowserHandleImpl.kt$BrowserHandleImpl$ch != '\u0000' &amp;&amp; !ch.isISOControl() &amp;&amp; !bool("ctrl") &amp;&amp; !bool("meta")</ID>
     <ID>ComplexCondition:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$isMacOSExecutable || isChromium || isSharedLib || isShellScript || hasNoExtension</ID>
@@ -82,7 +83,7 @@
     <ID>ConstructorParameterNaming:UserService.kt$UserBasicInfo$val updated_at: String? = null</ID>
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$fun install()</ID>
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun chordMatchesEvent( modifiers: Collection&lt;String&gt;, event: KeyEvent, ): Boolean</ID>
-    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun dispatchAction( actionId: String, windowId: String, ): Boolean</ID>
+    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun dispatchAction( actionId: String, windowId: String, perform: Boolean = true, ): Boolean</ID>
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun getKeyName(keyCode: Int): String</ID>
     <ID>CyclomaticComplexMethod:AuthScreenContainer.kt$@Composable fun AuthScreenContainer(onLoginSuccess: () -&gt; Unit)</ID>
     <ID>CyclomaticComplexMethod:BossActionButton.kt$@Composable fun BossActionButton( imageVector: ImageVector? = null, leftLogo: (@Composable () -&gt; Unit)? = null, leftIcon: ImageVector? = null, text: String, fontSize: TextUnit = 13.sp, color: Color = BossTheme.colors.textPrimary, iconColor: Color? = null, // Optional separate icon color (defaults to color if null) iconSize: Dp = 20.dp, // Icon size for imageVector mode maxTextWidth: Dp? = null, // Optional max width for text (truncates with ellipsis) modifier: Modifier = Modifier, contentPadding: PaddingValues = PaddingValues(2.dp), isSelected: Boolean = false, contextMenuItems: List&lt;ContextMenuItem&gt;? = null, contextDirection: Panel = bottom, hintText: String? = null, showHintWithDelay: Boolean = true, hintDirection: Panel = bottom, /** * Sized for a narrow column rather than the top bar. * * The vertical tab bar is 200dp wide and its own rows are 24dp of 10sp text; a control built * for a 40dp horizontal bar sits in it like furniture in the wrong room. Opt-in, so the top * bar - where every one of these numbers was chosen - is untouched. */ compact: Boolean = false, onClick: () -&gt; Unit = {}, )</ID>
@@ -234,7 +235,7 @@
     <ID>LargeClass:SplitView.kt$SplitViewState</ID>
     <ID>LargeClass:UpdateScriptGenerator.kt$UpdateScriptGenerator</ID>
     <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$fun install()</ID>
-    <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun dispatchAction( actionId: String, windowId: String, ): Boolean</ID>
+    <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun dispatchAction( actionId: String, windowId: String, perform: Boolean = true, ): Boolean</ID>
     <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun getKeyName(keyCode: Int): String</ID>
     <ID>LongMethod:ActionCard.kt$@Composable fun ActionCard( icon: ImageVector, title: String, shortcut: String? = null, onClick: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:AdvancedSettings.kt$@Composable fun AdvancedSettings()</ID>
@@ -510,7 +511,6 @@
     <ID>MatchingDeclarationName:SettingsSidebar.kt$SettingsSection</ID>
     <ID>MatchingDeclarationName:SidebarIconLimits.kt$SidebarIconRail</ID>
     <ID>MatchingDeclarationName:SupabaseModels.kt$User</ID>
-    <ID>MaxLineLength:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$if</ID>
     <ID>MaxLineLength:AdvancedSettings.kt$"Max plugin allocation: ${"%.1f".format(totalPluginMb / 1024f)} GB (16 plugins × ${pluginHeap.toInt()} MB)"</ID>
     <ID>MaxLineLength:AdvancedSettings.kt$var pluginInitHeap by remember(perfSettings) { mutableStateOf(perfSettings.pluginJvmInitialHeapMb.toFloat()) }</ID>
     <ID>MaxLineLength:AuthScreenContainer.kt$logger.debug(LogCategory.PASSKEY, "Passkey state changed to ShowEmbeddedBrowser, navigating to browser screen")</ID>
@@ -1069,6 +1069,8 @@
     <ID>RethrowCaughtException:FluckEngine.kt$FluckEngine$throw e2</ID>
     <ID>ReturnCount:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun detectContextFromAwtComponent(component: java.awt.Component?): ShortcutContext</ID>
     <ID>ReturnCount:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun findMatchingPluginDefault(event: KeyEvent): String?</ID>
+    <ID>ReturnCount:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun handleKeyPressed( event: KeyEvent, windowId: String, ): Boolean</ID>
+    <ID>ReturnCount:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun handleKeyReleased(event: KeyEvent): Boolean</ID>
     <ID>ReturnCount:ApplicationRestarter.kt$ApplicationRestarter$private fun buildRelaunchCommand(): List&lt;String&gt;</ID>
     <ID>ReturnCount:ApplicationRestarter.kt$ApplicationRestarter$private fun detectMacAppBundle(launcher: String?): String?</ID>
     <ID>ReturnCount:BossDraggableComponent.kt$BossDraggableComponent$fun getItemsForSlot( slot: Panel, hidden: Set&lt;String&gt;, ): List&lt;SidebarItem&gt;</ID>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -44,7 +44,6 @@
     <ID>TooManyFunctions:EditorAPIAccess.kt$EditorAPIAccess</ID>
     <ID>LongParameterList:DownloadCenter.kt$DownloadCenter$( id: String, title: String, kind: TransferKind, detail: String? = null, onCancel: (() -&gt; Unit)? = null, owner: String? = null, )</ID>
     <ID>LongParameterList:StoreVersionInstaller.kt$StoreVersionInstaller$( store: PluginRepository, request: StoreVersionRequest, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, )</ID>
-    <ID>ComplexCondition:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$handled &amp;&amp; (binding.actionId == KeymapActions.TAB_NEXT || binding.actionId == KeymapActions.TAB_PREVIOUS) &amp;&amp; KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU</ID>
     <ID>ComplexCondition:BossAppEventBusEffects.kt$processingState.totalTabs == 0 &amp;&amp; !processingState.isProcessingURLs &amp;&amp; !processingState.isProcessingTerminals &amp;&amp; !processingState.isProcessingFiles &amp;&amp; processingState.isRestorationComplete</ID>
     <ID>ComplexCondition:BrowserHandleImpl.kt$BrowserHandleImpl$ch != '\u0000' &amp;&amp; !ch.isISOControl() &amp;&amp; !bool("ctrl") &amp;&amp; !bool("meta")</ID>
     <ID>ComplexCondition:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$isMacOSExecutable || isChromium || isSharedLib || isShellScript || hasNoExtension</ID>
@@ -81,7 +80,6 @@
     <ID>ConstructorParameterNaming:UpdateService.kt$GitHubRelease$val tag_name: String</ID>
     <ID>ConstructorParameterNaming:UserService.kt$UserBasicInfo$val created_at: String? = null</ID>
     <ID>ConstructorParameterNaming:UserService.kt$UserBasicInfo$val updated_at: String? = null</ID>
-    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$fun install()</ID>
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun chordMatchesEvent( modifiers: Collection&lt;String&gt;, event: KeyEvent, ): Boolean</ID>
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun dispatchAction( actionId: String, windowId: String, perform: Boolean = true, ): Boolean</ID>
     <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun getKeyName(keyCode: Int): String</ID>
@@ -234,7 +232,6 @@
     <ID>LargeClass:PluginStoreSetup.kt$PluginStoreSetup</ID>
     <ID>LargeClass:SplitView.kt$SplitViewState</ID>
     <ID>LargeClass:UpdateScriptGenerator.kt$UpdateScriptGenerator</ID>
-    <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$fun install()</ID>
     <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun dispatchAction( actionId: String, windowId: String, perform: Boolean = true, ): Boolean</ID>
     <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$internal fun getKeyName(keyCode: Int): String</ID>
     <ID>LongMethod:ActionCard.kt$@Composable fun ActionCard( icon: ImageVector, title: String, shortcut: String? = null, onClick: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/KeyboardShortcutInterceptor.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/KeyboardShortcutInterceptor.kt
@@ -2,14 +2,17 @@ package ai.rever.boss.components.events
 
 import ai.rever.boss.keymap.KeymapSettingsManager
 import ai.rever.boss.keymap.handler.KeymapMatcher
+import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.ShortcutContext
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -22,7 +25,7 @@ import kotlinx.coroutines.launch
  * Set of modifier-only keys that should not trigger shortcut matching.
  * These keys don't have a standalone action and are only used in combination.
  */
-internal val MODIFIER_ONLY_KEYS =
+val MODIFIER_ONLY_KEYS =
     setOf(
         Key.CapsLock,
         Key.ShiftLeft,
@@ -44,6 +47,8 @@ internal val MODIFIER_ONLY_KEYS =
  * Use this to wrap components that consume all keyboard input (like terminals, browsers)
  * to ensure global/workspace shortcuts still work.
  *
+ * Recognizes shortcut chords on KeyDown and emits to KeyboardEventBus on primary KeyUp.
+ *
  * @param windowId The current window ID for event routing
  * @param source The event source identifier (e.g., COMPONENT_TERMINAL, COMPONENT_BROWSER)
  * @param context The shortcut context for matching (e.g., TERMINAL, BROWSER)
@@ -58,32 +63,70 @@ fun Modifier.interceptKeyboardShortcuts(
     val settings by KeymapSettingsManager.currentSettings.collectAsState()
     val matcher = remember(settings) { KeymapMatcher(settings) }
     val coroutineScope = rememberCoroutineScope()
+    var pendingKey by remember { mutableStateOf<Key?>(null) }
+    var pendingBinding by remember { mutableStateOf<KeyBinding?>(null) }
 
     return this.onPreviewKeyEvent { keyEvent ->
-        // Only handle key down events
-        if (keyEvent.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+        when (keyEvent.type) {
+            KeyEventType.KeyDown -> {
+                // Skip modifier-only keys
+                if (keyEvent.key in MODIFIER_ONLY_KEYS) {
+                    return@onPreviewKeyEvent false
+                }
 
-        // Skip modifier-only keys
-        if (keyEvent.key in MODIFIER_ONLY_KEYS) return@onPreviewKeyEvent false
+                // Check auto-repeat for the pending primary key
+                if (pendingKey == keyEvent.key && pendingBinding != null) {
+                    return@onPreviewKeyEvent true
+                }
 
-        // Check if this key combo matches any shortcut
-        val binding = matcher.match(keyEvent, context)
-
-        if (binding != null) {
-            // Emit to KeyboardEventBus for action execution
-            coroutineScope.launch {
-                KeyboardEventBus.emit(
-                    KeyboardEvent(
-                        keyEvent = keyEvent,
-                        source = source,
-                        context = context,
-                        sourceWindowId = windowId,
-                    ),
-                )
+                // Check if this key combo matches any shortcut
+                val binding = matcher.match(keyEvent, context)
+                if (binding != null) {
+                    pendingKey = keyEvent.key
+                    pendingBinding = binding
+                    true // Consume key down event - don't let wrapped component handle it
+                } else {
+                    pendingKey = null
+                    pendingBinding = null
+                    false // Let wrapped component handle regular input
+                }
             }
-            true // Consume the event - don't let wrapped component handle it
-        } else {
-            false // Let wrapped component handle regular input
+
+            KeyEventType.KeyUp -> {
+                val currentPendingKey = pendingKey
+                val currentPendingBinding = pendingBinding
+                if (currentPendingKey != null && currentPendingBinding != null) {
+                    if (keyEvent.key == currentPendingKey) {
+                        pendingKey = null
+                        pendingBinding = null
+                        // Emit to KeyboardEventBus for action execution on primary key release
+                        coroutineScope.launch {
+                            KeyboardEventBus.emit(
+                                KeyboardEvent(
+                                    keyEvent = keyEvent,
+                                    source = source,
+                                    context = context,
+                                    sourceWindowId = windowId,
+                                ),
+                            )
+                        }
+                        true
+                    } else if (keyEvent.key in MODIFIER_ONLY_KEYS) {
+                        // Releasing modifier alone cancels pending shortcut
+                        pendingKey = null
+                        pendingBinding = null
+                        false
+                    } else {
+                        pendingKey = null
+                        pendingBinding = null
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+
+            else -> false
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/KeyboardShortcutInterceptor.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/KeyboardShortcutInterceptor.kt
@@ -95,38 +95,28 @@ fun Modifier.interceptKeyboardShortcuts(
             KeyEventType.KeyUp -> {
                 val currentPendingKey = pendingKey
                 val currentPendingBinding = pendingBinding
-                if (currentPendingKey != null && currentPendingBinding != null) {
-                    if (keyEvent.key == currentPendingKey) {
-                        pendingKey = null
-                        pendingBinding = null
-                        // Emit to KeyboardEventBus for action execution on primary key release
-                        coroutineScope.launch {
-                            KeyboardEventBus.emit(
-                                KeyboardEvent(
-                                    keyEvent = keyEvent,
-                                    source = source,
-                                    context = context,
-                                    sourceWindowId = windowId,
-                                ),
-                            )
-                        }
-                        true
-                    } else if (keyEvent.key in MODIFIER_ONLY_KEYS) {
-                        // Releasing modifier alone cancels pending shortcut
-                        pendingKey = null
-                        pendingBinding = null
-                        false
-                    } else {
-                        pendingKey = null
-                        pendingBinding = null
-                        false
+                pendingKey = null
+                pendingBinding = null
+                if (currentPendingKey != null && currentPendingBinding != null && keyEvent.key == currentPendingKey) {
+                    coroutineScope.launch {
+                        KeyboardEventBus.emit(
+                            KeyboardEvent(
+                                keyEvent = keyEvent,
+                                source = source,
+                                context = context,
+                                sourceWindowId = windowId,
+                            ),
+                        )
                     }
+                    true
                 } else {
                     false
                 }
             }
 
-            else -> false
+            else -> {
+                false
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/KeyboardShortcutInterceptor.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/KeyboardShortcutInterceptor.kt
@@ -1,31 +1,30 @@
 package ai.rever.boss.components.events
 
 import ai.rever.boss.keymap.KeymapSettingsManager
-import ai.rever.boss.keymap.handler.KeymapMatcher
-import ai.rever.boss.keymap.model.KeyBinding
+import ai.rever.boss.keymap.handler.KeymapHandler
 import ai.rever.boss.keymap.model.ShortcutContext
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
 import kotlinx.coroutines.launch
 
 /**
  * Set of modifier-only keys that should not trigger shortcut matching.
  * These keys don't have a standalone action and are only used in combination.
  */
-val MODIFIER_ONLY_KEYS =
+internal val MODIFIER_ONLY_KEYS =
     setOf(
         Key.CapsLock,
         Key.ShiftLeft,
@@ -61,74 +60,34 @@ fun Modifier.interceptKeyboardShortcuts(
     context: ShortcutContext,
 ): Modifier {
     val settings by KeymapSettingsManager.currentSettings.collectAsState()
-    val matcher = remember(settings) { KeymapMatcher(settings) }
+    val handler = remember(settings, windowId, context) { KeymapHandler(settings) }
     val coroutineScope = rememberCoroutineScope()
-    var pendingKey by remember { mutableStateOf<Key?>(null) }
-    var pendingBinding by remember { mutableStateOf<KeyBinding?>(null) }
-
-    return this.onPreviewKeyEvent { keyEvent ->
-        when (keyEvent.type) {
-            KeyEventType.KeyDown -> {
-                // Skip modifier-only keys
-                if (keyEvent.key in MODIFIER_ONLY_KEYS) {
-                    return@onPreviewKeyEvent false
-                }
-
-                // Check auto-repeat for the pending primary key
-                if (pendingKey == keyEvent.key && pendingBinding != null) {
-                    return@onPreviewKeyEvent true
-                }
-
-                // Check if this key combo matches any shortcut
-                val binding = matcher.match(keyEvent, context)
-                if (binding != null) {
-                    pendingKey = keyEvent.key
-                    pendingBinding = binding
-                    true // Consume key down event - don't let wrapped component handle it
-                } else {
-                    pendingKey = null
-                    pendingBinding = null
-                    false // Let wrapped component handle regular input
-                }
-            }
-
-            KeyEventType.KeyUp -> {
-                val currentPendingKey = pendingKey
-                val currentPendingBinding = pendingBinding
-                if (currentPendingKey != null && currentPendingBinding != null) {
-                    if (keyEvent.key == currentPendingKey) {
-                        pendingKey = null
-                        pendingBinding = null
-                        // Emit to KeyboardEventBus for action execution on primary key release
-                        coroutineScope.launch {
-                            KeyboardEventBus.emit(
-                                KeyboardEvent(
-                                    keyEvent = keyEvent,
-                                    source = source,
-                                    context = context,
-                                    sourceWindowId = windowId,
-                                ),
-                            )
-                        }
-                        true
-                    } else if (keyEvent.key in MODIFIER_ONLY_KEYS) {
-                        // Releasing modifier alone cancels pending shortcut
-                        pendingKey = null
-                        pendingBinding = null
-                        false
-                    } else {
-                        pendingKey = null
-                        pendingBinding = null
-                        false
-                    }
-                } else {
-                    false
-                }
-            }
-
-            else -> false
+    val windowInfo = LocalWindowInfo.current
+    LaunchedEffect(handler, windowInfo) {
+        snapshotFlow { windowInfo.isWindowFocused }.collect { focused ->
+            if (!focused) handler.clearPendingShortcut()
         }
     }
+    DisposableEffect(handler) {
+        onDispose { handler.clearPendingShortcut() }
+    }
+
+    return this.onFocusChanged { if (!it.hasFocus) handler.clearPendingShortcut() }
+        .onPreviewKeyEvent { keyEvent ->
+            handler.handleKeyEvent(keyEvent, context) {
+                coroutineScope.launch {
+                    KeyboardEventBus.emit(
+                        KeyboardEvent(
+                            keyEvent = keyEvent,
+                            source = source,
+                            context = context,
+                            sourceWindowId = windowId,
+                        ),
+                    )
+                }
+                true
+            }
+        }
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/KeyboardShortcutInterceptor.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/KeyboardShortcutInterceptor.kt
@@ -5,19 +5,19 @@ import ai.rever.boss.keymap.handler.KeymapHandler
 import ai.rever.boss.keymap.model.ShortcutContext
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalWindowInfo
 import kotlinx.coroutines.launch
 
 /**
@@ -46,7 +46,9 @@ internal val MODIFIER_ONLY_KEYS =
  * Use this to wrap components that consume all keyboard input (like terminals, browsers)
  * to ensure global/workspace shortcuts still work.
  *
- * Recognizes shortcut chords on KeyDown and emits to KeyboardEventBus on primary KeyUp.
+ * Recognizes shortcut chords on KeyDown and emits a KeyUp event to KeyboardEventBus.
+ * Modifier-first release cancels, matching the AWT dispatcher. Place this modifier before
+ * the wrapped component's focus target so its focus observer can clear pending state.
  *
  * @param windowId The current window ID for event routing
  * @param source The event source identifier (e.g., COMPONENT_TERMINAL, COMPONENT_BROWSER)
@@ -72,7 +74,8 @@ fun Modifier.interceptKeyboardShortcuts(
         onDispose { handler.clearPendingShortcut() }
     }
 
-    return this.onFocusChanged { if (!it.hasFocus) handler.clearPendingShortcut() }
+    return this
+        .onFocusChanged { if (!it.hasFocus) handler.clearPendingShortcut() }
         .onPreviewKeyEvent { keyEvent ->
             handler.handleKeyEvent(keyEvent, context) {
                 coroutineScope.launch {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapHandler.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapHandler.kt
@@ -1,12 +1,26 @@
 package ai.rever.boss.keymap.handler
 
+import ai.rever.boss.components.events.MODIFIER_ONLY_KEYS
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.model.ShortcutContext
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+
+/**
+ * Information about an armed shortcut chord pending primary key release.
+ */
+data class PendingKeymapShortcut(
+    val binding: KeyBinding,
+    val primaryKey: Key,
+    val context: ShortcutContext,
+)
 
 /**
  * Context-aware keyboard shortcut handler.
@@ -14,6 +28,8 @@ import androidx.compose.ui.input.key.KeyEvent
  * 1. Current UI context (browser, terminal, workspace, etc.)
  * 2. Configured key bindings
  * 3. Enabled state of shortcuts
+ *
+ * Recognizes shortcut chords on KeyDown and executes the action on primary KeyUp.
  *
  * Usage:
  * ```kotlin
@@ -33,6 +49,20 @@ class KeymapHandler(
     private val logger = BossLogger.forComponent("KeymapHandler")
     private val matcher = KeymapMatcher(settings)
     private var _settings = settings
+    private var pendingShortcut: PendingKeymapShortcut? = null
+
+    /**
+     * Whether a shortcut chord is currently armed and pending release.
+     */
+    val hasPendingShortcut: Boolean
+        get() = pendingShortcut != null
+
+    /**
+     * Clear any pending shortcut state (e.g. on focus loss, window deactivation, or cancellation).
+     */
+    fun clearPendingShortcut() {
+        pendingShortcut = null
+    }
 
     /**
      * Current keymap settings.
@@ -45,11 +75,14 @@ class KeymapHandler(
      */
     fun updateSettings(newSettings: KeymapSettings) {
         _settings = newSettings
+        pendingShortcut = null
     }
 
     /**
      * Handle a keyboard event in the given context.
-     * Returns true if the event was handled, false otherwise.
+     * On KeyDown: Matches and arms a shortcut chord (returns true if matched/consumed without executing).
+     * On KeyUp: Executes the action when the matching primary key is released.
+     * Returns true if the event was handled/consumed, false otherwise.
      *
      * @param event The keyboard event to handle
      * @param context The current UI context
@@ -60,19 +93,63 @@ class KeymapHandler(
         context: ShortcutContext,
         executor: (actionId: String) -> Boolean,
     ): Boolean {
-        // Match the event to a binding
-        val binding = matcher.match(event, context) ?: return false
+        when (event.type) {
+            KeyEventType.KeyDown -> {
+                if (event.key in MODIFIER_ONLY_KEYS) {
+                    return false
+                }
 
-        // Execute the action
-        val handled = executor(binding.actionId)
+                // Check auto-repeat for the pending primary key
+                val currentPending = pendingShortcut
+                if (currentPending != null && currentPending.primaryKey == event.key) {
+                    return true
+                }
 
-        if (handled) {
-            logger.debug(LogCategory.UI, "Executed action", mapOf("actionId" to binding.actionId, "description" to binding.description))
-        } else {
-            logger.debug(LogCategory.UI, "Failed to execute action", mapOf("actionId" to binding.actionId))
+                // Match the event to a binding
+                val binding = matcher.match(event, context)
+                if (binding != null) {
+                    pendingShortcut = PendingKeymapShortcut(binding, event.key, context)
+                    return true
+                } else {
+                    pendingShortcut = null
+                    return false
+                }
+            }
+
+            KeyEventType.KeyUp -> {
+                val currentPending = pendingShortcut
+                if (currentPending != null) {
+                    if (event.key == currentPending.primaryKey) {
+                        pendingShortcut = null
+                        val handled = executor(currentPending.binding.actionId)
+                        if (handled) {
+                            logger.debug(
+                                LogCategory.UI,
+                                "Executed action on key release",
+                                mapOf("actionId" to currentPending.binding.actionId, "description" to currentPending.binding.description),
+                            )
+                        } else {
+                            logger.debug(
+                                LogCategory.UI,
+                                "Failed to execute action on key release",
+                                mapOf("actionId" to currentPending.binding.actionId),
+                            )
+                        }
+                        return handled
+                    } else if (event.key in MODIFIER_ONLY_KEYS) {
+                        // Releasing modifier alone cancels pending chord without invoking action
+                        pendingShortcut = null
+                        return false
+                    } else {
+                        pendingShortcut = null
+                        return false
+                    }
+                }
+                return false
+            }
+
+            else -> return false
         }
-
-        return handled
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapHandler.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapHandler.kt
@@ -92,64 +92,64 @@ class KeymapHandler(
         event: KeyEvent,
         context: ShortcutContext,
         executor: (actionId: String) -> Boolean,
-    ): Boolean {
+    ): Boolean =
         when (event.type) {
-            KeyEventType.KeyDown -> {
-                if (event.key in MODIFIER_ONLY_KEYS) {
-                    return false
-                }
-
-                // Check auto-repeat for the pending primary key
-                val currentPending = pendingShortcut
-                if (currentPending != null && currentPending.primaryKey == event.key) {
-                    return true
-                }
-
-                // Match the event to a binding
-                val binding = matcher.match(event, context)
-                if (binding != null) {
-                    pendingShortcut = PendingKeymapShortcut(binding, event.key, context)
-                    return true
-                } else {
-                    pendingShortcut = null
-                    return false
-                }
-            }
-
-            KeyEventType.KeyUp -> {
-                val currentPending = pendingShortcut
-                if (currentPending != null) {
-                    if (event.key == currentPending.primaryKey) {
-                        pendingShortcut = null
-                        val handled = executor(currentPending.binding.actionId)
-                        if (handled) {
-                            logger.debug(
-                                LogCategory.UI,
-                                "Executed action on key release",
-                                mapOf("actionId" to currentPending.binding.actionId, "description" to currentPending.binding.description),
-                            )
-                        } else {
-                            logger.debug(
-                                LogCategory.UI,
-                                "Failed to execute action on key release",
-                                mapOf("actionId" to currentPending.binding.actionId),
-                            )
-                        }
-                        return handled
-                    } else if (event.key in MODIFIER_ONLY_KEYS) {
-                        // Releasing modifier alone cancels pending chord without invoking action
-                        pendingShortcut = null
-                        return false
-                    } else {
-                        pendingShortcut = null
-                        return false
-                    }
-                }
-                return false
-            }
-
-            else -> return false
+            KeyEventType.KeyDown -> handleKeyDown(event, context)
+            KeyEventType.KeyUp -> handleKeyUp(event, executor)
+            else -> false
         }
+
+    @Suppress("ReturnCount")
+    private fun handleKeyDown(
+        event: KeyEvent,
+        context: ShortcutContext,
+    ): Boolean {
+        if (event.key in MODIFIER_ONLY_KEYS) {
+            return false
+        }
+
+        // Check auto-repeat for the pending primary key
+        val currentPending = pendingShortcut
+        if (currentPending != null && currentPending.primaryKey == event.key) {
+            return true
+        }
+
+        // Match the event to a binding
+        val binding = matcher.match(event, context)
+        return if (binding != null) {
+            pendingShortcut = PendingKeymapShortcut(binding, event.key, context)
+            true
+        } else {
+            pendingShortcut = null
+            false
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun handleKeyUp(
+        event: KeyEvent,
+        executor: (actionId: String) -> Boolean,
+    ): Boolean {
+        val currentPending = pendingShortcut ?: return false
+        pendingShortcut = null
+
+        if (event.key != currentPending.primaryKey) {
+            return false
+        }
+
+        val handled = executor(currentPending.binding.actionId)
+        val msg = if (handled) "Executed action on key release" else "Failed to execute action on key release"
+        val data =
+            if (handled) {
+                mapOf(
+                    "actionId" to currentPending.binding.actionId,
+                    "description" to currentPending.binding.description,
+                )
+            } else {
+                mapOf("actionId" to currentPending.binding.actionId)
+            }
+        logger.debug(LogCategory.UI, msg, data)
+        return handled
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapHandler.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapHandler.kt
@@ -10,6 +10,10 @@ import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 
@@ -47,21 +51,23 @@ class KeymapHandler(
     settings: KeymapSettings,
 ) {
     private val logger = BossLogger.forComponent("KeymapHandler")
-    private val matcher = KeymapMatcher(settings)
+    private var matcher = KeymapMatcher(settings)
     private var _settings = settings
-    private var pendingShortcut: PendingKeymapShortcut? = null
+    private val pendingShortcuts = mutableMapOf<Key, PendingKeymapShortcut>()
+    private val claimedKeys = mutableSetOf<Key>()
 
     /**
      * Whether a shortcut chord is currently armed and pending release.
      */
     val hasPendingShortcut: Boolean
-        get() = pendingShortcut != null
+        get() = pendingShortcuts.isNotEmpty()
 
     /**
      * Clear any pending shortcut state (e.g. on focus loss, window deactivation, or cancellation).
      */
     fun clearPendingShortcut() {
-        pendingShortcut = null
+        pendingShortcuts.clear()
+        claimedKeys.clear()
     }
 
     /**
@@ -75,7 +81,8 @@ class KeymapHandler(
      */
     fun updateSettings(newSettings: KeymapSettings) {
         _settings = newSettings
-        pendingShortcut = null
+        matcher = KeymapMatcher(newSettings)
+        clearPendingShortcut()
     }
 
     /**
@@ -93,63 +100,41 @@ class KeymapHandler(
         context: ShortcutContext,
         executor: (actionId: String) -> Boolean,
     ): Boolean {
-        when (event.type) {
-            KeyEventType.KeyDown -> {
-                if (event.key in MODIFIER_ONLY_KEYS) {
-                    return false
-                }
-
-                // Check auto-repeat for the pending primary key
-                val currentPending = pendingShortcut
-                if (currentPending != null && currentPending.primaryKey == event.key) {
-                    return true
-                }
-
-                // Match the event to a binding
-                val binding = matcher.match(event, context)
-                if (binding != null) {
-                    pendingShortcut = PendingKeymapShortcut(binding, event.key, context)
-                    return true
-                } else {
-                    pendingShortcut = null
-                    return false
-                }
-            }
-
-            KeyEventType.KeyUp -> {
-                val currentPending = pendingShortcut
-                if (currentPending != null) {
-                    if (event.key == currentPending.primaryKey) {
-                        pendingShortcut = null
-                        val handled = executor(currentPending.binding.actionId)
-                        if (handled) {
-                            logger.debug(
-                                LogCategory.UI,
-                                "Executed action on key release",
-                                mapOf("actionId" to currentPending.binding.actionId, "description" to currentPending.binding.description),
-                            )
-                        } else {
-                            logger.debug(
-                                LogCategory.UI,
-                                "Failed to execute action on key release",
-                                mapOf("actionId" to currentPending.binding.actionId),
-                            )
-                        }
-                        return handled
-                    } else if (event.key in MODIFIER_ONLY_KEYS) {
-                        // Releasing modifier alone cancels pending chord without invoking action
-                        pendingShortcut = null
-                        return false
-                    } else {
-                        pendingShortcut = null
-                        return false
-                    }
-                }
-                return false
-            }
-
-            else -> return false
+        pendingShortcuts.entries.removeAll { it.value.context != context }
+        val pending = pendingShortcuts[event.key]
+        val barePress = event.type == KeyEventType.KeyDown &&
+            !event.isMetaPressed && !event.isCtrlPressed && !event.isAltPressed && !event.isShiftPressed
+        if (barePress && pending != null && pending.binding.modifiers.isNotEmpty()) {
+            pendingShortcuts.remove(event.key)
+            claimedKeys.remove(event.key)
         }
+        return when (event.type) {
+            KeyEventType.KeyDown -> armShortcut(event, context)
+            KeyEventType.KeyUp -> releaseShortcut(event, executor)
+            else -> false
+        }
+    }
+
+    private fun armShortcut(event: KeyEvent, context: ShortcutContext): Boolean = when {
+        event.key in MODIFIER_ONLY_KEYS -> false
+        event.key in claimedKeys -> true
+        else -> {
+            val binding = matcher.match(event, context)
+            if (binding != null) pendingShortcuts[event.key] = PendingKeymapShortcut(binding, event.key, context)
+            if (binding != null) claimedKeys.add(event.key)
+            binding != null
+        }
+    }
+
+    private fun releaseShortcut(event: KeyEvent, executor: (String) -> Boolean): Boolean {
+        val claimed = claimedKeys.remove(event.key)
+        if (event.key in MODIFIER_ONLY_KEYS) pendingShortcuts.clear()
+        val pending = pendingShortcuts.remove(event.key)
+        if (pending != null) {
+            val handled = executor(pending.binding.actionId)
+            logger.debug(LogCategory.UI, "Released shortcut", mapOf("actionId" to pending.binding.actionId, "handled" to handled))
+        }
+        return claimed
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapHandler.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapHandler.kt
@@ -10,9 +10,9 @@ import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
@@ -102,8 +102,9 @@ class KeymapHandler(
     ): Boolean {
         pendingShortcuts.entries.removeAll { it.value.context != context }
         val pending = pendingShortcuts[event.key]
-        val barePress = event.type == KeyEventType.KeyDown &&
-            !event.isMetaPressed && !event.isCtrlPressed && !event.isAltPressed && !event.isShiftPressed
+        val hasModifier =
+            listOf(event.isMetaPressed, event.isCtrlPressed, event.isAltPressed, event.isShiftPressed).any { it }
+        val barePress = event.type == KeyEventType.KeyDown && !hasModifier
         if (barePress && pending != null && pending.binding.modifiers.isNotEmpty()) {
             pendingShortcuts.remove(event.key)
             claimedKeys.remove(event.key)
@@ -115,24 +116,41 @@ class KeymapHandler(
         }
     }
 
-    private fun armShortcut(event: KeyEvent, context: ShortcutContext): Boolean = when {
-        event.key in MODIFIER_ONLY_KEYS -> false
-        event.key in claimedKeys -> true
-        else -> {
-            val binding = matcher.match(event, context)
-            if (binding != null) pendingShortcuts[event.key] = PendingKeymapShortcut(binding, event.key, context)
-            if (binding != null) claimedKeys.add(event.key)
-            binding != null
-        }
-    }
+    private fun armShortcut(
+        event: KeyEvent,
+        context: ShortcutContext,
+    ): Boolean =
+        when {
+            event.key in MODIFIER_ONLY_KEYS -> {
+                false
+            }
 
-    private fun releaseShortcut(event: KeyEvent, executor: (String) -> Boolean): Boolean {
+            event.key in claimedKeys -> {
+                true
+            }
+
+            else -> {
+                val binding = matcher.match(event, context)
+                if (binding != null) pendingShortcuts[event.key] = PendingKeymapShortcut(binding, event.key, context)
+                if (binding != null) claimedKeys.add(event.key)
+                binding != null
+            }
+        }
+
+    private fun releaseShortcut(
+        event: KeyEvent,
+        executor: (String) -> Boolean,
+    ): Boolean {
         val claimed = claimedKeys.remove(event.key)
         if (event.key in MODIFIER_ONLY_KEYS) pendingShortcuts.clear()
         val pending = pendingShortcuts.remove(event.key)
         if (pending != null) {
             val handled = executor(pending.binding.actionId)
-            logger.debug(LogCategory.UI, "Released shortcut", mapOf("actionId" to pending.binding.actionId, "handled" to handled))
+            logger.debug(
+                LogCategory.UI,
+                "Released shortcut",
+                mapOf("actionId" to pending.binding.actionId, "handled" to handled),
+            )
         }
         return claimed
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -59,7 +59,7 @@ object AWTKeyboardInterceptor {
     // modifier is a benign mismatch — the stray release just no-ops downstream.
     private var tabCycleModifierKeyCode = -1
     private var tabCycleWindowId: String? = null
-    private val claimedKeys = mutableSetOf<Int>()
+    private val claimedKeys = ConcurrentHashMap.newKeySet<Int>()
 
     // Minimum time shift must be released to count as a clean release (prevents false positives from held shift)
     private const val MIN_SHIFT_RELEASE_MS = 50
@@ -95,7 +95,7 @@ object AWTKeyboardInterceptor {
 
     // One pending action per physical primary key supports overlapping chords. Normal
     // dispatch and focus changes run on the EDT; shutdown also clears this state.
-    internal val pendingShortcuts = HashMap<Int, PendingShortcut>()
+    internal val pendingShortcuts = ConcurrentHashMap<Int, PendingShortcut>()
 
     private var focusListener: java.beans.PropertyChangeListener? = null
 
@@ -178,7 +178,6 @@ object AWTKeyboardInterceptor {
                 finishTabCycle()
             }
         KeyboardFocusManager.getCurrentKeyboardFocusManager().addPropertyChangeListener("focusedWindow", focusListener)
-        KeyboardFocusManager.getCurrentKeyboardFocusManager().addPropertyChangeListener("focusOwner", focusListener)
         isInstalled = true
     }
 
@@ -187,7 +186,9 @@ object AWTKeyboardInterceptor {
         event: KeyEvent,
         windowId: String? = findWindowId(KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow),
     ): Boolean {
-        // Modifier cancellation must precede both the Shift gesture and MRU commit paths.
+        // Keep #492's cancellation policy: releasing any modifier before the primary key
+        // cancels the chord. No bound action fires from a modifier release (#490).
+        // Cancellation must precede both the Shift gesture and MRU commit paths.
         if (event.id == KeyEvent.KEY_RELEASED && isModifierOnlyKey(event.keyCode)) {
             pendingShortcuts.clear()
             if (event.keyCode == tabCycleModifierKeyCode) finishTabCycle()
@@ -198,16 +199,20 @@ object AWTKeyboardInterceptor {
             lastShiftPressTime = 0
             lastShiftReleaseTime = 0
         }
-        val handled = when (event.id) {
-            KeyEvent.KEY_RELEASED -> handleKeyReleased(event)
-            KeyEvent.KEY_PRESSED -> windowId != null && handleKeyPressed(event, windowId)
-            else -> false
-        }
+        val handled =
+            when (event.id) {
+                KeyEvent.KEY_RELEASED -> handleKeyReleased(event)
+                KeyEvent.KEY_PRESSED -> windowId != null && handleKeyPressed(event, windowId)
+                else -> false
+            }
         if (handled) event.consume()
         return handled
     }
 
-    private fun handleShiftEvent(event: KeyEvent, windowId: String?): Boolean {
+    private fun handleShiftEvent(
+        event: KeyEvent,
+        windowId: String?,
+    ): Boolean {
         val now = System.currentTimeMillis()
         var handled = false
         when (event.id) {
@@ -227,6 +232,7 @@ object AWTKeyboardInterceptor {
                     lastShiftPressTime = now
                 }
             }
+
             KeyEvent.KEY_RELEASED -> {
                 if (shiftPressCount == 1 && now - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
                     lastShiftReleaseTime = now
@@ -256,7 +262,6 @@ object AWTKeyboardInterceptor {
         dispatcher = null
         focusListener?.let { l ->
             KeyboardFocusManager.getCurrentKeyboardFocusManager().removePropertyChangeListener("focusedWindow", l)
-            KeyboardFocusManager.getCurrentKeyboardFocusManager().removePropertyChangeListener("focusOwner", l)
         }
         focusListener = null
         isInstalled = false
@@ -340,11 +345,16 @@ object AWTKeyboardInterceptor {
             }
 
             claimedKeys.add(event.keyCode)
-            pendingShortcuts[event.keyCode] = PendingShortcut(
-                keyCode = event.keyCode, windowId = windowId, hostBinding = match,
-                metaDown = event.isMetaDown, controlDown = event.isControlDown,
-                shiftDown = event.isShiftDown, altDown = event.isAltDown,
-            )
+            pendingShortcuts[event.keyCode] =
+                PendingShortcut(
+                    keyCode = event.keyCode,
+                    windowId = windowId,
+                    hostBinding = match,
+                    metaDown = event.isMetaDown,
+                    controlDown = event.isControlDown,
+                    shiftDown = event.isShiftDown,
+                    altDown = event.isAltDown,
+                )
             return true
         }
 
@@ -362,9 +372,13 @@ object AWTKeyboardInterceptor {
             // confirmed for real at key-up in handleKeyReleased.
             pendingShortcuts[event.keyCode] =
                 PendingShortcut(
-                    keyCode = event.keyCode, windowId = windowId, pluginActionId = pluginActionId,
-                    metaDown = event.isMetaDown, controlDown = event.isControlDown,
-                    shiftDown = event.isShiftDown, altDown = event.isAltDown,
+                    keyCode = event.keyCode,
+                    windowId = windowId,
+                    pluginActionId = pluginActionId,
+                    metaDown = event.isMetaDown,
+                    controlDown = event.isControlDown,
+                    shiftDown = event.isShiftDown,
+                    altDown = event.isAltDown,
                 )
             return true
         }
@@ -394,7 +408,9 @@ object AWTKeyboardInterceptor {
             val match = checkNotNull(pending.hostBinding)
             val handled = dispatchAction(match.binding.actionId, pending.windowId, perform = true)
             val cyclesTabs = match.binding.actionId in setOf(KeymapActions.TAB_NEXT, KeymapActions.TAB_PREVIOUS)
-            if (handled && cyclesTabs && KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU) {
+            if (
+                handled && cyclesTabs && KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU
+            ) {
                 tabCycleWindowId = pending.windowId
                 tabCycleModifierKeyCode = cyclingModifierKeyCode(match.keystroke)
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -80,19 +80,22 @@ object AWTKeyboardInterceptor {
         val windowId: String,
         val hostBinding: BindingMatch? = null,
         val pluginActionId: String? = null,
-    )
+        val metaDown: Boolean = false,
+        val controlDown: Boolean = false,
+        val shiftDown: Boolean = false,
+        val altDown: Boolean = false,
+    ) {
+        /** Whether the key press carries the same modifier flags as the armed chord. */
+        fun sameModifiersAs(event: KeyEvent): Boolean =
+            metaDown == event.isMetaDown &&
+                controlDown == event.isControlDown &&
+                shiftDown == event.isShiftDown &&
+                altDown == event.isAltDown
+    }
 
     // One pending action per physical primary key supports overlapping chords. Normal
     // dispatch and focus changes run on the EDT; shutdown also clears this state.
-    private val pendingShortcuts = mutableMapOf<Int, PendingShortcut>()
-
-    // Retained as the test seam for the original single-chord regression suite.
-    internal var pendingShortcut: PendingShortcut?
-        get() = pendingShortcuts.values.firstOrNull()
-        set(value) {
-            pendingShortcuts.clear()
-            if (value != null) pendingShortcuts[value.keyCode] = value
-        }
+    internal val pendingShortcuts = HashMap<Int, PendingShortcut>()
 
     private var focusListener: java.beans.PropertyChangeListener? = null
 
@@ -112,10 +115,14 @@ object AWTKeyboardInterceptor {
      * Call this from BossWindow's DisposableEffect onDispose.
      */
     fun unregisterWindow(awtWindow: Window) {
-        cancelPendingShortcut()
-        finishTabCycle()
         val windowId = windowIdMap.remove(awtWindow)
         if (windowId != null) {
+            pendingShortcuts.entries.removeAll { entry ->
+                (entry.value.windowId == windowId).also { removed ->
+                    if (removed) claimedKeys.remove(entry.key)
+                }
+            }
+            if (tabCycleWindowId == windowId) finishTabCycle()
             windowContextMap.remove(windowId)
         }
     }
@@ -278,7 +285,7 @@ object AWTKeyboardInterceptor {
         // or invoking anything a second time. This is what stops OS auto-repeat from firing
         // the action over and over - the actual fire happens once, in handleKeyReleased.
         val pending = pendingShortcuts[event.keyCode]
-        if (pending != null && !event.isMetaDown && !event.isControlDown && !event.isAltDown) {
+        if (pending != null && (pending.windowId != windowId || !pending.sameModifiersAs(event))) {
             pendingShortcuts.remove(event.keyCode)
             claimedKeys.remove(event.keyCode)
         } else if (event.keyCode in claimedKeys || pending != null) {
@@ -333,7 +340,11 @@ object AWTKeyboardInterceptor {
             }
 
             claimedKeys.add(event.keyCode)
-            pendingShortcuts[event.keyCode] = PendingShortcut(keyCode = event.keyCode, windowId = windowId, hostBinding = match)
+            pendingShortcuts[event.keyCode] = PendingShortcut(
+                keyCode = event.keyCode, windowId = windowId, hostBinding = match,
+                metaDown = event.isMetaDown, controlDown = event.isControlDown,
+                shiftDown = event.isShiftDown, altDown = event.isAltDown,
+            )
             return true
         }
 
@@ -350,7 +361,11 @@ object AWTKeyboardInterceptor {
             // this" without actually dispatching, so this arms on chord match alone and is
             // confirmed for real at key-up in handleKeyReleased.
             pendingShortcuts[event.keyCode] =
-                PendingShortcut(keyCode = event.keyCode, windowId = windowId, pluginActionId = pluginActionId)
+                PendingShortcut(
+                    keyCode = event.keyCode, windowId = windowId, pluginActionId = pluginActionId,
+                    metaDown = event.isMetaDown, controlDown = event.isControlDown,
+                    shiftDown = event.isShiftDown, altDown = event.isAltDown,
+                )
             return true
         }
 
@@ -362,7 +377,7 @@ object AWTKeyboardInterceptor {
      * BossConsole#490 shortcut actually invokes anything. Returns whether the release should
      * be consumed.
      *
-     * A released key that doesn't match [pendingShortcut] - including a modifier released by
+     * A released key that doesn't match [pendingShortcuts] - including a modifier released by
      * itself, since a modifier can never BE [PendingShortcut.keyCode] - invokes nothing and
      * is not consumed.
      */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -64,6 +64,31 @@ object AWTKeyboardInterceptor {
     private const val MIN_SHIFT_RELEASE_MS = 50
 
     /**
+     * Pending shortcut chord armed on KEY_PRESSED awaiting primary key release on KEY_RELEASED.
+     */
+    internal data class PendingShortcut(
+        val actionId: String,
+        val windowId: String,
+        val primaryKeyCode: Int,
+        val isPluginShortcut: Boolean = false,
+        val tabCycleMatch: BindingMatch? = null,
+    )
+
+    private var pendingShortcut: PendingShortcut? = null
+
+    /**
+     * Check if a shortcut chord is currently pending release.
+     */
+    internal fun hasPendingShortcut(): Boolean = pendingShortcut != null
+
+    /**
+     * Clear any pending shortcut state (e.g. on focus loss, window unregister, or cancellation).
+     */
+    fun clearPendingShortcut() {
+        pendingShortcut = null
+    }
+
+    /**
      * Register an AWT window with its BOSS window ID.
      * Call this from BossWindow's DisposableEffect when window is created.
      */
@@ -79,6 +104,7 @@ object AWTKeyboardInterceptor {
      * Call this from BossWindow's DisposableEffect onDispose.
      */
     fun unregisterWindow(awtWindow: Window) {
+        clearPendingShortcut()
         val windowId = windowIdMap.remove(awtWindow)
         if (windowId != null) {
             windowContextMap.remove(windowId)
@@ -124,166 +150,193 @@ object AWTKeyboardInterceptor {
     fun install() {
         if (isInstalled) return
 
-        dispatcher =
-            KeyEventDispatcher { event ->
-                // Handle double-shift detection for global search
-                if (event.keyCode == KeyEvent.VK_SHIFT) {
-                    val currentTime = System.currentTimeMillis()
-
-                    when (event.id) {
-                        KeyEvent.KEY_PRESSED -> {
-                            // Check if this is a quick second press after a clean release
-                            val timeSinceRelease = currentTime - lastShiftReleaseTime
-                            if (timeSinceRelease < DOUBLE_SHIFT_THRESHOLD_MS &&
-                                timeSinceRelease >= MIN_SHIFT_RELEASE_MS && // Ensure clean release (not held)
-                                shiftPressCount == 1
-                            ) {
-                                // Double-shift detected!
-                                shiftPressCount = 0
-                                lastShiftPressTime = 0
-                                lastShiftReleaseTime = 0
-
-                                // Get the focused window's BOSS window ID
-                                val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
-                                val windowId = findWindowId(focusedWindow)
-                                if (windowId != null) {
-                                    try {
-                                        MenuActionsHandler.triggerOpenGlobalSearch(windowId)
-                                        event.consume()
-                                        return@KeyEventDispatcher true
-                                    } catch (e: Exception) {
-                                        // Log but don't crash the event dispatcher
-                                        System.err.println("Error triggering global search: ${e.message}")
-                                    }
-                                }
-                            } else {
-                                // First shift press or timeout - start counting
-                                shiftPressCount = 1
-                                lastShiftPressTime = currentTime
-                            }
-                        }
-
-                        KeyEvent.KEY_RELEASED -> {
-                            // Record release time for detecting second press
-                            if (shiftPressCount == 1 && currentTime - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
-                                lastShiftReleaseTime = currentTime
-                            } else {
-                                // Too slow or wrong sequence - reset
-                                shiftPressCount = 0
-                            }
-                        }
-                    }
-                    return@KeyEventDispatcher false // Let shift events propagate
-                }
-
-                // Reset double-shift state if any other key is pressed
-                if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
-                    shiftPressCount = 0
-                    lastShiftPressTime = 0
-                    lastShiftReleaseTime = 0
-                }
-
-                // Commit an in-progress MRU tab cycle when its own cycling modifier is released.
-                // Only fires while a cycle is active and only for that specific modifier, so
-                // unrelated modifier keyups don't churn the UI thread or commit prematurely.
-                // The release itself is not consumed.
-                if (event.id == KeyEvent.KEY_RELEASED && tabCycleActive && event.keyCode == tabCycleModifierKeyCode) {
-                    tabCycleActive = false
-                    val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
-                    findWindowId(focusedWindow)?.let { MenuActionsHandler.triggerCommitTabCycle(it) }
-                    return@KeyEventDispatcher false
-                }
-
-                // Only intercept KEY_PRESSED events for other shortcuts
-                if (event.id != KeyEvent.KEY_PRESSED) {
-                    return@KeyEventDispatcher false
-                }
-
-                // Skip if no modifier keys are pressed (most shortcuts require modifiers)
-                if (!event.isMetaDown && !event.isControlDown && !event.isAltDown) {
-                    return@KeyEventDispatcher false
-                }
-
-                // Skip modifier-only key presses
-                if (isModifierOnlyKey(event.keyCode)) {
-                    return@KeyEventDispatcher false
-                }
-
-                // Get the focused window's BOSS window ID
-                val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
-                val windowId = findWindowId(focusedWindow) ?: return@KeyEventDispatcher false
-
-                // Try to match the key event against shortcuts
-                val match = findMatchingBinding(event)
-                val binding = match?.binding
-
-                if (binding != null) {
-                    // Dispatch the action through MenuActionsHandler
-                    val handled = dispatchAction(binding.actionId, windowId)
-                    if (!handled) {
-                        // A host binding matched but has no dispatch case here, because the
-                        // chord is served further down or by nothing at all. QUICK_SWITCHER_OPEN
-                        // (Ctrl+Space) and TEST_EXTERNAL_LINK (Cmd+Shift+G) are the two that
-                        // reach this today, and every EDITOR_* binding would join them if
-                        // updateWindowContext were ever wired up.
-                        //
-                        // NOT the EDITOR bindings today: detectCurrentContext can only answer
-                        // BROWSER, TERMINAL or GLOBAL, so isContextEligible drops an
-                        // EDITOR-context binding in findMatchingBinding and it never gets here.
-                        // EDITOR_GO_TO_LINE (Cmd+L) is therefore kept safe from a plugin GLOBAL
-                        // default by the fluck browser not registering one, not by this branch.
-                        //
-                        // Return rather than fall through to the plugin-default pass below. That
-                        // pass is documented as running only when NO host binding matched, and
-                        // letting an undispatched host binding fall into it inverts the rule:
-                        // whichever plugin registered the same chord as a GLOBAL default would
-                        // shadow the host binding AND consume the event (a plugin's onAction
-                        // returns Unit, so PluginShortcutRegistryImpl.dispatch reports success
-                        // for any registered action), leaving the real handler with nothing.
-                        return@KeyEventDispatcher false
-                    }
-
-                    // Begin (or continue) an MRU tab cycle: remember which modifier is
-                    // sustaining it so its release - and only its release - commits the cycle.
-                    // This arms even when the focused panel has <=1 tab (the component-side
-                    // switchTab/commit then no-op), so the interceptor may briefly believe a
-                    // cycle is active when none is - harmless, and Tab stays swallowed.
-                    if ((binding.actionId == KeymapActions.TAB_NEXT || binding.actionId == KeymapActions.TAB_PREVIOUS) &&
-                        KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU
-                    ) {
-                        tabCycleActive = true
-                        // From the keystroke that MATCHED, not the binding's primary: an
-                        // alternate can carry the other primary modifier, and arming on Meta
-                        // while the user holds Control means the release never commits. The
-                        // switcher overlay then stays on screen with Tab swallowed until some
-                        // unrelated modifier release happens to match.
-                        tabCycleModifierKeyCode = cyclingModifierKeyCode(match.keystroke)
-                    }
-                    // Consume the event to prevent it from reaching BossTerm
-                    event.consume()
-                    return@KeyEventDispatcher true
-                }
-
-                // Plugin-contributed GLOBAL shortcuts (PluginShortcutRegistry).
-                // Host bindings always win — this pass only runs when no host
-                // binding matched. User rebinds live in the keymap settings under
-                // the plugin actionId (matched by the pass above); a spec's
-                // defaultBinding applies only while the keymap has no entry for
-                // that actionId.
-                val pluginActionId = findMatchingPluginDefault(event)
-                if (pluginActionId != null) {
-                    val handled = PluginShortcutRegistryImpl.dispatch(pluginActionId, windowId)
-                    if (handled) {
-                        event.consume()
-                        return@KeyEventDispatcher true
-                    }
-                }
-
-                false // Let event propagate normally
-            }
-
+        dispatcher = KeyEventDispatcher { event -> processKeyEvent(event) }
         KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(dispatcher)
         isInstalled = true
+    }
+
+    /**
+     * Process an AWT KeyEvent for shortcut handling.
+     * Arms on KEY_PRESSED, executes on KEY_RELEASED of primary key.
+     */
+    internal fun processKeyEvent(event: KeyEvent): Boolean {
+        // Handle double-shift detection for global search
+        if (event.keyCode == KeyEvent.VK_SHIFT) {
+            val currentTime = System.currentTimeMillis()
+
+            when (event.id) {
+                KeyEvent.KEY_PRESSED -> {
+                    // Check if this is a quick second press after a clean release
+                    val timeSinceRelease = currentTime - lastShiftReleaseTime
+                    if (timeSinceRelease < DOUBLE_SHIFT_THRESHOLD_MS &&
+                        timeSinceRelease >= MIN_SHIFT_RELEASE_MS && // Ensure clean release (not held)
+                        shiftPressCount == 1
+                    ) {
+                        // Double-shift detected!
+                        shiftPressCount = 0
+                        lastShiftPressTime = 0
+                        lastShiftReleaseTime = 0
+
+                        // Get the focused window's BOSS window ID
+                        val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
+                        val windowId = findWindowId(focusedWindow)
+                        if (windowId != null) {
+                            try {
+                                MenuActionsHandler.triggerOpenGlobalSearch(windowId)
+                                event.consume()
+                                return true
+                            } catch (e: Exception) {
+                                // Log but don't crash the event dispatcher
+                                System.err.println("Error triggering global search: ${e.message}")
+                            }
+                        }
+                    } else {
+                        // First shift press or timeout - start counting
+                        shiftPressCount = 1
+                        lastShiftPressTime = currentTime
+                    }
+                }
+
+                KeyEvent.KEY_RELEASED -> {
+                    // Record release time for detecting second press
+                    if (shiftPressCount == 1 && currentTime - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
+                        lastShiftReleaseTime = currentTime
+                    } else {
+                        // Too slow or wrong sequence - reset
+                        shiftPressCount = 0
+                    }
+                }
+            }
+            return false // Let shift events propagate
+        }
+
+        // Reset double-shift state if any other key is pressed
+        if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
+            shiftPressCount = 0
+            lastShiftPressTime = 0
+            lastShiftReleaseTime = 0
+        }
+
+        // Commit an in-progress MRU tab cycle when its own cycling modifier is released.
+        // Only fires while a cycle is active and only for that specific modifier, so
+        // unrelated modifier keyups don't churn the UI thread or commit prematurely.
+        // The release itself is not consumed.
+        if (event.id == KeyEvent.KEY_RELEASED && tabCycleActive && event.keyCode == tabCycleModifierKeyCode) {
+            tabCycleActive = false
+            val focusedWindow = resolveWindow(event)
+            findWindowId(focusedWindow)?.let { MenuActionsHandler.triggerCommitTabCycle(it) }
+            return false
+        }
+
+        // Handle KEY_RELEASED for pending shortcuts
+        if (event.id == KeyEvent.KEY_RELEASED) {
+            val pending = pendingShortcut
+            if (pending != null) {
+                if (event.keyCode == pending.primaryKeyCode) {
+                    // Primary key released: invoke the bound action!
+                    pendingShortcut = null
+                    if (pending.isPluginShortcut) {
+                        val handled = PluginShortcutRegistryImpl.dispatch(pending.actionId, pending.windowId)
+                        if (handled) {
+                            event.consume()
+                            return true
+                        }
+                    } else {
+                        val handled = dispatchAction(pending.actionId, pending.windowId)
+                        if (handled) {
+                            val match = pending.tabCycleMatch
+                            if (match != null &&
+                                (match.binding.actionId == KeymapActions.TAB_NEXT || match.binding.actionId == KeymapActions.TAB_PREVIOUS) &&
+                                KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU
+                            ) {
+                                tabCycleActive = true
+                                tabCycleModifierKeyCode = cyclingModifierKeyCode(match.keystroke)
+                            }
+                            event.consume()
+                            return true
+                        }
+                    }
+                    return false
+                } else if (isModifierOnlyKey(event.keyCode)) {
+                    // Releasing a modifier by itself cancels the pending shortcut chord
+                    pendingShortcut = null
+                    return false
+                } else {
+                    // An unrelated key was released
+                    pendingShortcut = null
+                    return false
+                }
+            }
+            return false
+        }
+
+        // Only intercept KEY_PRESSED events for other shortcuts
+        if (event.id != KeyEvent.KEY_PRESSED) {
+            return false
+        }
+
+        // Skip if no modifier keys are pressed (most shortcuts require modifiers)
+        if (!event.isMetaDown && !event.isControlDown && !event.isAltDown) {
+            pendingShortcut = null
+            return false
+        }
+
+        // Skip modifier-only key presses
+        if (isModifierOnlyKey(event.keyCode)) {
+            return false
+        }
+
+        // Auto-repeat check: if this key is already pending, consume without re-triggering
+        val currentPending = pendingShortcut
+        if (currentPending != null && currentPending.primaryKeyCode == event.keyCode) {
+            event.consume()
+            return true
+        }
+
+        // Get the focused window's BOSS window ID
+        val focusedWindow = resolveWindow(event)
+        val windowId = findWindowId(focusedWindow) ?: return false
+
+        // Try to match the key event against shortcuts
+        val match = findMatchingBinding(event)
+        val binding = match?.binding
+
+        if (binding != null) {
+            if (!canDispatchAction(binding.actionId, windowId)) {
+                pendingShortcut = null
+                return false
+            }
+
+            // Arm the shortcut to trigger on key release and consume the key down event
+            pendingShortcut =
+                PendingShortcut(
+                    actionId = binding.actionId,
+                    windowId = windowId,
+                    primaryKeyCode = event.keyCode,
+                    isPluginShortcut = false,
+                    tabCycleMatch = match,
+                )
+            event.consume()
+            return true
+        }
+
+        // Plugin-contributed GLOBAL shortcuts (PluginShortcutRegistry).
+        val pluginActionId = findMatchingPluginDefault(event)
+        if (pluginActionId != null) {
+            pendingShortcut =
+                PendingShortcut(
+                    actionId = pluginActionId,
+                    windowId = windowId,
+                    primaryKeyCode = event.keyCode,
+                    isPluginShortcut = true,
+                    tabCycleMatch = null,
+                )
+            event.consume()
+            return true
+        }
+
+        pendingShortcut = null
+        return false // Let event propagate normally
     }
 
     /**
@@ -296,8 +349,19 @@ object AWTKeyboardInterceptor {
         }
         dispatcher = null
         isInstalled = false
+        clearPendingShortcut()
         windowIdMap.clear()
         windowContextMap.clear()
+    }
+
+    /**
+     * Resolve the target AWT window for a KeyEvent.
+     */
+    internal fun resolveWindow(event: KeyEvent): Window? {
+        val focused = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
+        if (focused != null) return focused
+        val comp = event.component ?: (event.source as? java.awt.Component)
+        return if (comp is Window) comp else comp?.let { javax.swing.SwingUtilities.getWindowAncestor(it) }
     }
 
     /**
@@ -351,14 +415,17 @@ object AWTKeyboardInterceptor {
      * 1. Explicit per-window context (set by Compose layer)
      * 2. AWT focus owner class hierarchy (fallback)
      */
-    private fun detectCurrentContext(windowId: String?): ShortcutContext {
+    private fun detectCurrentContext(windowId: String?, event: KeyEvent? = null): ShortcutContext {
         // Primary: explicit per-window context from Compose layer
         if (windowId != null) {
             windowContextMap[windowId]?.let { return it }
         }
 
         // Fallback: detect from AWT focus owner's class hierarchy
-        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
+        val focusOwner =
+            KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
+                ?: event?.component
+                ?: (event?.source as? java.awt.Component)
         return detectContextFromAwtComponent(focusOwner)
     }
 
@@ -420,9 +487,9 @@ object AWTKeyboardInterceptor {
         val settings = KeymapSettingsManager.currentSettings.value
 
         // Detect current context for filtering
-        val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
+        val focusedWindow = resolveWindow(event)
         val windowId = findWindowId(focusedWindow)
-        val currentContext = detectCurrentContext(windowId)
+        val currentContext = detectCurrentContext(windowId, event)
 
         // Collect all matching bindings with their context priority
         var bestMatch: BindingMatch? = null
@@ -682,6 +749,61 @@ object AWTKeyboardInterceptor {
         trigger(windowId)
         return true
     }
+
+    /**
+     * Check whether [actionId] can currently be handled by [dispatchAction] for [windowId].
+     * Used during KEY_PRESSED to verify if the interceptor will claim the chord on release.
+     */
+    internal fun canDispatchAction(
+        actionId: String,
+        windowId: String,
+    ): Boolean =
+        when (actionId) {
+            KeymapActions.TAB_NEW,
+            KeymapActions.TAB_CLOSE,
+            KeymapActions.TAB_NEXT,
+            KeymapActions.TAB_PREVIOUS,
+            KeymapActions.WINDOW_NEW,
+            KeymapActions.WINDOW_CLOSE,
+            KeymapActions.BROWSER_ZOOM_IN,
+            KeymapActions.BROWSER_ZOOM_OUT,
+            KeymapActions.BROWSER_ZOOM_RESET,
+            KeymapActions.FOCUS_MODE_TOGGLE,
+            KeymapActions.CHROME_DENSITY_CYCLE,
+            KeymapActions.PANEL_SPLIT_VERTICAL,
+            KeymapActions.PANEL_SPLIT_HORIZONTAL,
+            KeymapActions.BROWSER_RELOAD,
+            KeymapActions.BROWSER_FIND,
+            KeymapActions.BROWSER_BACK,
+            KeymapActions.BROWSER_FORWARD,
+            KeymapActions.BROWSER_DEVTOOLS,
+            KeymapActions.CODEBASE_OPEN,
+            KeymapActions.GLOBAL_SEARCH_OPEN,
+            KeymapActions.SETTINGS_OPEN,
+            KeymapActions.WORKSPACE_SAVE,
+            KeymapActions.HELP_SHORTCUTS -> true
+
+            KeymapActions.TAB_REOPEN_CLOSED -> ClosedTabHistory.hasEntries(windowId)
+
+            KeymapActions.TAB_NEXT_POSITIONAL,
+            KeymapActions.TAB_PREVIOUS_POSITIONAL -> MenuActionsHandler.canStepTabs(windowId)
+
+            KeymapActions.TAB_SELECT_LAST -> MenuActionsHandler.activePanelTabCount(windowId) > 0
+
+            KeymapActions.PANEL_NAVIGATE_LEFT,
+            KeymapActions.PANEL_NAVIGATE_RIGHT,
+            KeymapActions.PANEL_NAVIGATE_UP,
+            KeymapActions.PANEL_NAVIGATE_DOWN -> (MenuActionsHandler.panelCountState.value[windowId] ?: 1) > 1
+
+            else -> {
+                val tabIndex = KeymapActions.TAB_SELECT_BY_INDEX.indexOf(actionId)
+                if (tabIndex >= 0) {
+                    MenuActionsHandler.activePanelTabCount(windowId) > tabIndex
+                } else {
+                    actionId.startsWith(PluginShortcutRegistryImpl.ACTION_ID_PREFIX)
+                }
+            }
+        }
 
     /**
      * Dispatch an action through MenuActionsHandler.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap
  * checks if they match registered shortcuts, and dispatches actions through
  * MenuActionsHandler if matched.
  */
+@Suppress("LargeClass")
 object AWTKeyboardInterceptor {
     private var isInstalled = false
     private var dispatcher: KeyEventDispatcher? = null
@@ -159,145 +160,137 @@ object AWTKeyboardInterceptor {
      * Process an AWT KeyEvent for shortcut handling.
      * Arms on KEY_PRESSED, executes on KEY_RELEASED of primary key.
      */
+    @Suppress("ReturnCount")
     internal fun processKeyEvent(event: KeyEvent): Boolean {
-        // Handle double-shift detection for global search
-        if (event.keyCode == KeyEvent.VK_SHIFT) {
-            val currentTime = System.currentTimeMillis()
+        if (handleDoubleShift(event)) return true
+        if (handleTabCycleRelease(event)) return false
+        if (event.id == KeyEvent.KEY_RELEASED) {
+            return handleKeyRelease(event)
+        }
+        if (event.id == KeyEvent.KEY_PRESSED) {
+            return handleKeyPress(event)
+        }
+        return false
+    }
 
-            when (event.id) {
-                KeyEvent.KEY_PRESSED -> {
-                    // Check if this is a quick second press after a clean release
-                    val timeSinceRelease = currentTime - lastShiftReleaseTime
-                    if (timeSinceRelease < DOUBLE_SHIFT_THRESHOLD_MS &&
-                        timeSinceRelease >= MIN_SHIFT_RELEASE_MS && // Ensure clean release (not held)
-                        shiftPressCount == 1
-                    ) {
-                        // Double-shift detected!
-                        shiftPressCount = 0
-                        lastShiftPressTime = 0
-                        lastShiftReleaseTime = 0
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "NestedBlockDepth")
+    private fun handleDoubleShift(event: KeyEvent): Boolean {
+        if (event.keyCode != KeyEvent.VK_SHIFT) {
+            if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
+                shiftPressCount = 0
+                lastShiftPressTime = 0
+                lastShiftReleaseTime = 0
+            }
+            return false
+        }
 
-                        // Get the focused window's BOSS window ID
-                        val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
-                        val windowId = findWindowId(focusedWindow)
-                        if (windowId != null) {
-                            try {
-                                MenuActionsHandler.triggerOpenGlobalSearch(windowId)
-                                event.consume()
-                                return true
-                            } catch (e: Exception) {
-                                // Log but don't crash the event dispatcher
-                                System.err.println("Error triggering global search: ${e.message}")
-                            }
+        val currentTime = System.currentTimeMillis()
+        when (event.id) {
+            KeyEvent.KEY_PRESSED -> {
+                val timeSinceRelease = currentTime - lastShiftReleaseTime
+                if (timeSinceRelease < DOUBLE_SHIFT_THRESHOLD_MS &&
+                    timeSinceRelease >= MIN_SHIFT_RELEASE_MS &&
+                    shiftPressCount == 1
+                ) {
+                    shiftPressCount = 0
+                    lastShiftPressTime = 0
+                    lastShiftReleaseTime = 0
+
+                    val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
+                    val windowId = findWindowId(focusedWindow)
+                    if (windowId != null) {
+                        try {
+                            MenuActionsHandler.triggerOpenGlobalSearch(windowId)
+                            event.consume()
+                            return true
+                        } catch (e: Exception) {
+                            System.err.println("Error triggering global search: ${e.message}")
                         }
-                    } else {
-                        // First shift press or timeout - start counting
-                        shiftPressCount = 1
-                        lastShiftPressTime = currentTime
                     }
-                }
-
-                KeyEvent.KEY_RELEASED -> {
-                    // Record release time for detecting second press
-                    if (shiftPressCount == 1 && currentTime - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
-                        lastShiftReleaseTime = currentTime
-                    } else {
-                        // Too slow or wrong sequence - reset
-                        shiftPressCount = 0
-                    }
+                } else {
+                    shiftPressCount = 1
+                    lastShiftPressTime = currentTime
                 }
             }
-            return false // Let shift events propagate
-        }
 
-        // Reset double-shift state if any other key is pressed
-        if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
-            shiftPressCount = 0
-            lastShiftPressTime = 0
-            lastShiftReleaseTime = 0
+            KeyEvent.KEY_RELEASED -> {
+                if (shiftPressCount == 1 && currentTime - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
+                    lastShiftReleaseTime = currentTime
+                } else {
+                    shiftPressCount = 0
+                }
+            }
         }
+        return false
+    }
 
-        // Commit an in-progress MRU tab cycle when its own cycling modifier is released.
-        // Only fires while a cycle is active and only for that specific modifier, so
-        // unrelated modifier keyups don't churn the UI thread or commit prematurely.
-        // The release itself is not consumed.
+    private fun handleTabCycleRelease(event: KeyEvent): Boolean {
         if (event.id == KeyEvent.KEY_RELEASED && tabCycleActive && event.keyCode == tabCycleModifierKeyCode) {
             tabCycleActive = false
             val focusedWindow = resolveWindow(event)
             findWindowId(focusedWindow)?.let { MenuActionsHandler.triggerCommitTabCycle(it) }
+            return true
+        }
+        return false
+    }
+
+    @Suppress("ReturnCount")
+    private fun handleKeyRelease(event: KeyEvent): Boolean {
+        val pending = pendingShortcut ?: return false
+        pendingShortcut = null
+
+        if (event.keyCode != pending.primaryKeyCode) {
             return false
         }
 
-        // Handle KEY_RELEASED for pending shortcuts
-        if (event.id == KeyEvent.KEY_RELEASED) {
-            val pending = pendingShortcut
-            if (pending != null) {
-                if (event.keyCode == pending.primaryKeyCode) {
-                    // Primary key released: invoke the bound action!
-                    pendingShortcut = null
-                    if (pending.isPluginShortcut) {
-                        val handled = PluginShortcutRegistryImpl.dispatch(pending.actionId, pending.windowId)
-                        if (handled) {
-                            event.consume()
-                            return true
-                        }
-                    } else {
-                        val handled = dispatchAction(pending.actionId, pending.windowId)
-                        if (handled) {
-                            val match = pending.tabCycleMatch
-                            if (match != null &&
-                                (match.binding.actionId == KeymapActions.TAB_NEXT || match.binding.actionId == KeymapActions.TAB_PREVIOUS) &&
-                                KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU
-                            ) {
-                                tabCycleActive = true
-                                tabCycleModifierKeyCode = cyclingModifierKeyCode(match.keystroke)
-                            }
-                            event.consume()
-                            return true
-                        }
-                    }
-                    return false
-                } else if (isModifierOnlyKey(event.keyCode)) {
-                    // Releasing a modifier by itself cancels the pending shortcut chord
-                    pendingShortcut = null
-                    return false
-                } else {
-                    // An unrelated key was released
-                    pendingShortcut = null
-                    return false
+        val handled =
+            if (pending.isPluginShortcut) {
+                PluginShortcutRegistryImpl.dispatch(pending.actionId, pending.windowId)
+            } else {
+                val actionHandled = dispatchAction(pending.actionId, pending.windowId)
+                if (actionHandled) {
+                    updateTabCycleOnDispatch(pending.tabCycleMatch)
                 }
+                actionHandled
             }
-            return false
-        }
 
-        // Only intercept KEY_PRESSED events for other shortcuts
-        if (event.id != KeyEvent.KEY_PRESSED) {
-            return false
+        if (handled) {
+            event.consume()
         }
+        return handled
+    }
 
-        // Skip if no modifier keys are pressed (most shortcuts require modifiers)
+    private fun updateTabCycleOnDispatch(match: BindingMatch?) {
+        if (match == null) return
+        val actionId = match.binding.actionId
+        val isTabSwitch = actionId == KeymapActions.TAB_NEXT || actionId == KeymapActions.TAB_PREVIOUS
+        val isMru = KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU
+        if (isTabSwitch && isMru) {
+            tabCycleActive = true
+            tabCycleModifierKeyCode = cyclingModifierKeyCode(match.keystroke)
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun handleKeyPress(event: KeyEvent): Boolean {
         if (!event.isMetaDown && !event.isControlDown && !event.isAltDown) {
             pendingShortcut = null
             return false
         }
 
-        // Skip modifier-only key presses
         if (isModifierOnlyKey(event.keyCode)) {
             return false
         }
 
-        // Auto-repeat check: if this key is already pending, consume without re-triggering
         val currentPending = pendingShortcut
         if (currentPending != null && currentPending.primaryKeyCode == event.keyCode) {
             event.consume()
             return true
         }
 
-        // Get the focused window's BOSS window ID
         val focusedWindow = resolveWindow(event)
         val windowId = findWindowId(focusedWindow) ?: return false
 
-        // Try to match the key event against shortcuts
         val match = findMatchingBinding(event)
         val binding = match?.binding
 
@@ -307,7 +300,6 @@ object AWTKeyboardInterceptor {
                 return false
             }
 
-            // Arm the shortcut to trigger on key release and consume the key down event
             pendingShortcut =
                 PendingShortcut(
                     actionId = binding.actionId,
@@ -320,7 +312,6 @@ object AWTKeyboardInterceptor {
             return true
         }
 
-        // Plugin-contributed GLOBAL shortcuts (PluginShortcutRegistry).
         val pluginActionId = findMatchingPluginDefault(event)
         if (pluginActionId != null) {
             pendingShortcut =
@@ -336,7 +327,7 @@ object AWTKeyboardInterceptor {
         }
 
         pendingShortcut = null
-        return false // Let event propagate normally
+        return false
     }
 
     /**
@@ -415,7 +406,10 @@ object AWTKeyboardInterceptor {
      * 1. Explicit per-window context (set by Compose layer)
      * 2. AWT focus owner class hierarchy (fallback)
      */
-    private fun detectCurrentContext(windowId: String?, event: KeyEvent? = null): ShortcutContext {
+    private fun detectCurrentContext(
+        windowId: String?,
+        event: KeyEvent? = null,
+    ): ShortcutContext {
         // Primary: explicit per-window context from Compose layer
         if (windowId != null) {
             windowContextMap[windowId]?.let { return it }
@@ -781,19 +775,32 @@ object AWTKeyboardInterceptor {
             KeymapActions.GLOBAL_SEARCH_OPEN,
             KeymapActions.SETTINGS_OPEN,
             KeymapActions.WORKSPACE_SAVE,
-            KeymapActions.HELP_SHORTCUTS -> true
+            KeymapActions.HELP_SHORTCUTS,
+            -> {
+                true
+            }
 
-            KeymapActions.TAB_REOPEN_CLOSED -> ClosedTabHistory.hasEntries(windowId)
+            KeymapActions.TAB_REOPEN_CLOSED -> {
+                ClosedTabHistory.hasEntries(windowId)
+            }
 
             KeymapActions.TAB_NEXT_POSITIONAL,
-            KeymapActions.TAB_PREVIOUS_POSITIONAL -> MenuActionsHandler.canStepTabs(windowId)
+            KeymapActions.TAB_PREVIOUS_POSITIONAL,
+            -> {
+                MenuActionsHandler.canStepTabs(windowId)
+            }
 
-            KeymapActions.TAB_SELECT_LAST -> MenuActionsHandler.activePanelTabCount(windowId) > 0
+            KeymapActions.TAB_SELECT_LAST -> {
+                MenuActionsHandler.activePanelTabCount(windowId) > 0
+            }
 
             KeymapActions.PANEL_NAVIGATE_LEFT,
             KeymapActions.PANEL_NAVIGATE_RIGHT,
             KeymapActions.PANEL_NAVIGATE_UP,
-            KeymapActions.PANEL_NAVIGATE_DOWN -> (MenuActionsHandler.panelCountState.value[windowId] ?: 1) > 1
+            KeymapActions.PANEL_NAVIGATE_DOWN,
+            -> {
+                (MenuActionsHandler.panelCountState.value[windowId] ?: 1) > 1
+            }
 
             else -> {
                 val tabIndex = KeymapActions.TAB_SELECT_BY_INDEX.indexOf(actionId)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -64,29 +64,32 @@ object AWTKeyboardInterceptor {
     private const val MIN_SHIFT_RELEASE_MS = 50
 
     /**
-     * Pending shortcut chord armed on KEY_PRESSED awaiting primary key release on KEY_RELEASED.
+     * A shortcut chord recognized on KEY_PRESSED and held until its primary key's matching
+     * KEY_RELEASED fires it - BossConsole#490: an action must not run while its keys are
+     * still held, and must not re-fire on OS auto-repeat KEY_PRESSED events.
+     *
+     * Exactly one of [hostBinding] / [pluginActionId] is set. A host binding can be probed
+     * (see [dispatchAction]'s `perform` parameter) before arming, so [handleKeyPressed] only
+     * arms one that would actually dispatch. [PluginShortcutRegistryImpl.dispatch] has no
+     * side-effect-free equivalent, so a plugin default arms on chord match alone and is
+     * confirmed for real at release time in [handleKeyReleased].
      */
     internal data class PendingShortcut(
-        val actionId: String,
+        val keyCode: Int,
         val windowId: String,
-        val primaryKeyCode: Int,
-        val isPluginShortcut: Boolean = false,
-        val tabCycleMatch: BindingMatch? = null,
+        val hostBinding: BindingMatch? = null,
+        val pluginActionId: String? = null,
     )
 
-    private var pendingShortcut: PendingShortcut? = null
+    // The shortcut armed on a currently-held key, or null. Process-global like the double-
+    // shift and tab-cycle state above, for the same reason: a chord armed in one window and
+    // released after focus moved elsewhere is a narrow, harmless mismatch, not a leak - the
+    // stray release just finds nothing to fire. Accessed only from the AWT event dispatch
+    // thread and the focus-loss listener installed alongside the dispatcher, both of which
+    // run there.
+    internal var pendingShortcut: PendingShortcut? = null
 
-    /**
-     * Check if a shortcut chord is currently pending release.
-     */
-    internal fun hasPendingShortcut(): Boolean = pendingShortcut != null
-
-    /**
-     * Clear any pending shortcut state (e.g. on focus loss, window unregister, or cancellation).
-     */
-    fun clearPendingShortcut() {
-        pendingShortcut = null
-    }
+    private var focusListener: java.beans.PropertyChangeListener? = null
 
     /**
      * Register an AWT window with its BOSS window ID.
@@ -104,7 +107,6 @@ object AWTKeyboardInterceptor {
      * Call this from BossWindow's DisposableEffect onDispose.
      */
     fun unregisterWindow(awtWindow: Window) {
-        clearPendingShortcut()
         val windowId = windowIdMap.remove(awtWindow)
         if (windowId != null) {
             windowContextMap.remove(windowId)
@@ -150,193 +152,110 @@ object AWTKeyboardInterceptor {
     fun install() {
         if (isInstalled) return
 
-        dispatcher = KeyEventDispatcher { event -> processKeyEvent(event) }
-        KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(dispatcher)
-        isInstalled = true
-    }
+        dispatcher =
+            KeyEventDispatcher { event ->
+                // Handle double-shift detection for global search
+                if (event.keyCode == KeyEvent.VK_SHIFT) {
+                    val currentTime = System.currentTimeMillis()
 
-    /**
-     * Process an AWT KeyEvent for shortcut handling.
-     * Arms on KEY_PRESSED, executes on KEY_RELEASED of primary key.
-     */
-    internal fun processKeyEvent(event: KeyEvent): Boolean {
-        // Handle double-shift detection for global search
-        if (event.keyCode == KeyEvent.VK_SHIFT) {
-            val currentTime = System.currentTimeMillis()
+                    when (event.id) {
+                        KeyEvent.KEY_PRESSED -> {
+                            // Check if this is a quick second press after a clean release
+                            val timeSinceRelease = currentTime - lastShiftReleaseTime
+                            if (timeSinceRelease < DOUBLE_SHIFT_THRESHOLD_MS &&
+                                timeSinceRelease >= MIN_SHIFT_RELEASE_MS && // Ensure clean release (not held)
+                                shiftPressCount == 1
+                            ) {
+                                // Double-shift detected!
+                                shiftPressCount = 0
+                                lastShiftPressTime = 0
+                                lastShiftReleaseTime = 0
 
-            when (event.id) {
-                KeyEvent.KEY_PRESSED -> {
-                    // Check if this is a quick second press after a clean release
-                    val timeSinceRelease = currentTime - lastShiftReleaseTime
-                    if (timeSinceRelease < DOUBLE_SHIFT_THRESHOLD_MS &&
-                        timeSinceRelease >= MIN_SHIFT_RELEASE_MS && // Ensure clean release (not held)
-                        shiftPressCount == 1
-                    ) {
-                        // Double-shift detected!
-                        shiftPressCount = 0
-                        lastShiftPressTime = 0
-                        lastShiftReleaseTime = 0
+                                // Get the focused window's BOSS window ID
+                                val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
+                                val windowId = findWindowId(focusedWindow)
+                                if (windowId != null) {
+                                    try {
+                                        MenuActionsHandler.triggerOpenGlobalSearch(windowId)
+                                        event.consume()
+                                        return@KeyEventDispatcher true
+                                    } catch (e: Exception) {
+                                        // Log but don't crash the event dispatcher
+                                        System.err.println("Error triggering global search: ${e.message}")
+                                    }
+                                }
+                            } else {
+                                // First shift press or timeout - start counting
+                                shiftPressCount = 1
+                                lastShiftPressTime = currentTime
+                            }
+                        }
 
-                        // Get the focused window's BOSS window ID
+                        KeyEvent.KEY_RELEASED -> {
+                            // Record release time for detecting second press
+                            if (shiftPressCount == 1 && currentTime - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
+                                lastShiftReleaseTime = currentTime
+                            } else {
+                                // Too slow or wrong sequence - reset
+                                shiftPressCount = 0
+                            }
+                        }
+                    }
+                    return@KeyEventDispatcher false // Let shift events propagate
+                }
+
+                // Reset double-shift state if any other key is pressed
+                if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
+                    shiftPressCount = 0
+                    lastShiftPressTime = 0
+                    lastShiftReleaseTime = 0
+                }
+
+                // Commit an in-progress MRU tab cycle when its own cycling modifier is released.
+                // Only fires while a cycle is active and only for that specific modifier, so
+                // unrelated modifier keyups don't churn the UI thread or commit prematurely.
+                // The release itself is not consumed.
+                if (event.id == KeyEvent.KEY_RELEASED && tabCycleActive && event.keyCode == tabCycleModifierKeyCode) {
+                    tabCycleActive = false
+                    val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
+                    findWindowId(focusedWindow)?.let { MenuActionsHandler.triggerCommitTabCycle(it) }
+                    return@KeyEventDispatcher false
+                }
+
+                // Only shortcuts from here on, and only these two event kinds.
+                if (event.id != KeyEvent.KEY_PRESSED && event.id != KeyEvent.KEY_RELEASED) {
+                    return@KeyEventDispatcher false
+                }
+
+                val handled =
+                    if (event.id == KeyEvent.KEY_RELEASED) {
+                        // Uses the windowId captured when the chord was armed, not whatever is
+                        // focused now - if focus moved, the listener below already cleared
+                        // pendingShortcut and this finds nothing to fire.
+                        handleKeyReleased(event)
+                    } else {
                         val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
                         val windowId = findWindowId(focusedWindow)
-                        if (windowId != null) {
-                            try {
-                                MenuActionsHandler.triggerOpenGlobalSearch(windowId)
-                                event.consume()
-                                return true
-                            } catch (e: Exception) {
-                                // Log but don't crash the event dispatcher
-                                System.err.println("Error triggering global search: ${e.message}")
-                            }
-                        }
-                    } else {
-                        // First shift press or timeout - start counting
-                        shiftPressCount = 1
-                        lastShiftPressTime = currentTime
+                        windowId != null && handleKeyPressed(event, windowId)
                     }
+
+                if (handled) {
+                    // Consume the event to prevent it from reaching BossTerm
+                    event.consume()
                 }
-
-                KeyEvent.KEY_RELEASED -> {
-                    // Record release time for detecting second press
-                    if (shiftPressCount == 1 && currentTime - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
-                        lastShiftReleaseTime = currentTime
-                    } else {
-                        // Too slow or wrong sequence - reset
-                        shiftPressCount = 0
-                    }
-                }
-            }
-            return false // Let shift events propagate
-        }
-
-        // Reset double-shift state if any other key is pressed
-        if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
-            shiftPressCount = 0
-            lastShiftPressTime = 0
-            lastShiftReleaseTime = 0
-        }
-
-        // Commit an in-progress MRU tab cycle when its own cycling modifier is released.
-        // Only fires while a cycle is active and only for that specific modifier, so
-        // unrelated modifier keyups don't churn the UI thread or commit prematurely.
-        // The release itself is not consumed.
-        if (event.id == KeyEvent.KEY_RELEASED && tabCycleActive && event.keyCode == tabCycleModifierKeyCode) {
-            tabCycleActive = false
-            val focusedWindow = resolveWindow(event)
-            findWindowId(focusedWindow)?.let { MenuActionsHandler.triggerCommitTabCycle(it) }
-            return false
-        }
-
-        // Handle KEY_RELEASED for pending shortcuts
-        if (event.id == KeyEvent.KEY_RELEASED) {
-            val pending = pendingShortcut
-            if (pending != null) {
-                if (event.keyCode == pending.primaryKeyCode) {
-                    // Primary key released: invoke the bound action!
-                    pendingShortcut = null
-                    if (pending.isPluginShortcut) {
-                        val handled = PluginShortcutRegistryImpl.dispatch(pending.actionId, pending.windowId)
-                        if (handled) {
-                            event.consume()
-                            return true
-                        }
-                    } else {
-                        val handled = dispatchAction(pending.actionId, pending.windowId)
-                        if (handled) {
-                            val match = pending.tabCycleMatch
-                            if (match != null &&
-                                (match.binding.actionId == KeymapActions.TAB_NEXT || match.binding.actionId == KeymapActions.TAB_PREVIOUS) &&
-                                KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU
-                            ) {
-                                tabCycleActive = true
-                                tabCycleModifierKeyCode = cyclingModifierKeyCode(match.keystroke)
-                            }
-                            event.consume()
-                            return true
-                        }
-                    }
-                    return false
-                } else if (isModifierOnlyKey(event.keyCode)) {
-                    // Releasing a modifier by itself cancels the pending shortcut chord
-                    pendingShortcut = null
-                    return false
-                } else {
-                    // An unrelated key was released
-                    pendingShortcut = null
-                    return false
-                }
-            }
-            return false
-        }
-
-        // Only intercept KEY_PRESSED events for other shortcuts
-        if (event.id != KeyEvent.KEY_PRESSED) {
-            return false
-        }
-
-        // Skip if no modifier keys are pressed (most shortcuts require modifiers)
-        if (!event.isMetaDown && !event.isControlDown && !event.isAltDown) {
-            pendingShortcut = null
-            return false
-        }
-
-        // Skip modifier-only key presses
-        if (isModifierOnlyKey(event.keyCode)) {
-            return false
-        }
-
-        // Auto-repeat check: if this key is already pending, consume without re-triggering
-        val currentPending = pendingShortcut
-        if (currentPending != null && currentPending.primaryKeyCode == event.keyCode) {
-            event.consume()
-            return true
-        }
-
-        // Get the focused window's BOSS window ID
-        val focusedWindow = resolveWindow(event)
-        val windowId = findWindowId(focusedWindow) ?: return false
-
-        // Try to match the key event against shortcuts
-        val match = findMatchingBinding(event)
-        val binding = match?.binding
-
-        if (binding != null) {
-            if (!canDispatchAction(binding.actionId, windowId)) {
-                pendingShortcut = null
-                return false
+                handled
             }
 
-            // Arm the shortcut to trigger on key release and consume the key down event
-            pendingShortcut =
-                PendingShortcut(
-                    actionId = binding.actionId,
-                    windowId = windowId,
-                    primaryKeyCode = event.keyCode,
-                    isPluginShortcut = false,
-                    tabCycleMatch = match,
-                )
-            event.consume()
-            return true
-        }
-
-        // Plugin-contributed GLOBAL shortcuts (PluginShortcutRegistry).
-        val pluginActionId = findMatchingPluginDefault(event)
-        if (pluginActionId != null) {
-            pendingShortcut =
-                PendingShortcut(
-                    actionId = pluginActionId,
-                    windowId = windowId,
-                    primaryKeyCode = event.keyCode,
-                    isPluginShortcut = true,
-                    tabCycleMatch = null,
-                )
-            event.consume()
-            return true
-        }
-
-        pendingShortcut = null
-        return false // Let event propagate normally
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(dispatcher)
+        focusListener =
+            java.beans.PropertyChangeListener {
+                // Focus moved (another window, another app, or none) while a chord was held:
+                // BossConsole#490 requires this to drop any pending shortcut rather than fire
+                // it, or leave it armed, for whichever key happens to release next.
+                cancelPendingShortcut()
+            }
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().addPropertyChangeListener("focusedWindow", focusListener)
+        isInstalled = true
     }
 
     /**
@@ -348,20 +267,156 @@ object AWTKeyboardInterceptor {
             KeyboardFocusManager.getCurrentKeyboardFocusManager().removeKeyEventDispatcher(d)
         }
         dispatcher = null
+        focusListener?.let { l ->
+            KeyboardFocusManager.getCurrentKeyboardFocusManager().removePropertyChangeListener("focusedWindow", l)
+        }
+        focusListener = null
         isInstalled = false
-        clearPendingShortcut()
         windowIdMap.clear()
         windowContextMap.clear()
+        cancelPendingShortcut()
     }
 
     /**
-     * Resolve the target AWT window for a KeyEvent.
+     * Recognize a shortcut chord on KEY_PRESSED and arm it - never invokes anything;
+     * BossConsole#490 requires the bound action to fire only on the matching key-up, which
+     * [handleKeyReleased] does. Returns whether the press should be consumed (kept from the
+     * focused component, e.g. BossTerm).
+     *
+     * `internal` - not just to let [install]'s dispatcher reach it - so a test can drive
+     * KEY_PRESSED handling with a synthetic AWT event and an explicit windowId, without
+     * registering a real AWT [Window].
      */
-    internal fun resolveWindow(event: KeyEvent): Window? {
-        val focused = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
-        if (focused != null) return focused
-        val comp = event.component ?: (event.source as? java.awt.Component)
-        return if (comp is Window) comp else comp?.let { javax.swing.SwingUtilities.getWindowAncestor(it) }
+    internal fun handleKeyPressed(
+        event: KeyEvent,
+        windowId: String,
+    ): Boolean {
+        // A repeat KEY_PRESSED for the primary key already armed: keep claiming it (so it
+        // doesn't leak to the focused component while held) without re-matching, re-arming,
+        // or invoking anything a second time. This is what stops OS auto-repeat from firing
+        // the action over and over - the actual fire happens once, in handleKeyReleased.
+        pendingShortcut?.let { armed ->
+            if (event.keyCode == armed.keyCode) return true
+        }
+
+        // Skip if no modifier keys are pressed (most shortcuts require modifiers)
+        if (!event.isMetaDown && !event.isControlDown && !event.isAltDown) {
+            return false
+        }
+
+        // Skip modifier-only key presses
+        if (isModifierOnlyKey(event.keyCode)) {
+            return false
+        }
+
+        // Try to match the key event against shortcuts
+        val match = findMatchingBinding(event)
+        val binding = match?.binding
+
+        if (binding != null) {
+            // Probe only (perform = false): decide claimed-vs-not with the SAME gate
+            // handleKeyReleased will use to actually fire, evaluated now so the press-time
+            // claim decision matches this interceptor's pre-#490 timing. A narrow race exists
+            // if the gate's answer changes between this probe and the eventual fire (e.g. the
+            // last other panel closes while the chord is held) - accepted, since the
+            // alternative is a second predicate mirroring dispatchAction's `when` that could
+            // drift from it, which is exactly the kind of duplication this codebase avoids
+            // elsewhere (see AGENTS.md on blockingDependentsOf).
+            val wouldHandle = dispatchAction(binding.actionId, windowId, perform = false)
+            if (!wouldHandle) {
+                // A host binding matched but has no dispatch case here, because the chord is
+                // served further down or by nothing at all. QUICK_SWITCHER_OPEN (Ctrl+Space)
+                // and TEST_EXTERNAL_LINK (Cmd+Shift+G) are the two that reach this today, and
+                // every EDITOR_* binding would join them if updateWindowContext were ever
+                // wired up.
+                //
+                // NOT the EDITOR bindings today: detectCurrentContext can only answer
+                // BROWSER, TERMINAL or GLOBAL, so isContextEligible drops an EDITOR-context
+                // binding in findMatchingBinding and it never gets here. EDITOR_GO_TO_LINE
+                // (Cmd+L) is therefore kept safe from a plugin GLOBAL default by the fluck
+                // browser not registering one, not by this branch.
+                //
+                // Return rather than fall through to the plugin-default pass below. That pass
+                // is documented as running only when NO host binding matched, and letting an
+                // undispatched host binding fall into it inverts the rule: whichever plugin
+                // registered the same chord as a GLOBAL default would shadow the host binding
+                // AND consume the event (a plugin's onAction returns Unit, so
+                // PluginShortcutRegistryImpl.dispatch reports success for any registered
+                // action), leaving the real handler with nothing.
+                return false
+            }
+
+            pendingShortcut = PendingShortcut(keyCode = event.keyCode, windowId = windowId, hostBinding = match)
+            return true
+        }
+
+        // Plugin-contributed GLOBAL shortcuts (PluginShortcutRegistry).
+        // Host bindings always win — this pass only runs when no host
+        // binding matched. User rebinds live in the keymap settings under
+        // the plugin actionId (matched by the pass above); a spec's
+        // defaultBinding applies only while the keymap has no entry for
+        // that actionId.
+        val pluginActionId = findMatchingPluginDefault(event)
+        if (pluginActionId != null) {
+            // No side-effect-free way to ask PluginShortcutRegistryImpl "would you handle
+            // this" without actually dispatching, so this arms on chord match alone and is
+            // confirmed for real at key-up in handleKeyReleased.
+            pendingShortcut =
+                PendingShortcut(keyCode = event.keyCode, windowId = windowId, pluginActionId = pluginActionId)
+            return true
+        }
+
+        return false
+    }
+
+    /**
+     * Fire an armed shortcut when its primary key is released - the only place a
+     * BossConsole#490 shortcut actually invokes anything. Returns whether the release should
+     * be consumed.
+     *
+     * A released key that doesn't match [pendingShortcut] - including a modifier released by
+     * itself, since a modifier can never BE [PendingShortcut.keyCode] - invokes nothing and
+     * is not consumed.
+     */
+    internal fun handleKeyReleased(event: KeyEvent): Boolean {
+        val pending = pendingShortcut ?: return false
+        if (event.keyCode != pending.keyCode) return false
+        pendingShortcut = null
+
+        return if (pending.pluginActionId != null) {
+            PluginShortcutRegistryImpl.dispatch(pending.pluginActionId, pending.windowId)
+        } else {
+            val binding = pending.hostBinding!!.binding
+            val handled = dispatchAction(binding.actionId, pending.windowId, perform = true)
+
+            // Begin (or continue) an MRU tab cycle: remember which modifier is sustaining it
+            // so its release - and only its release - commits the cycle. This arms even when
+            // the focused panel has <=1 tab (the component-side switchTab/commit then no-op),
+            // so the interceptor may briefly believe a cycle is active when none is -
+            // harmless, and Tab stays swallowed.
+            if (handled &&
+                (binding.actionId == KeymapActions.TAB_NEXT || binding.actionId == KeymapActions.TAB_PREVIOUS) &&
+                KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU
+            ) {
+                tabCycleActive = true
+                // From the keystroke that MATCHED, not the binding's primary: an alternate can
+                // carry the other primary modifier, and arming on Meta while the user holds
+                // Control means the release never commits. The switcher overlay then stays on
+                // screen with Tab swallowed until some unrelated modifier release happens to
+                // match.
+                tabCycleModifierKeyCode = cyclingModifierKeyCode(pending.hostBinding.keystroke)
+            }
+            handled
+        }
+    }
+
+    /**
+     * Clear any shortcut armed on KEY_PRESSED but not yet fired - BossConsole#490's
+     * cancellation requirement. Called on focus loss (the listener [install] registers) and
+     * on [uninstall]; safe to call when nothing is pending.
+     */
+    internal fun cancelPendingShortcut() {
+        pendingShortcut = null
     }
 
     /**
@@ -415,17 +470,14 @@ object AWTKeyboardInterceptor {
      * 1. Explicit per-window context (set by Compose layer)
      * 2. AWT focus owner class hierarchy (fallback)
      */
-    private fun detectCurrentContext(windowId: String?, event: KeyEvent? = null): ShortcutContext {
+    private fun detectCurrentContext(windowId: String?): ShortcutContext {
         // Primary: explicit per-window context from Compose layer
         if (windowId != null) {
             windowContextMap[windowId]?.let { return it }
         }
 
         // Fallback: detect from AWT focus owner's class hierarchy
-        val focusOwner =
-            KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
-                ?: event?.component
-                ?: (event?.source as? java.awt.Component)
+        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
         return detectContextFromAwtComponent(focusOwner)
     }
 
@@ -487,9 +539,9 @@ object AWTKeyboardInterceptor {
         val settings = KeymapSettingsManager.currentSettings.value
 
         // Detect current context for filtering
-        val focusedWindow = resolveWindow(event)
+        val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
         val windowId = findWindowId(focusedWindow)
-        val currentContext = detectCurrentContext(windowId, event)
+        val currentContext = detectCurrentContext(windowId)
 
         // Collect all matching bindings with their context priority
         var bestMatch: BindingMatch? = null
@@ -704,13 +756,18 @@ object AWTKeyboardInterceptor {
     /**
      * Run [trigger] and claim the event, but only while [windowId]'s active panel has more than
      * one tab. Returning false leaves the chord to the focused component.
+     *
+     * [perform] gates only [trigger] - the gate check above it always runs, so a `perform =
+     * false` probe (see [dispatchAction]) answers "would this claim the chord" without the
+     * side effect.
      */
     internal fun dispatchIfCanStepTabs(
         windowId: String,
+        perform: Boolean = true,
         trigger: (String) -> Unit,
     ): Boolean {
         if (!MenuActionsHandler.canStepTabs(windowId)) return false
-        trigger(windowId)
+        if (perform) trigger(windowId)
         return true
     }
 
@@ -727,10 +784,11 @@ object AWTKeyboardInterceptor {
     internal fun dispatchIfTabExistsAt(
         windowId: String,
         index: Int,
+        perform: Boolean = true,
         trigger: (String) -> Unit,
     ): Boolean {
         if (MenuActionsHandler.activePanelTabCount(windowId) <= index) return false
-        trigger(windowId)
+        if (perform) trigger(windowId)
         return true
     }
 
@@ -742,68 +800,14 @@ object AWTKeyboardInterceptor {
      */
     internal fun dispatchIfMultiPanel(
         windowId: String,
+        perform: Boolean = true,
         trigger: (String) -> Unit,
     ): Boolean {
         val panelCount = MenuActionsHandler.panelCountState.value[windowId] ?: 1
         if (panelCount <= 1) return false
-        trigger(windowId)
+        if (perform) trigger(windowId)
         return true
     }
-
-    /**
-     * Check whether [actionId] can currently be handled by [dispatchAction] for [windowId].
-     * Used during KEY_PRESSED to verify if the interceptor will claim the chord on release.
-     */
-    internal fun canDispatchAction(
-        actionId: String,
-        windowId: String,
-    ): Boolean =
-        when (actionId) {
-            KeymapActions.TAB_NEW,
-            KeymapActions.TAB_CLOSE,
-            KeymapActions.TAB_NEXT,
-            KeymapActions.TAB_PREVIOUS,
-            KeymapActions.WINDOW_NEW,
-            KeymapActions.WINDOW_CLOSE,
-            KeymapActions.BROWSER_ZOOM_IN,
-            KeymapActions.BROWSER_ZOOM_OUT,
-            KeymapActions.BROWSER_ZOOM_RESET,
-            KeymapActions.FOCUS_MODE_TOGGLE,
-            KeymapActions.CHROME_DENSITY_CYCLE,
-            KeymapActions.PANEL_SPLIT_VERTICAL,
-            KeymapActions.PANEL_SPLIT_HORIZONTAL,
-            KeymapActions.BROWSER_RELOAD,
-            KeymapActions.BROWSER_FIND,
-            KeymapActions.BROWSER_BACK,
-            KeymapActions.BROWSER_FORWARD,
-            KeymapActions.BROWSER_DEVTOOLS,
-            KeymapActions.CODEBASE_OPEN,
-            KeymapActions.GLOBAL_SEARCH_OPEN,
-            KeymapActions.SETTINGS_OPEN,
-            KeymapActions.WORKSPACE_SAVE,
-            KeymapActions.HELP_SHORTCUTS -> true
-
-            KeymapActions.TAB_REOPEN_CLOSED -> ClosedTabHistory.hasEntries(windowId)
-
-            KeymapActions.TAB_NEXT_POSITIONAL,
-            KeymapActions.TAB_PREVIOUS_POSITIONAL -> MenuActionsHandler.canStepTabs(windowId)
-
-            KeymapActions.TAB_SELECT_LAST -> MenuActionsHandler.activePanelTabCount(windowId) > 0
-
-            KeymapActions.PANEL_NAVIGATE_LEFT,
-            KeymapActions.PANEL_NAVIGATE_RIGHT,
-            KeymapActions.PANEL_NAVIGATE_UP,
-            KeymapActions.PANEL_NAVIGATE_DOWN -> (MenuActionsHandler.panelCountState.value[windowId] ?: 1) > 1
-
-            else -> {
-                val tabIndex = KeymapActions.TAB_SELECT_BY_INDEX.indexOf(actionId)
-                if (tabIndex >= 0) {
-                    MenuActionsHandler.activePanelTabCount(windowId) > tabIndex
-                } else {
-                    actionId.startsWith(PluginShortcutRegistryImpl.ACTION_ID_PREFIX)
-                }
-            }
-        }
 
     /**
      * Dispatch an action through MenuActionsHandler.
@@ -812,30 +816,38 @@ object AWTKeyboardInterceptor {
      * Internal rather than private so desktopTest can assert which actions the interceptor
      * claims: returning false is load-bearing, because it is what leaves a chord to the
      * component that really serves it.
+     *
+     * [perform] defaults to true (dispatch for real - every existing caller's behaviour is
+     * unchanged). [handleKeyPressed] calls this once with `perform = false` to probe whether a
+     * host binding WOULD dispatch, without the side effect, so it can decide whether to arm a
+     * [PendingShortcut] for [handleKeyReleased] to actually fire later - see BossConsole#490.
+     * A gate (a `dispatchIf*` helper, or [ClosedTabHistory.hasEntries] below) always still
+     * runs; `perform` only gates the trigger itself.
      */
     internal fun dispatchAction(
         actionId: String,
         windowId: String,
+        perform: Boolean = true,
     ): Boolean =
         when (actionId) {
             // Tab Management
             KeymapActions.TAB_NEW -> {
-                MenuActionsHandler.triggerNewTab(windowId)
+                if (perform) MenuActionsHandler.triggerNewTab(windowId)
                 true
             }
 
             KeymapActions.TAB_CLOSE -> {
-                MenuActionsHandler.triggerCloseTab(windowId)
+                if (perform) MenuActionsHandler.triggerCloseTab(windowId)
                 true
             }
 
             KeymapActions.TAB_NEXT -> {
-                MenuActionsHandler.triggerNextTab(windowId)
+                if (perform) MenuActionsHandler.triggerNextTab(windowId)
                 true
             }
 
             KeymapActions.TAB_PREVIOUS -> {
-                MenuActionsHandler.triggerPreviousTab(windowId)
+                if (perform) MenuActionsHandler.triggerPreviousTab(windowId)
                 true
             }
 
@@ -846,7 +858,7 @@ object AWTKeyboardInterceptor {
                 if (!ClosedTabHistory.hasEntries(windowId)) {
                     false
                 } else {
-                    MenuActionsHandler.triggerReopenClosedTab(windowId)
+                    if (perform) MenuActionsHandler.triggerReopenClosedTab(windowId)
                     true
                 }
             }
@@ -855,55 +867,55 @@ object AWTKeyboardInterceptor {
             // nowhere to step, and claiming the chord would take Cmd+Shift+Bracket away from an
             // editor (where the VS Code and IntelliJ presets put these) for no effect.
             KeymapActions.TAB_NEXT_POSITIONAL -> {
-                dispatchIfCanStepTabs(windowId) { MenuActionsHandler.triggerNextTabPositional(it) }
+                dispatchIfCanStepTabs(windowId, perform) { MenuActionsHandler.triggerNextTabPositional(it) }
             }
 
             KeymapActions.TAB_PREVIOUS_POSITIONAL -> {
-                dispatchIfCanStepTabs(windowId) { MenuActionsHandler.triggerPreviousTabPositional(it) }
+                dispatchIfCanStepTabs(windowId, perform) { MenuActionsHandler.triggerPreviousTabPositional(it) }
             }
 
             // Index 0, not 8: Cmd+9 means "the last tab", so any non-empty panel serves it. In a
             // one-tab panel it is claimed and reselects the already-active tab, which is what
             // browsers do; only an empty panel lets the chord through.
             KeymapActions.TAB_SELECT_LAST -> {
-                dispatchIfTabExistsAt(windowId, 0) { MenuActionsHandler.triggerSelectLastTab(it) }
+                dispatchIfTabExistsAt(windowId, 0, perform) { MenuActionsHandler.triggerSelectLastTab(it) }
             }
 
             // Window Management
             KeymapActions.WINDOW_NEW -> {
-                WindowOperations.createNewWindow()
+                if (perform) WindowOperations.createNewWindow()
                 true
             }
 
             KeymapActions.WINDOW_CLOSE -> {
-                WindowOperations.closeWindow(windowId)
+                if (perform) WindowOperations.closeWindow(windowId)
                 true
             }
 
             // Browser Controls (Zoom)
             KeymapActions.BROWSER_ZOOM_IN -> {
-                MenuActionsHandler.triggerZoomIn(windowId)
+                if (perform) MenuActionsHandler.triggerZoomIn(windowId)
                 true
             }
 
             KeymapActions.BROWSER_ZOOM_OUT -> {
-                MenuActionsHandler.triggerZoomOut(windowId)
+                if (perform) MenuActionsHandler.triggerZoomOut(windowId)
                 true
             }
 
             KeymapActions.BROWSER_ZOOM_RESET -> {
-                MenuActionsHandler.triggerActualSize(windowId)
+                if (perform) MenuActionsHandler.triggerActualSize(windowId)
                 true
             }
 
             // View Controls
             KeymapActions.FOCUS_MODE_TOGGLE -> {
-                MenuActionsHandler.triggerToggleFocusMode(windowId)
+                if (perform) MenuActionsHandler.triggerToggleFocusMode(windowId)
                 true
             }
 
             KeymapActions.CHROME_DENSITY_CYCLE -> {
-                MenuActionsHandler.triggerChromeDensityCycle(windowId)
+                if (perform) MenuActionsHandler.triggerChromeDensityCycle(windowId)
                 true
             }
 
@@ -917,40 +929,40 @@ object AWTKeyboardInterceptor {
             // (With a split open the chord is the user's panel navigation either way - that is
             // already what the enabled menu accelerator does today.)
             KeymapActions.PANEL_NAVIGATE_LEFT -> {
-                dispatchIfMultiPanel(windowId) { MenuActionsHandler.triggerNavigatePanelLeft(it) }
+                dispatchIfMultiPanel(windowId, perform) { MenuActionsHandler.triggerNavigatePanelLeft(it) }
             }
 
             KeymapActions.PANEL_NAVIGATE_RIGHT -> {
-                dispatchIfMultiPanel(windowId) { MenuActionsHandler.triggerNavigatePanelRight(it) }
+                dispatchIfMultiPanel(windowId, perform) { MenuActionsHandler.triggerNavigatePanelRight(it) }
             }
 
             KeymapActions.PANEL_NAVIGATE_UP -> {
-                dispatchIfMultiPanel(windowId) { MenuActionsHandler.triggerNavigatePanelUp(it) }
+                dispatchIfMultiPanel(windowId, perform) { MenuActionsHandler.triggerNavigatePanelUp(it) }
             }
 
             KeymapActions.PANEL_NAVIGATE_DOWN -> {
-                dispatchIfMultiPanel(windowId) { MenuActionsHandler.triggerNavigatePanelDown(it) }
+                dispatchIfMultiPanel(windowId, perform) { MenuActionsHandler.triggerNavigatePanelDown(it) }
             }
 
             // Split Panel
             KeymapActions.PANEL_SPLIT_VERTICAL -> {
-                MenuActionsHandler.triggerSplitVertically(windowId)
+                if (perform) MenuActionsHandler.triggerSplitVertically(windowId)
                 true
             }
 
             KeymapActions.PANEL_SPLIT_HORIZONTAL -> {
-                MenuActionsHandler.triggerSplitHorizontally(windowId)
+                if (perform) MenuActionsHandler.triggerSplitHorizontally(windowId)
                 true
             }
 
             // Browser Controls
             KeymapActions.BROWSER_RELOAD -> {
-                MenuActionsHandler.triggerReloadBrowser(windowId)
+                if (perform) MenuActionsHandler.triggerReloadBrowser(windowId)
                 true
             }
 
             KeymapActions.BROWSER_FIND -> {
-                MenuActionsHandler.triggerBrowserFind(windowId)
+                if (perform) MenuActionsHandler.triggerBrowserFind(windowId)
                 true
             }
 
@@ -962,47 +974,47 @@ object AWTKeyboardInterceptor {
             // actions do need `enabled`, because an accelerator fires window-wide whatever the
             // context - see ActiveBrowserRegistry.windowsWithActiveBrowser.)
             KeymapActions.BROWSER_BACK -> {
-                MenuActionsHandler.triggerBrowserBack(windowId)
+                if (perform) MenuActionsHandler.triggerBrowserBack(windowId)
                 true
             }
 
             KeymapActions.BROWSER_FORWARD -> {
-                MenuActionsHandler.triggerBrowserForward(windowId)
+                if (perform) MenuActionsHandler.triggerBrowserForward(windowId)
                 true
             }
 
             KeymapActions.BROWSER_DEVTOOLS -> {
-                MenuActionsHandler.triggerBrowserDevTools(windowId)
+                if (perform) MenuActionsHandler.triggerBrowserDevTools(windowId)
                 true
             }
 
             // Codebase
             KeymapActions.CODEBASE_OPEN -> {
-                MenuActionsHandler.triggerOpenCodebase(windowId)
+                if (perform) MenuActionsHandler.triggerOpenCodebase(windowId)
                 true
             }
 
             // Global Search
             KeymapActions.GLOBAL_SEARCH_OPEN -> {
-                MenuActionsHandler.triggerOpenGlobalSearch(windowId)
+                if (perform) MenuActionsHandler.triggerOpenGlobalSearch(windowId)
                 true
             }
 
             // Settings
             KeymapActions.SETTINGS_OPEN -> {
-                MenuActionsHandler.triggerOpenSettings(windowId)
+                if (perform) MenuActionsHandler.triggerOpenSettings(windowId)
                 true
             }
 
             // Workspace
             KeymapActions.WORKSPACE_SAVE -> {
-                MenuActionsHandler.triggerSaveWorkspace(windowId)
+                if (perform) MenuActionsHandler.triggerSaveWorkspace(windowId)
                 true
             }
 
             // Help
             KeymapActions.HELP_SHORTCUTS -> {
-                MenuActionsHandler.triggerShowShortcutHelp(windowId)
+                if (perform) MenuActionsHandler.triggerShowShortcutHelp(windowId)
                 true
             }
 
@@ -1012,7 +1024,7 @@ object AWTKeyboardInterceptor {
                 val tabIndex = KeymapActions.TAB_SELECT_BY_INDEX.indexOf(actionId)
                 when {
                     tabIndex >= 0 -> {
-                        dispatchIfTabExistsAt(windowId, tabIndex) {
+                        dispatchIfTabExistsAt(windowId, tabIndex, perform) {
                             MenuActionsHandler.triggerSelectTabByIndex(it, tabIndex)
                         }
                     }
@@ -1021,7 +1033,10 @@ object AWTKeyboardInterceptor {
                     // reached when the user rebound a plugin shortcut (the binding
                     // then lives in the keymap settings and matches the main pass).
                     actionId.startsWith(PluginShortcutRegistryImpl.ACTION_ID_PREFIX) -> {
-                        PluginShortcutRegistryImpl.dispatch(actionId, windowId)
+                        // No side-effect-free probe exists for a plugin dispatch (unlike the
+                        // gates above), so a perform = false call optimistically reports
+                        // claimed; handleKeyReleased confirms for real at perform = true.
+                        if (perform) PluginShortcutRegistryImpl.dispatch(actionId, windowId) else true
                     }
 
                     else -> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -42,13 +42,7 @@ object AWTKeyboardInterceptor {
      */
     private val windowContextMap = ConcurrentHashMap<String, ShortcutContext>()
 
-    // Double-shift detection for global search (like IntelliJ's Search Everywhere)
-    private var lastShiftPressTime: Long = 0
-    private var lastShiftReleaseTime: Long = 0
-    private var shiftPressCount: Int = 0
-
-    // 500ms threshold follows accessibility guidelines for double-tap gestures (typically 500-800ms)
-    private const val DOUBLE_SHIFT_THRESHOLD_MS = 500
+    private val doubleShiftGesture = DoubleShiftGesture()
 
     // MRU tab-cycle tracking. Set when Ctrl+Tab starts a cycle in MRU mode, alongside the
     // physical keycode of the modifier sustaining it; the cycle commits only when THAT
@@ -60,9 +54,6 @@ object AWTKeyboardInterceptor {
     private var tabCycleModifierKeyCode = -1
     private var tabCycleWindowId: String? = null
     private val claimedKeys = ConcurrentHashMap.newKeySet<Int>()
-
-    // Minimum time shift must be released to count as a clean release (prevents false positives from held shift)
-    private const val MIN_SHIFT_RELEASE_MS = 50
 
     /**
      * A shortcut chord recognized on KEY_PRESSED and held until its primary key's matching
@@ -195,9 +186,7 @@ object AWTKeyboardInterceptor {
         }
         if (event.keyCode == KeyEvent.VK_SHIFT) return handleShiftEvent(event, windowId)
         if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
-            shiftPressCount = 0
-            lastShiftPressTime = 0
-            lastShiftReleaseTime = 0
+            doubleShiftGesture.reset()
         }
         val handled =
             when (event.id) {
@@ -213,35 +202,11 @@ object AWTKeyboardInterceptor {
         event: KeyEvent,
         windowId: String?,
     ): Boolean {
-        val now = System.currentTimeMillis()
-        var handled = false
-        when (event.id) {
-            KeyEvent.KEY_PRESSED -> {
-                val gap = now - lastShiftReleaseTime
-                if (gap in MIN_SHIFT_RELEASE_MS until DOUBLE_SHIFT_THRESHOLD_MS && shiftPressCount == 1) {
-                    shiftPressCount = 0
-                    lastShiftPressTime = 0
-                    lastShiftReleaseTime = 0
-                    if (windowId != null) {
-                        MenuActionsHandler.triggerOpenGlobalSearch(windowId)
-                        event.consume()
-                        handled = true
-                    }
-                } else {
-                    shiftPressCount = 1
-                    lastShiftPressTime = now
-                }
-            }
-
-            KeyEvent.KEY_RELEASED -> {
-                if (shiftPressCount == 1 && now - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
-                    lastShiftReleaseTime = now
-                } else {
-                    shiftPressCount = 0
-                }
-            }
-        }
-        return handled
+        val matched = doubleShiftGesture.handle(event.id, System.currentTimeMillis())
+        if (!matched || windowId == null) return false
+        MenuActionsHandler.triggerOpenGlobalSearch(windowId)
+        event.consume()
+        return true
     }
 
     private fun finishTabCycle() {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/AWTKeyboardInterceptor.kt
@@ -57,8 +57,9 @@ object AWTKeyboardInterceptor {
     // Accessed only from the AWT event dispatch thread. Process-global (like the double-
     // shift state above): cycling in one window then focusing another without releasing the
     // modifier is a benign mismatch — the stray release just no-ops downstream.
-    private var tabCycleActive = false
     private var tabCycleModifierKeyCode = -1
+    private var tabCycleWindowId: String? = null
+    private val claimedKeys = mutableSetOf<Int>()
 
     // Minimum time shift must be released to count as a clean release (prevents false positives from held shift)
     private const val MIN_SHIFT_RELEASE_MS = 50
@@ -81,13 +82,17 @@ object AWTKeyboardInterceptor {
         val pluginActionId: String? = null,
     )
 
-    // The shortcut armed on a currently-held key, or null. Process-global like the double-
-    // shift and tab-cycle state above, for the same reason: a chord armed in one window and
-    // released after focus moved elsewhere is a narrow, harmless mismatch, not a leak - the
-    // stray release just finds nothing to fire. Accessed only from the AWT event dispatch
-    // thread and the focus-loss listener installed alongside the dispatcher, both of which
-    // run there.
-    internal var pendingShortcut: PendingShortcut? = null
+    // One pending action per physical primary key supports overlapping chords. Normal
+    // dispatch and focus changes run on the EDT; shutdown also clears this state.
+    private val pendingShortcuts = mutableMapOf<Int, PendingShortcut>()
+
+    // Retained as the test seam for the original single-chord regression suite.
+    internal var pendingShortcut: PendingShortcut?
+        get() = pendingShortcuts.values.firstOrNull()
+        set(value) {
+            pendingShortcuts.clear()
+            if (value != null) pendingShortcuts[value.keyCode] = value
+        }
 
     private var focusListener: java.beans.PropertyChangeListener? = null
 
@@ -107,6 +112,8 @@ object AWTKeyboardInterceptor {
      * Call this from BossWindow's DisposableEffect onDispose.
      */
     fun unregisterWindow(awtWindow: Window) {
+        cancelPendingShortcut()
+        finishTabCycle()
         val windowId = windowIdMap.remove(awtWindow)
         if (windowId != null) {
             windowContextMap.remove(windowId)
@@ -152,99 +159,7 @@ object AWTKeyboardInterceptor {
     fun install() {
         if (isInstalled) return
 
-        dispatcher =
-            KeyEventDispatcher { event ->
-                // Handle double-shift detection for global search
-                if (event.keyCode == KeyEvent.VK_SHIFT) {
-                    val currentTime = System.currentTimeMillis()
-
-                    when (event.id) {
-                        KeyEvent.KEY_PRESSED -> {
-                            // Check if this is a quick second press after a clean release
-                            val timeSinceRelease = currentTime - lastShiftReleaseTime
-                            if (timeSinceRelease < DOUBLE_SHIFT_THRESHOLD_MS &&
-                                timeSinceRelease >= MIN_SHIFT_RELEASE_MS && // Ensure clean release (not held)
-                                shiftPressCount == 1
-                            ) {
-                                // Double-shift detected!
-                                shiftPressCount = 0
-                                lastShiftPressTime = 0
-                                lastShiftReleaseTime = 0
-
-                                // Get the focused window's BOSS window ID
-                                val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
-                                val windowId = findWindowId(focusedWindow)
-                                if (windowId != null) {
-                                    try {
-                                        MenuActionsHandler.triggerOpenGlobalSearch(windowId)
-                                        event.consume()
-                                        return@KeyEventDispatcher true
-                                    } catch (e: Exception) {
-                                        // Log but don't crash the event dispatcher
-                                        System.err.println("Error triggering global search: ${e.message}")
-                                    }
-                                }
-                            } else {
-                                // First shift press or timeout - start counting
-                                shiftPressCount = 1
-                                lastShiftPressTime = currentTime
-                            }
-                        }
-
-                        KeyEvent.KEY_RELEASED -> {
-                            // Record release time for detecting second press
-                            if (shiftPressCount == 1 && currentTime - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
-                                lastShiftReleaseTime = currentTime
-                            } else {
-                                // Too slow or wrong sequence - reset
-                                shiftPressCount = 0
-                            }
-                        }
-                    }
-                    return@KeyEventDispatcher false // Let shift events propagate
-                }
-
-                // Reset double-shift state if any other key is pressed
-                if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
-                    shiftPressCount = 0
-                    lastShiftPressTime = 0
-                    lastShiftReleaseTime = 0
-                }
-
-                // Commit an in-progress MRU tab cycle when its own cycling modifier is released.
-                // Only fires while a cycle is active and only for that specific modifier, so
-                // unrelated modifier keyups don't churn the UI thread or commit prematurely.
-                // The release itself is not consumed.
-                if (event.id == KeyEvent.KEY_RELEASED && tabCycleActive && event.keyCode == tabCycleModifierKeyCode) {
-                    tabCycleActive = false
-                    val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
-                    findWindowId(focusedWindow)?.let { MenuActionsHandler.triggerCommitTabCycle(it) }
-                    return@KeyEventDispatcher false
-                }
-
-                // Only shortcuts from here on, and only these two event kinds.
-                if (event.id != KeyEvent.KEY_PRESSED && event.id != KeyEvent.KEY_RELEASED) {
-                    return@KeyEventDispatcher false
-                }
-
-                val handled =
-                    if (event.id == KeyEvent.KEY_RELEASED) {
-                        // Uses the windowId captured when the chord was armed, not whatever is
-                        // focused now - if focus moved, the listener below already cleared
-                        // pendingShortcut and this finds nothing to fire.
-                        handleKeyReleased(event)
-                    } else {
-                        val focusedWindow = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow
-                        val windowId = findWindowId(focusedWindow)
-                        windowId != null && handleKeyPressed(event, windowId)
-                    }
-
-                if (handled) {
-                    // Consume the event to prevent it from reaching BossTerm
-                    event.consume()
-                }
-                handled
-            }
+        dispatcher = KeyEventDispatcher { event -> processKeyEvent(event) }
 
         KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(dispatcher)
         focusListener =
@@ -253,9 +168,74 @@ object AWTKeyboardInterceptor {
                 // BossConsole#490 requires this to drop any pending shortcut rather than fire
                 // it, or leave it armed, for whichever key happens to release next.
                 cancelPendingShortcut()
+                finishTabCycle()
             }
         KeyboardFocusManager.getCurrentKeyboardFocusManager().addPropertyChangeListener("focusedWindow", focusListener)
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().addPropertyChangeListener("focusOwner", focusListener)
         isInstalled = true
+    }
+
+    /** The same dispatcher path is exercised with an explicit window id in headless tests. */
+    internal fun processKeyEvent(
+        event: KeyEvent,
+        windowId: String? = findWindowId(KeyboardFocusManager.getCurrentKeyboardFocusManager().focusedWindow),
+    ): Boolean {
+        // Modifier cancellation must precede both the Shift gesture and MRU commit paths.
+        if (event.id == KeyEvent.KEY_RELEASED && isModifierOnlyKey(event.keyCode)) {
+            pendingShortcuts.clear()
+            if (event.keyCode == tabCycleModifierKeyCode) finishTabCycle()
+        }
+        if (event.keyCode == KeyEvent.VK_SHIFT) return handleShiftEvent(event, windowId)
+        if (event.id == KeyEvent.KEY_PRESSED && !isModifierOnlyKey(event.keyCode)) {
+            shiftPressCount = 0
+            lastShiftPressTime = 0
+            lastShiftReleaseTime = 0
+        }
+        val handled = when (event.id) {
+            KeyEvent.KEY_RELEASED -> handleKeyReleased(event)
+            KeyEvent.KEY_PRESSED -> windowId != null && handleKeyPressed(event, windowId)
+            else -> false
+        }
+        if (handled) event.consume()
+        return handled
+    }
+
+    private fun handleShiftEvent(event: KeyEvent, windowId: String?): Boolean {
+        val now = System.currentTimeMillis()
+        var handled = false
+        when (event.id) {
+            KeyEvent.KEY_PRESSED -> {
+                val gap = now - lastShiftReleaseTime
+                if (gap in MIN_SHIFT_RELEASE_MS until DOUBLE_SHIFT_THRESHOLD_MS && shiftPressCount == 1) {
+                    shiftPressCount = 0
+                    lastShiftPressTime = 0
+                    lastShiftReleaseTime = 0
+                    if (windowId != null) {
+                        MenuActionsHandler.triggerOpenGlobalSearch(windowId)
+                        event.consume()
+                        handled = true
+                    }
+                } else {
+                    shiftPressCount = 1
+                    lastShiftPressTime = now
+                }
+            }
+            KeyEvent.KEY_RELEASED -> {
+                if (shiftPressCount == 1 && now - lastShiftPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
+                    lastShiftReleaseTime = now
+                } else {
+                    shiftPressCount = 0
+                }
+            }
+        }
+        return handled
+    }
+
+    private fun finishTabCycle() {
+        val windowId = tabCycleWindowId
+        tabCycleModifierKeyCode = -1
+        tabCycleWindowId = null
+        if (windowId != null) MenuActionsHandler.triggerCommitTabCycle(windowId)
     }
 
     /**
@@ -269,12 +249,14 @@ object AWTKeyboardInterceptor {
         dispatcher = null
         focusListener?.let { l ->
             KeyboardFocusManager.getCurrentKeyboardFocusManager().removePropertyChangeListener("focusedWindow", l)
+            KeyboardFocusManager.getCurrentKeyboardFocusManager().removePropertyChangeListener("focusOwner", l)
         }
         focusListener = null
         isInstalled = false
         windowIdMap.clear()
         windowContextMap.clear()
         cancelPendingShortcut()
+        finishTabCycle()
     }
 
     /**
@@ -295,8 +277,12 @@ object AWTKeyboardInterceptor {
         // doesn't leak to the focused component while held) without re-matching, re-arming,
         // or invoking anything a second time. This is what stops OS auto-repeat from firing
         // the action over and over - the actual fire happens once, in handleKeyReleased.
-        pendingShortcut?.let { armed ->
-            if (event.keyCode == armed.keyCode) return true
+        val pending = pendingShortcuts[event.keyCode]
+        if (pending != null && !event.isMetaDown && !event.isControlDown && !event.isAltDown) {
+            pendingShortcuts.remove(event.keyCode)
+            claimedKeys.remove(event.keyCode)
+        } else if (event.keyCode in claimedKeys || pending != null) {
+            return true
         }
 
         // Skip if no modifier keys are pressed (most shortcuts require modifiers)
@@ -346,7 +332,8 @@ object AWTKeyboardInterceptor {
                 return false
             }
 
-            pendingShortcut = PendingShortcut(keyCode = event.keyCode, windowId = windowId, hostBinding = match)
+            claimedKeys.add(event.keyCode)
+            pendingShortcuts[event.keyCode] = PendingShortcut(keyCode = event.keyCode, windowId = windowId, hostBinding = match)
             return true
         }
 
@@ -358,10 +345,11 @@ object AWTKeyboardInterceptor {
         // that actionId.
         val pluginActionId = findMatchingPluginDefault(event)
         if (pluginActionId != null) {
+            claimedKeys.add(event.keyCode)
             // No side-effect-free way to ask PluginShortcutRegistryImpl "would you handle
             // this" without actually dispatching, so this arms on chord match alone and is
             // confirmed for real at key-up in handleKeyReleased.
-            pendingShortcut =
+            pendingShortcuts[event.keyCode] =
                 PendingShortcut(keyCode = event.keyCode, windowId = windowId, pluginActionId = pluginActionId)
             return true
         }
@@ -379,35 +367,25 @@ object AWTKeyboardInterceptor {
      * is not consumed.
      */
     internal fun handleKeyReleased(event: KeyEvent): Boolean {
-        val pending = pendingShortcut ?: return false
-        if (event.keyCode != pending.keyCode) return false
-        pendingShortcut = null
+        val claimed = claimedKeys.remove(event.keyCode)
+        if (isModifierOnlyKey(event.keyCode)) {
+            pendingShortcuts.clear()
+        }
+        val pending = pendingShortcuts.remove(event.keyCode) ?: return claimed
 
-        return if (pending.pluginActionId != null) {
+        if (pending.pluginActionId != null) {
             PluginShortcutRegistryImpl.dispatch(pending.pluginActionId, pending.windowId)
         } else {
-            val binding = pending.hostBinding!!.binding
-            val handled = dispatchAction(binding.actionId, pending.windowId, perform = true)
-
-            // Begin (or continue) an MRU tab cycle: remember which modifier is sustaining it
-            // so its release - and only its release - commits the cycle. This arms even when
-            // the focused panel has <=1 tab (the component-side switchTab/commit then no-op),
-            // so the interceptor may briefly believe a cycle is active when none is -
-            // harmless, and Tab stays swallowed.
-            if (handled &&
-                (binding.actionId == KeymapActions.TAB_NEXT || binding.actionId == KeymapActions.TAB_PREVIOUS) &&
-                KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU
-            ) {
-                tabCycleActive = true
-                // From the keystroke that MATCHED, not the binding's primary: an alternate can
-                // carry the other primary modifier, and arming on Meta while the user holds
-                // Control means the release never commits. The switcher overlay then stays on
-                // screen with Tab swallowed until some unrelated modifier release happens to
-                // match.
-                tabCycleModifierKeyCode = cyclingModifierKeyCode(pending.hostBinding.keystroke)
+            val match = checkNotNull(pending.hostBinding)
+            val handled = dispatchAction(match.binding.actionId, pending.windowId, perform = true)
+            val cyclesTabs = match.binding.actionId in setOf(KeymapActions.TAB_NEXT, KeymapActions.TAB_PREVIOUS)
+            if (handled && cyclesTabs && KeymapSettingsManager.currentSettings.value.tabSwitchMode == TabSwitchMode.MRU) {
+                tabCycleWindowId = pending.windowId
+                tabCycleModifierKeyCode = cyclingModifierKeyCode(match.keystroke)
             }
-            handled
         }
+        // The press was claimed. Its release remains ours even if the action became unavailable.
+        return true
     }
 
     /**
@@ -416,7 +394,8 @@ object AWTKeyboardInterceptor {
      * on [uninstall]; safe to call when nothing is pending.
      */
     internal fun cancelPendingShortcut() {
-        pendingShortcut = null
+        pendingShortcuts.clear()
+        claimedKeys.clear()
     }
 
     /**
@@ -1033,10 +1012,13 @@ object AWTKeyboardInterceptor {
                     // reached when the user rebound a plugin shortcut (the binding
                     // then lives in the keymap settings and matches the main pass).
                     actionId.startsWith(PluginShortcutRegistryImpl.ACTION_ID_PREFIX) -> {
-                        // No side-effect-free probe exists for a plugin dispatch (unlike the
-                        // gates above), so a perform = false call optimistically reports
-                        // claimed; handleKeyReleased confirms for real at perform = true.
-                        if (perform) PluginShortcutRegistryImpl.dispatch(actionId, windowId) else true
+                        // The registry's presence check is side-effect-free. Dispatch rechecks
+                        // it on release in case the provider was unregistered while held.
+                        if (perform) {
+                            PluginShortcutRegistryImpl.dispatch(actionId, windowId)
+                        } else {
+                            PluginShortcutRegistryImpl.shortcuts.value.any { it.spec.actionId == actionId }
+                        }
                     }
 
                     else -> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/DoubleShiftGesture.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/DoubleShiftGesture.kt
@@ -1,0 +1,49 @@
+package ai.rever.boss.window
+
+import java.awt.event.KeyEvent
+
+/** Tracks the double-Shift search gesture separately from shortcut dispatch and window routing. */
+internal class DoubleShiftGesture {
+    private var lastPressTime: Long = 0
+    private var lastReleaseTime: Long = 0
+    private var pressCount: Int = 0
+
+    fun reset() {
+        pressCount = 0
+        lastPressTime = 0
+        lastReleaseTime = 0
+    }
+
+    /** Returns true on the second press after a short, clean release. */
+    fun handle(
+        eventId: Int,
+        now: Long,
+    ): Boolean {
+        when (eventId) {
+            KeyEvent.KEY_PRESSED -> {
+                val gap = now - lastReleaseTime
+                if (gap in MIN_RELEASE_MS until DOUBLE_SHIFT_THRESHOLD_MS && pressCount == 1) {
+                    reset()
+                    return true
+                }
+                pressCount = 1
+                lastPressTime = now
+            }
+
+            KeyEvent.KEY_RELEASED -> {
+                if (pressCount == 1 && now - lastPressTime < DOUBLE_SHIFT_THRESHOLD_MS) {
+                    lastReleaseTime = now
+                } else {
+                    pressCount = 0
+                }
+            }
+        }
+        return false
+    }
+
+    private companion object {
+        // Match the existing gesture timing: a 50ms clean release within a 500ms double tap.
+        const val MIN_RELEASE_MS = 50
+        const val DOUBLE_SHIFT_THRESHOLD_MS = 500
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
@@ -307,12 +307,11 @@ class ContainedCrashReportTest {
             // readText via runCatching: the writer thread sweeps old reports while
             // we are listing, so a file can vanish between listFiles and the read.
             val written = reports().filter { runCatching { it.readText() }.getOrDefault("").contains(text) }
-            if (written.isNotEmpty()) {
-                written.forEach { it.delete() }
-                return
-            }
+            // Windows can temporarily deny deletion too. The marker must be gone
+            // before callers assert the number of reports; otherwise keep polling.
+            if (written.isNotEmpty() && written.all { it.delete() || !it.exists() }) return
             Thread.sleep(20)
         }
-        throw AssertionError("the contained-report writer never drained")
+        throw AssertionError("the contained-report writer never drained or its marker could not be deleted")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.crash
 
 import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -89,7 +90,7 @@ class ContainedCrashReportTest {
         CrashHandler.recordContained(uniqueThrowable("write"))
         awaitFiles(1)
 
-        val text = reports().single().readText()
+        val text = readReport(reports().single())
         assertTrue(text.contains("contained render fault"), "the file should say what it is")
         assertTrue(text.contains("plugin:"), "pluginId is the most useful field on this path")
         assertTrue(text.contains("contained-report-test write"), "the original message should survive")
@@ -111,7 +112,7 @@ class ContainedCrashReportTest {
 
             val temp = tempFiles().single()
             assertTrue(
-                temp.readText().contains("contained-report-test atomic-publish"),
+                readReport(temp).contains("contained-report-test atomic-publish"),
                 "the temp file must be complete",
             )
         } finally {
@@ -119,7 +120,7 @@ class ContainedCrashReportTest {
         }
 
         awaitFiles(1)
-        assertTrue(reports().single().readText().contains("contained-report-test atomic-publish"))
+        assertTrue(readReport(reports().single()).contains("contained-report-test atomic-publish"))
         assertTrue(tempFiles().isEmpty(), "the temp file must be removed after publication")
     }
 
@@ -200,7 +201,7 @@ class ContainedCrashReportTest {
 
         assertEquals(
             PROBE_PLUGIN,
-            attributionOf(reports().single().readText()),
+            attributionOf(readReport(reports().single())),
             "the plugin scope held at the fault must survive the hop to the writer thread",
         )
     }
@@ -223,7 +224,7 @@ class ContainedCrashReportTest {
 
         val attributions =
             reports()
-                .map { it.readText() }
+                .map { readReport(it) }
                 .associate { text -> markerOf(text) to attributionOf(text) }
 
         assertEquals(
@@ -243,7 +244,7 @@ class ContainedCrashReportTest {
         CrashHandler.recordContained(uniqueThrowable("host-fault"))
         awaitFiles(1)
 
-        val text = reports().single().readText()
+        val text = readReport(reports().single())
         assertEquals("(unattributed)", attributionOf(text), "a host fault must not be blamed on a plugin")
     }
 
@@ -262,6 +263,23 @@ class ContainedCrashReportTest {
             .first { it.startsWith("message:") }
             .substringAfter("contained-report-test ")
             .trim()
+
+    /**
+     * Publication does not guarantee immediate read access on Windows: a transient
+     * sharing violation can reject opening an already-visible report. Retry only
+     * I/O failures, not empty/incorrect content, and preserve a persistent failure.
+     */
+    private fun readReport(file: File): String {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (true) {
+            try {
+                return file.readText()
+            } catch (e: IOException) {
+                if (System.nanoTime() >= deadline) throw e
+                Thread.sleep(20)
+            }
+        }
+    }
 
     /** The write is handed to a background thread, so poll rather than sleep a fixed span. */
     private fun awaitFiles(count: Int) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapHandlerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapHandlerTest.kt
@@ -5,6 +5,8 @@ import ai.rever.boss.keymap.handler.MapBasedActionExecutor
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.model.ShortcutContext
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -324,5 +326,197 @@ class KeymapHandlerTest {
 
         assertNotNull(handler)
         assertTrue(handler.isBound("test.action"))
+    }
+
+    // ==================== KEY RELEASE & REPEAT SEMANTICS TESTS ====================
+
+    @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+    private fun createKeyEvent(
+        key: Key,
+        type: KeyEventType,
+        meta: Boolean = false,
+        ctrl: Boolean = false,
+        shift: Boolean = false,
+        alt: Boolean = false,
+    ): androidx.compose.ui.input.key.KeyEvent =
+        androidx.compose.ui.input.key.KeyEvent(
+            key = key,
+            type = type,
+            isMetaPressed = if (ai.rever.boss.utils.SystemUtils.isMacOS) meta else false,
+            isCtrlPressed = if (ai.rever.boss.utils.SystemUtils.isMacOS) ctrl else (meta || ctrl),
+            isShiftPressed = shift,
+            isAltPressed = alt,
+        )
+
+    @Test
+    fun `handleKeyEvent on KeyDown consumes event without executing action`() {
+        val binding =
+            KeyBinding(
+                actionId = "test.action",
+                key = "N",
+                modifiers = listOf("Cmd"),
+                context = ShortcutContext.GLOBAL,
+                enabled = true,
+            )
+
+        val handler = KeymapHandler.from(KeymapSettings.fromBindings(listOf(binding)))
+        var executed = false
+
+        val keyDown = createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true)
+        val handled = handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
+            executed = true
+            true
+        }
+
+        assertTrue(handled, "KeyDown matching shortcut should be consumed")
+        assertFalse(executed, "KeyDown must not execute the action yet")
+        assertTrue(handler.hasPendingShortcut, "Handler should have pending shortcut armed")
+    }
+
+    @Test
+    fun `handleKeyEvent on KeyUp after matching KeyDown executes action exactly once`() {
+        val binding =
+            KeyBinding(
+                actionId = "test.action",
+                key = "N",
+                modifiers = listOf("Cmd"),
+                context = ShortcutContext.GLOBAL,
+                enabled = true,
+            )
+
+        val handler = KeymapHandler.from(KeymapSettings.fromBindings(listOf(binding)))
+        var executionCount = 0
+
+        val keyDown = createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true)
+        handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
+            executionCount++
+            true
+        }
+
+        val keyUp = createKeyEvent(Key.N, KeyEventType.KeyUp, meta = true)
+        val handled = handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
+            executionCount++
+            true
+        }
+
+        assertTrue(handled, "KeyUp should be handled")
+        assertEquals(1, executionCount, "Action must be executed exactly once on KeyUp")
+        assertFalse(handler.hasPendingShortcut, "Pending shortcut should be cleared after execution")
+    }
+
+    @Test
+    fun `repeated KeyDown events do not trigger multiple executions`() {
+        val binding =
+            KeyBinding(
+                actionId = "test.action",
+                key = "N",
+                modifiers = listOf("Cmd"),
+                context = ShortcutContext.GLOBAL,
+                enabled = true,
+            )
+
+        val handler = KeymapHandler.from(KeymapSettings.fromBindings(listOf(binding)))
+        var executionCount = 0
+
+        // Simulate auto-repeat key-down events
+        repeat(5) {
+            val keyDown = createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true)
+            val handled = handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
+                executionCount++
+                true
+            }
+            assertTrue(handled, "Auto-repeat KeyDown should be consumed")
+        }
+
+        assertEquals(0, executionCount, "Auto-repeat KeyDown events must not execute action")
+
+        // Release primary key
+        val keyUp = createKeyEvent(Key.N, KeyEventType.KeyUp, meta = true)
+        val handled = handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
+            executionCount++
+            true
+        }
+
+        assertTrue(handled, "KeyUp should be handled")
+        assertEquals(1, executionCount, "Action must execute exactly once upon release")
+    }
+
+    @Test
+    fun `releasing modifier alone cancels pending chord without executing action`() {
+        val binding =
+            KeyBinding(
+                actionId = "test.action",
+                key = "N",
+                modifiers = listOf("Cmd"),
+                context = ShortcutContext.GLOBAL,
+                enabled = true,
+            )
+
+        val handler = KeymapHandler.from(KeymapSettings.fromBindings(listOf(binding)))
+        var executed = false
+
+        val keyDown = createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true)
+        handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
+            executed = true
+            true
+        }
+        assertTrue(handler.hasPendingShortcut)
+
+        // Release Meta/Cmd modifier alone
+        val modifierKeyUp = createKeyEvent(Key.MetaLeft, KeyEventType.KeyUp, meta = false)
+        val handled = handler.handleKeyEvent(modifierKeyUp, ShortcutContext.GLOBAL) {
+            executed = true
+            true
+        }
+
+        assertFalse(handled, "Modifier release alone should not be consumed as action")
+        assertFalse(executed, "Modifier release must not execute the action")
+        assertFalse(handler.hasPendingShortcut, "Pending shortcut must be cancelled on modifier release")
+
+        // Subsequent primary key up should do nothing
+        val keyUp = createKeyEvent(Key.N, KeyEventType.KeyUp, meta = false)
+        val keyUpHandled = handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
+            executed = true
+            true
+        }
+
+        assertFalse(keyUpHandled)
+        assertFalse(executed)
+    }
+
+    @Test
+    fun `clearPendingShortcut cancels pending shortcut on focus loss or reset`() {
+        val binding =
+            KeyBinding(
+                actionId = "test.action",
+                key = "N",
+                modifiers = listOf("Cmd"),
+                context = ShortcutContext.GLOBAL,
+                enabled = true,
+            )
+
+        val handler = KeymapHandler.from(KeymapSettings.fromBindings(listOf(binding)))
+        var executed = false
+
+        val keyDown = createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true)
+        handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
+            executed = true
+            true
+        }
+        assertTrue(handler.hasPendingShortcut)
+
+        // Focus loss or cancellation clears pending state
+        handler.clearPendingShortcut()
+        assertFalse(handler.hasPendingShortcut)
+
+        // Subsequent key up should not trigger action
+        val keyUp = createKeyEvent(Key.N, KeyEventType.KeyUp, meta = true)
+        val handled = handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
+            executed = true
+            true
+        }
+
+        assertFalse(handled)
+        assertFalse(executed)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapHandlerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapHandlerTest.kt
@@ -363,10 +363,11 @@ class KeymapHandlerTest {
         var executed = false
 
         val keyDown = createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true)
-        val handled = handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
-            executed = true
-            true
-        }
+        val handled =
+            handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
+                executed = true
+                true
+            }
 
         assertTrue(handled, "KeyDown matching shortcut should be consumed")
         assertFalse(executed, "KeyDown must not execute the action yet")
@@ -394,10 +395,11 @@ class KeymapHandlerTest {
         }
 
         val keyUp = createKeyEvent(Key.N, KeyEventType.KeyUp, meta = true)
-        val handled = handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
-            executionCount++
-            true
-        }
+        val handled =
+            handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
+                executionCount++
+                true
+            }
 
         assertTrue(handled, "KeyUp should be handled")
         assertEquals(1, executionCount, "Action must be executed exactly once on KeyUp")
@@ -421,10 +423,11 @@ class KeymapHandlerTest {
         // Simulate auto-repeat key-down events
         repeat(5) {
             val keyDown = createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true)
-            val handled = handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
-                executionCount++
-                true
-            }
+            val handled =
+                handler.handleKeyEvent(keyDown, ShortcutContext.GLOBAL) {
+                    executionCount++
+                    true
+                }
             assertTrue(handled, "Auto-repeat KeyDown should be consumed")
         }
 
@@ -432,10 +435,11 @@ class KeymapHandlerTest {
 
         // Release primary key
         val keyUp = createKeyEvent(Key.N, KeyEventType.KeyUp, meta = true)
-        val handled = handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
-            executionCount++
-            true
-        }
+        val handled =
+            handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
+                executionCount++
+                true
+            }
 
         assertTrue(handled, "KeyUp should be handled")
         assertEquals(1, executionCount, "Action must execute exactly once upon release")
@@ -464,10 +468,11 @@ class KeymapHandlerTest {
 
         // Release Meta/Cmd modifier alone
         val modifierKeyUp = createKeyEvent(Key.MetaLeft, KeyEventType.KeyUp, meta = false)
-        val handled = handler.handleKeyEvent(modifierKeyUp, ShortcutContext.GLOBAL) {
-            executed = true
-            true
-        }
+        val handled =
+            handler.handleKeyEvent(modifierKeyUp, ShortcutContext.GLOBAL) {
+                executed = true
+                true
+            }
 
         assertFalse(handled, "Modifier release alone should not be consumed as action")
         assertFalse(executed, "Modifier release must not execute the action")
@@ -475,10 +480,11 @@ class KeymapHandlerTest {
 
         // Subsequent primary key up should do nothing
         val keyUp = createKeyEvent(Key.N, KeyEventType.KeyUp, meta = false)
-        val keyUpHandled = handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
-            executed = true
-            true
-        }
+        val keyUpHandled =
+            handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
+                executed = true
+                true
+            }
 
         assertFalse(keyUpHandled)
         assertFalse(executed)
@@ -511,10 +517,11 @@ class KeymapHandlerTest {
 
         // Subsequent key up should not trigger action
         val keyUp = createKeyEvent(Key.N, KeyEventType.KeyUp, meta = true)
-        val handled = handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
-            executed = true
-            true
-        }
+        val handled =
+            handler.handleKeyEvent(keyUp, ShortcutContext.GLOBAL) {
+                executed = true
+                true
+            }
 
         assertFalse(handled)
         assertFalse(executed)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapHandlerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapHandlerTest.kt
@@ -480,7 +480,7 @@ class KeymapHandlerTest {
             true
         }
 
-        assertFalse(keyUpHandled)
+        assertTrue(keyUpHandled, "The claimed primary release stays consumed after cancellation")
         assertFalse(executed)
     }
 
@@ -518,5 +518,39 @@ class KeymapHandlerTest {
 
         assertFalse(handled)
         assertFalse(executed)
+    }
+
+    @Test
+    fun `updated bindings replace matcher and context changes cancel a held action`() {
+        val binding = KeyBinding(actionId = "test.action", key = "N", modifiers = listOf("Cmd"))
+        val handler = KeymapHandler(KeymapSettings.fromBindings(listOf(binding)))
+        handler.updateSettings(KeymapSettings.fromBindings(listOf(binding.copy(key = "T"))))
+        var calls = 0
+        val execute: (String) -> Boolean = { calls++; true }
+        assertFalse(handler.handleKeyEvent(createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true),
+            ShortcutContext.GLOBAL, execute))
+        assertTrue(handler.handleKeyEvent(createKeyEvent(Key.T, KeyEventType.KeyDown, meta = true),
+            ShortcutContext.GLOBAL, execute))
+        assertTrue(handler.handleKeyEvent(createKeyEvent(Key.T, KeyEventType.KeyUp, meta = true),
+            ShortcutContext.TERMINAL, execute))
+        assertEquals(0, calls)
+    }
+
+    @Test
+    fun `overlapping Compose chords retain each action and suppress repeats`() {
+        val bindings = listOf("N", "T").map { KeyBinding(actionId = it, key = it, modifiers = listOf("Cmd")) }
+        val handler = KeymapHandler(KeymapSettings.fromBindings(bindings))
+        val calls = mutableListOf<String>()
+        val execute: (String) -> Boolean = { calls.add(it); true }
+        for (key in listOf(Key.N, Key.T, Key.N)) {
+            assertTrue(handler.handleKeyEvent(createKeyEvent(key, KeyEventType.KeyDown, meta = true),
+                ShortcutContext.GLOBAL, execute))
+        }
+        assertTrue(calls.isEmpty())
+        for (key in listOf(Key.N, Key.T)) {
+            assertTrue(handler.handleKeyEvent(createKeyEvent(key, KeyEventType.KeyUp, meta = true),
+                ShortcutContext.GLOBAL, execute))
+        }
+        assertEquals(listOf("N", "T"), calls)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapHandlerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/KeymapHandlerTest.kt
@@ -533,13 +533,31 @@ class KeymapHandlerTest {
         val handler = KeymapHandler(KeymapSettings.fromBindings(listOf(binding)))
         handler.updateSettings(KeymapSettings.fromBindings(listOf(binding.copy(key = "T"))))
         var calls = 0
-        val execute: (String) -> Boolean = { calls++; true }
-        assertFalse(handler.handleKeyEvent(createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true),
-            ShortcutContext.GLOBAL, execute))
-        assertTrue(handler.handleKeyEvent(createKeyEvent(Key.T, KeyEventType.KeyDown, meta = true),
-            ShortcutContext.GLOBAL, execute))
-        assertTrue(handler.handleKeyEvent(createKeyEvent(Key.T, KeyEventType.KeyUp, meta = true),
-            ShortcutContext.TERMINAL, execute))
+        val execute: (String) -> Boolean = {
+            calls++
+            true
+        }
+        assertFalse(
+            handler.handleKeyEvent(
+                createKeyEvent(Key.N, KeyEventType.KeyDown, meta = true),
+                ShortcutContext.GLOBAL,
+                execute,
+            ),
+        )
+        assertTrue(
+            handler.handleKeyEvent(
+                createKeyEvent(Key.T, KeyEventType.KeyDown, meta = true),
+                ShortcutContext.GLOBAL,
+                execute,
+            ),
+        )
+        assertTrue(
+            handler.handleKeyEvent(
+                createKeyEvent(Key.T, KeyEventType.KeyUp, meta = true),
+                ShortcutContext.TERMINAL,
+                execute,
+            ),
+        )
         assertEquals(0, calls)
     }
 
@@ -548,15 +566,28 @@ class KeymapHandlerTest {
         val bindings = listOf("N", "T").map { KeyBinding(actionId = it, key = it, modifiers = listOf("Cmd")) }
         val handler = KeymapHandler(KeymapSettings.fromBindings(bindings))
         val calls = mutableListOf<String>()
-        val execute: (String) -> Boolean = { calls.add(it); true }
+        val execute: (String) -> Boolean = {
+            calls.add(it)
+            true
+        }
         for (key in listOf(Key.N, Key.T, Key.N)) {
-            assertTrue(handler.handleKeyEvent(createKeyEvent(key, KeyEventType.KeyDown, meta = true),
-                ShortcutContext.GLOBAL, execute))
+            assertTrue(
+                handler.handleKeyEvent(
+                    createKeyEvent(key, KeyEventType.KeyDown, meta = true),
+                    ShortcutContext.GLOBAL,
+                    execute,
+                ),
+            )
         }
         assertTrue(calls.isEmpty())
         for (key in listOf(Key.N, Key.T)) {
-            assertTrue(handler.handleKeyEvent(createKeyEvent(key, KeyEventType.KeyUp, meta = true),
-                ShortcutContext.GLOBAL, execute))
+            assertTrue(
+                handler.handleKeyEvent(
+                    createKeyEvent(key, KeyEventType.KeyUp, meta = true),
+                    ShortcutContext.GLOBAL,
+                    execute,
+                ),
+            )
         }
         assertEquals(listOf("N", "T"), calls)
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/DoubleShiftGestureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/DoubleShiftGestureTest.kt
@@ -1,0 +1,47 @@
+package ai.rever.boss.window
+
+import java.awt.event.KeyEvent
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DoubleShiftGestureTest {
+    @Test
+    fun `two taps match once on the second press`() {
+        val gesture = DoubleShiftGesture()
+        assertFalse(gesture.handle(KeyEvent.KEY_PRESSED, 1000))
+        assertFalse(gesture.handle(KeyEvent.KEY_RELEASED, 1050))
+        assertTrue(gesture.handle(KeyEvent.KEY_PRESSED, 1100))
+        assertFalse(gesture.handle(KeyEvent.KEY_PRESSED, 1110))
+    }
+
+    @Test
+    fun `held Shift and too short release do not match`() {
+        val gesture = DoubleShiftGesture()
+        assertFalse(gesture.handle(KeyEvent.KEY_PRESSED, 1000))
+        assertFalse(gesture.handle(KeyEvent.KEY_PRESSED, 1100))
+        assertFalse(gesture.handle(KeyEvent.KEY_RELEASED, 1150))
+        assertFalse(gesture.handle(KeyEvent.KEY_PRESSED, 1199))
+    }
+
+    @Test
+    fun `long hold and expired double tap do not match`() {
+        val held = DoubleShiftGesture()
+        assertFalse(held.handle(KeyEvent.KEY_PRESSED, 1000))
+        assertFalse(held.handle(KeyEvent.KEY_RELEASED, 1500))
+        assertFalse(held.handle(KeyEvent.KEY_PRESSED, 1550))
+        val expired = DoubleShiftGesture()
+        assertFalse(expired.handle(KeyEvent.KEY_PRESSED, 1000))
+        assertFalse(expired.handle(KeyEvent.KEY_RELEASED, 1050))
+        assertFalse(expired.handle(KeyEvent.KEY_PRESSED, 1550))
+    }
+
+    @Test
+    fun `intervening key resets the gesture`() {
+        val gesture = DoubleShiftGesture()
+        assertFalse(gesture.handle(KeyEvent.KEY_PRESSED, 1000))
+        assertFalse(gesture.handle(KeyEvent.KEY_RELEASED, 1050))
+        gesture.reset()
+        assertFalse(gesture.handle(KeyEvent.KEY_PRESSED, 1100))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpInvocationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpInvocationTest.kt
@@ -1,0 +1,201 @@
+package ai.rever.boss.window
+
+import ai.rever.boss.keymap.model.KeyBinding
+import ai.rever.boss.keymap.model.KeyStroke
+import ai.rever.boss.keymap.model.KeymapActions
+import java.awt.Canvas
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * BossConsole#490: a shortcut's bound action must fire on the primary key's KEY_RELEASED,
+ * never on KEY_PRESSED (including OS auto-repeat presses while the key is held), and any
+ * chord armed but not yet fired must be dropped on cancellation.
+ *
+ * These drive [AWTKeyboardInterceptor.handleKeyPressed] / [AWTKeyboardInterceptor.handleKeyReleased]
+ * directly with synthetic AWT events - the same way [HostBindingPrecedenceTest] drives
+ * [AWTKeyboardInterceptor.dispatchAction] directly - rather than going through [install]'s real
+ * `KeyEventDispatcher` (which needs a registered AWT `Window`) or real chord matching (which
+ * reads the on-disk keymap via `KeymapSettingsManager`, and so differs between a dev machine
+ * and CI - the same reason [TabStepGateTest] and friends avoid it).
+ * [AWTKeyboardInterceptor.pendingShortcut] is set directly to arm a known chord instead.
+ */
+class ShortcutKeyUpInvocationTest {
+    private val source = Canvas()
+
+    private fun keyEvent(
+        id: Int,
+        keyCode: Int,
+        modifiers: Int = 0,
+    ): KeyEvent = KeyEvent(source, id, System.currentTimeMillis(), modifiers, keyCode, keyCode.toChar())
+
+    private fun tabNewBinding() =
+        AWTKeyboardInterceptor.BindingMatch(
+            KeyBinding(actionId = KeymapActions.TAB_NEW, key = "N", modifiers = listOf("Cmd")),
+            KeyStroke("N", listOf("Cmd")),
+        )
+
+    private fun pendingFor(
+        windowId: String,
+        keyCode: Int = KeyEvent.VK_N,
+    ) = AWTKeyboardInterceptor.PendingShortcut(keyCode = keyCode, windowId = windowId, hostBinding = tabNewBinding())
+
+    @AfterTest
+    fun clearPending() {
+        AWTKeyboardInterceptor.cancelPendingShortcut()
+    }
+
+    @Test
+    fun `a matching key-up fires the action exactly once`() {
+        AWTKeyboardInterceptor.pendingShortcut = pendingFor("keyup-once")
+
+        val release = keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)
+        assertTrue(AWTKeyboardInterceptor.handleKeyReleased(release), "the first release must fire")
+        assertNull(AWTKeyboardInterceptor.pendingShortcut, "firing must clear the armed chord")
+        assertFalse(
+            AWTKeyboardInterceptor.handleKeyReleased(release),
+            "a second release of the same key must not fire again",
+        )
+    }
+
+    @Test
+    fun `a release of a different key does not fire the armed chord`() {
+        val pending = pendingFor("keyup-mismatch")
+        AWTKeyboardInterceptor.pendingShortcut = pending
+
+        assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_W)))
+        assertEquals(
+            pending,
+            AWTKeyboardInterceptor.pendingShortcut,
+            "an unrelated release must leave the armed chord alone",
+        )
+    }
+
+    @Test
+    fun `releasing a modifier by itself does not fire the armed chord`() {
+        // A modifier can never itself be the armed keyCode - handleKeyPressed rejects a
+        // modifier-only press before arming (see the test below) - so its own release is just
+        // another mismatch. Pinned explicitly since #490 names this acceptance criterion.
+        val pending = pendingFor("keyup-modifier")
+        AWTKeyboardInterceptor.pendingShortcut = pending
+
+        assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_CONTROL)))
+        assertEquals(pending, AWTKeyboardInterceptor.pendingShortcut)
+    }
+
+    @Test
+    fun `with no chord armed, a key-up does nothing`() {
+        AWTKeyboardInterceptor.pendingShortcut = null
+        assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)))
+    }
+
+    @Test
+    fun `a repeat key-down for the armed key is claimed without re-arming or firing`() {
+        val windowId = "keyup-repeat"
+        val pending = pendingFor(windowId)
+        AWTKeyboardInterceptor.pendingShortcut = pending
+
+        // OS auto-repeat delivers KEY_PRESSED again and again while a key is held; each one
+        // must stay claimed (so it doesn't leak to the focused component) without firing.
+        val repeatPress = keyEvent(KeyEvent.KEY_PRESSED, KeyEvent.VK_N, InputEvent.META_DOWN_MASK)
+        repeat(5) {
+            val claimed = AWTKeyboardInterceptor.handleKeyPressed(repeatPress, windowId)
+            assertTrue(claimed, "a repeat press must stay claimed")
+        }
+        assertEquals(
+            pending,
+            AWTKeyboardInterceptor.pendingShortcut,
+            "repeats must not re-arm or replace the pending chord",
+        )
+
+        // Still fires exactly once, on the eventual release - not once per repeat.
+        assertTrue(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)))
+        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+    }
+
+    @Test
+    fun `a key-down with no modifier held is never armed`() {
+        val press = keyEvent(KeyEvent.KEY_PRESSED, KeyEvent.VK_N, 0)
+        assertFalse(AWTKeyboardInterceptor.handleKeyPressed(press, "keyup-nomod"))
+        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+    }
+
+    @Test
+    fun `a bare modifier key-down is never armed`() {
+        val press = keyEvent(KeyEvent.KEY_PRESSED, KeyEvent.VK_CONTROL, InputEvent.CTRL_DOWN_MASK)
+        assertFalse(AWTKeyboardInterceptor.handleKeyPressed(press, "keyup-modonly"))
+        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+    }
+
+    @Test
+    fun `the bound action's side effect - not just the claim - is decided at release, not arm`() {
+        // TAB_NEXT_POSITIONAL is gated on MenuActionsHandler.canStepTabs. Arming while the gate
+        // is open and then closing it before release proves the actual dispatch happens at
+        // release: if key-down had already invoked the action (the pre-#490 behaviour), closing
+        // the gate afterward could not change what already fired.
+        val windowId = "keyup-gate-race"
+        MenuActionsHandler.updateActivePanelTabCount(windowId, 2)
+        assertTrue(MenuActionsHandler.canStepTabs(windowId))
+
+        val binding =
+            KeyBinding(
+                actionId = KeymapActions.TAB_NEXT_POSITIONAL,
+                key = "CloseBracket",
+                modifiers = listOf("Cmd", "Shift"),
+            )
+        val keystroke = KeyStroke("CloseBracket", listOf("Cmd", "Shift"))
+        AWTKeyboardInterceptor.pendingShortcut =
+            AWTKeyboardInterceptor.PendingShortcut(
+                keyCode = KeyEvent.VK_CLOSE_BRACKET,
+                windowId = windowId,
+                hostBinding = AWTKeyboardInterceptor.BindingMatch(binding, keystroke),
+            )
+
+        // Close the gate before the key is ever released.
+        MenuActionsHandler.updateActivePanelTabCount(windowId, 1)
+        assertFalse(MenuActionsHandler.canStepTabs(windowId))
+
+        assertFalse(
+            AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_CLOSE_BRACKET)),
+            "the gate closed before release, so nothing should fire",
+        )
+    }
+
+    @Test
+    fun `cancelling drops an armed chord so its eventual release does nothing`() {
+        AWTKeyboardInterceptor.pendingShortcut = pendingFor("keyup-cancel")
+
+        AWTKeyboardInterceptor.cancelPendingShortcut()
+
+        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+        assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)))
+    }
+
+    @Test
+    fun `a plugin-armed chord dispatches through PluginShortcutRegistryImpl once, at release`() {
+        // No side-effect-free probe exists for a plugin dispatch (see PendingShortcut's KDoc),
+        // so this only proves WHEN dispatch is attempted (once, at release, never at arm) via
+        // an unregistered action id, which PluginShortcutRegistryImpl.dispatch reports as
+        // unhandled either way - a crash or a second attempt would still fail this test.
+        AWTKeyboardInterceptor.pendingShortcut =
+            AWTKeyboardInterceptor.PendingShortcut(
+                keyCode = KeyEvent.VK_N,
+                windowId = "keyup-plugin",
+                pluginActionId = "plugin.nonexistent.action",
+            )
+
+        val release = keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)
+        assertFalse(AWTKeyboardInterceptor.handleKeyReleased(release))
+        assertNull(
+            AWTKeyboardInterceptor.pendingShortcut,
+            "the attempt still clears the armed state, even when unhandled",
+        )
+        assertFalse(AWTKeyboardInterceptor.handleKeyReleased(release), "nothing left to fire on a second release")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpInvocationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpInvocationTest.kt
@@ -86,7 +86,7 @@ class ShortcutKeyUpInvocationTest {
         AWTKeyboardInterceptor.pendingShortcut = pending
 
         assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_CONTROL)))
-        assertEquals(pending, AWTKeyboardInterceptor.pendingShortcut)
+        assertNull(AWTKeyboardInterceptor.pendingShortcut)
     }
 
     @Test
@@ -161,9 +161,9 @@ class ShortcutKeyUpInvocationTest {
         MenuActionsHandler.updateActivePanelTabCount(windowId, 1)
         assertFalse(MenuActionsHandler.canStepTabs(windowId))
 
-        assertFalse(
+        assertTrue(
             AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_CLOSE_BRACKET)),
-            "the gate closed before release, so nothing should fire",
+            "the action gate closes, but an already claimed chord still owns its release",
         )
     }
 
@@ -191,7 +191,7 @@ class ShortcutKeyUpInvocationTest {
             )
 
         val release = keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)
-        assertFalse(AWTKeyboardInterceptor.handleKeyReleased(release))
+        assertTrue(AWTKeyboardInterceptor.handleKeyReleased(release))
         assertNull(
             AWTKeyboardInterceptor.pendingShortcut,
             "the attempt still clears the armed state, even when unhandled",

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpInvocationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpInvocationTest.kt
@@ -272,5 +272,4 @@ class ShortcutKeyUpInvocationTest {
         )
         assertFalse(AWTKeyboardInterceptor.handleKeyReleased(release), "nothing left to fire on a second release")
     }
-
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpInvocationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpInvocationTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertTrue
  * `KeyEventDispatcher` (which needs a registered AWT `Window`) or real chord matching (which
  * reads the on-disk keymap via `KeymapSettingsManager`, and so differs between a dev machine
  * and CI - the same reason [TabStepGateTest] and friends avoid it).
- * [AWTKeyboardInterceptor.pendingShortcut] is set directly to arm a known chord instead.
+ * [AWTKeyboardInterceptor.pendingShortcuts] is set directly to arm a known chord instead.
  */
 class ShortcutKeyUpInvocationTest {
     private val source = Canvas()
@@ -44,7 +44,13 @@ class ShortcutKeyUpInvocationTest {
     private fun pendingFor(
         windowId: String,
         keyCode: Int = KeyEvent.VK_N,
-    ) = AWTKeyboardInterceptor.PendingShortcut(keyCode = keyCode, windowId = windowId, hostBinding = tabNewBinding())
+        metaDown: Boolean = true,
+    ) = AWTKeyboardInterceptor.PendingShortcut(
+        keyCode = keyCode,
+        windowId = windowId,
+        hostBinding = tabNewBinding(),
+        metaDown = metaDown,
+    )
 
     @AfterTest
     fun clearPending() {
@@ -53,11 +59,11 @@ class ShortcutKeyUpInvocationTest {
 
     @Test
     fun `a matching key-up fires the action exactly once`() {
-        AWTKeyboardInterceptor.pendingShortcut = pendingFor("keyup-once")
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] = pendingFor("keyup-once")
 
         val release = keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)
         assertTrue(AWTKeyboardInterceptor.handleKeyReleased(release), "the first release must fire")
-        assertNull(AWTKeyboardInterceptor.pendingShortcut, "firing must clear the armed chord")
+        assertNull(AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N], "firing must clear the armed chord")
         assertFalse(
             AWTKeyboardInterceptor.handleKeyReleased(release),
             "a second release of the same key must not fire again",
@@ -67,12 +73,12 @@ class ShortcutKeyUpInvocationTest {
     @Test
     fun `a release of a different key does not fire the armed chord`() {
         val pending = pendingFor("keyup-mismatch")
-        AWTKeyboardInterceptor.pendingShortcut = pending
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] = pending
 
         assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_W)))
         assertEquals(
             pending,
-            AWTKeyboardInterceptor.pendingShortcut,
+            AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N],
             "an unrelated release must leave the armed chord alone",
         )
     }
@@ -83,15 +89,15 @@ class ShortcutKeyUpInvocationTest {
         // modifier-only press before arming (see the test below) - so its own release is just
         // another mismatch. Pinned explicitly since #490 names this acceptance criterion.
         val pending = pendingFor("keyup-modifier")
-        AWTKeyboardInterceptor.pendingShortcut = pending
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] = pending
 
         assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_CONTROL)))
-        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+        assertNull(AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N])
     }
 
     @Test
     fun `with no chord armed, a key-up does nothing`() {
-        AWTKeyboardInterceptor.pendingShortcut = null
+        assertTrue(AWTKeyboardInterceptor.pendingShortcuts.isEmpty())
         assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)))
     }
 
@@ -99,7 +105,7 @@ class ShortcutKeyUpInvocationTest {
     fun `a repeat key-down for the armed key is claimed without re-arming or firing`() {
         val windowId = "keyup-repeat"
         val pending = pendingFor(windowId)
-        AWTKeyboardInterceptor.pendingShortcut = pending
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] = pending
 
         // OS auto-repeat delivers KEY_PRESSED again and again while a key is held; each one
         // must stay claimed (so it doesn't leak to the focused component) without firing.
@@ -110,27 +116,85 @@ class ShortcutKeyUpInvocationTest {
         }
         assertEquals(
             pending,
-            AWTKeyboardInterceptor.pendingShortcut,
+            AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N],
             "repeats must not re-arm or replace the pending chord",
         )
 
         // Still fires exactly once, on the eventual release - not once per repeat.
         assertTrue(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)))
-        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+        assertNull(AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N])
     }
 
     @Test
     fun `a key-down with no modifier held is never armed`() {
         val press = keyEvent(KeyEvent.KEY_PRESSED, KeyEvent.VK_N, 0)
         assertFalse(AWTKeyboardInterceptor.handleKeyPressed(press, "keyup-nomod"))
-        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+        assertNull(AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N])
     }
 
     @Test
     fun `a bare modifier key-down is never armed`() {
         val press = keyEvent(KeyEvent.KEY_PRESSED, KeyEvent.VK_CONTROL, InputEvent.CTRL_DOWN_MASK)
         assertFalse(AWTKeyboardInterceptor.handleKeyPressed(press, "keyup-modonly"))
-        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+        assertNull(AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_CONTROL])
+    }
+
+    @Test
+    fun `a stale arm with different modifiers does not swallow a later bare keystroke`() {
+        // Simulates a lost KEY_RELEASED: the chord is still armed with Cmd held, but the user
+        // has since let go of everything and is now typing 'n' on its own. Regression for the
+        // review's finding #2 on BossConsole#490 - the repeat-claim check used to key on keyCode
+        // alone, so this bare press matched the stale entry and was silently swallowed, then its
+        // release fired the shortcut for a keystroke that was never meant to be one.
+        //
+        // Only the repeat-claim check itself is exercised here (via handleKeyPressed), not the
+        // full re-match-and-arm path below it - that reads the real on-disk keymap via
+        // findMatchingBinding, which this suite deliberately avoids depending on (see the class
+        // KDoc). A bare, unmodified press has no binding to match regardless of what the keymap
+        // says, so handleKeyPressed correctly returns false here either way.
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] = pendingFor("keyup-stale", metaDown = true)
+
+        val barePress = keyEvent(KeyEvent.KEY_PRESSED, KeyEvent.VK_N, 0)
+        assertFalse(
+            AWTKeyboardInterceptor.handleKeyPressed(barePress, "keyup-stale"),
+            "a bare press must fall through to the modifier gate, not match the stale entry",
+        )
+
+        // A stale action must be removed, not merely skipped during the new press.
+        assertNull(AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N])
+        assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)))
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] = pendingFor("keyup-fresh", metaDown = true)
+        assertEquals("keyup-fresh", AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N]?.windowId)
+    }
+
+    @Test
+    fun `two chords on different keys stay armed independently - one does not evict the other`() {
+        // Regression for the review's finding #3: rolling Cmd+N into Cmd+T without fully
+        // releasing N used to overwrite a single pending slot, silently dropping the first
+        // chord (its eventual release found nothing to fire, and leaked to the focused
+        // component with no matching key-down to explain it). Armed by hand rather than through
+        // handleKeyPressed's real-keymap matching, per this suite's usual pattern.
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] = pendingFor("keyup-roll", metaDown = true)
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_T] =
+            AWTKeyboardInterceptor.PendingShortcut(
+                keyCode = KeyEvent.VK_T,
+                windowId = "keyup-roll",
+                hostBinding =
+                    AWTKeyboardInterceptor.BindingMatch(
+                        KeyBinding(actionId = KeymapActions.TAB_CLOSE, key = "T", modifiers = listOf("Cmd")),
+                        KeyStroke("T", listOf("Cmd")),
+                    ),
+                metaDown = true,
+            )
+
+        assertEquals(2, AWTKeyboardInterceptor.pendingShortcuts.size, "both chords must stay armed")
+
+        assertTrue(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_T)))
+        assertTrue(
+            AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)),
+            "the first chord must still fire on its own release, not have been silently dropped",
+        )
+        assertTrue(AWTKeyboardInterceptor.pendingShortcuts.isEmpty())
     }
 
     @Test
@@ -150,30 +214,36 @@ class ShortcutKeyUpInvocationTest {
                 modifiers = listOf("Cmd", "Shift"),
             )
         val keystroke = KeyStroke("CloseBracket", listOf("Cmd", "Shift"))
-        AWTKeyboardInterceptor.pendingShortcut =
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_CLOSE_BRACKET] =
             AWTKeyboardInterceptor.PendingShortcut(
                 keyCode = KeyEvent.VK_CLOSE_BRACKET,
                 windowId = windowId,
                 hostBinding = AWTKeyboardInterceptor.BindingMatch(binding, keystroke),
+                metaDown = true,
+                shiftDown = true,
             )
 
         // Close the gate before the key is ever released.
         MenuActionsHandler.updateActivePanelTabCount(windowId, 1)
         assertFalse(MenuActionsHandler.canStepTabs(windowId))
 
+        // Still consumed - the release matched and cleared an armed chord, which is what
+        // decides consumption (finding #4). Whether the gated action actually fired is a
+        // separate question this return value no longer answers.
         assertTrue(
             AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_CLOSE_BRACKET)),
-            "the action gate closes, but an already claimed chord still owns its release",
+            "a release that matched and cleared an armed chord is consumed regardless of whether the gate let it fire",
         )
+        assertNull(AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_CLOSE_BRACKET])
     }
 
     @Test
     fun `cancelling drops an armed chord so its eventual release does nothing`() {
-        AWTKeyboardInterceptor.pendingShortcut = pendingFor("keyup-cancel")
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] = pendingFor("keyup-cancel")
 
         AWTKeyboardInterceptor.cancelPendingShortcut()
 
-        assertNull(AWTKeyboardInterceptor.pendingShortcut)
+        assertTrue(AWTKeyboardInterceptor.pendingShortcuts.isEmpty())
         assertFalse(AWTKeyboardInterceptor.handleKeyReleased(keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)))
     }
 
@@ -183,19 +253,24 @@ class ShortcutKeyUpInvocationTest {
         // so this only proves WHEN dispatch is attempted (once, at release, never at arm) via
         // an unregistered action id, which PluginShortcutRegistryImpl.dispatch reports as
         // unhandled either way - a crash or a second attempt would still fail this test.
-        AWTKeyboardInterceptor.pendingShortcut =
+        AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N] =
             AWTKeyboardInterceptor.PendingShortcut(
                 keyCode = KeyEvent.VK_N,
                 windowId = "keyup-plugin",
                 pluginActionId = "plugin.nonexistent.action",
+                metaDown = true,
             )
 
         val release = keyEvent(KeyEvent.KEY_RELEASED, KeyEvent.VK_N)
-        assertTrue(AWTKeyboardInterceptor.handleKeyReleased(release))
+        assertTrue(
+            AWTKeyboardInterceptor.handleKeyReleased(release),
+            "consumed because it matched and cleared an armed chord, even though nothing handled it",
+        )
         assertNull(
-            AWTKeyboardInterceptor.pendingShortcut,
+            AWTKeyboardInterceptor.pendingShortcuts[KeyEvent.VK_N],
             "the attempt still clears the armed state, even when unhandled",
         )
         assertFalse(AWTKeyboardInterceptor.handleKeyReleased(release), "nothing left to fire on a second release")
     }
+
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
@@ -1,26 +1,26 @@
 package ai.rever.boss.window
 
 import ai.rever.boss.components.plugin.registries.PluginShortcutRegistryImpl
-import ai.rever.boss.plugin.api.KeyChordSpec
-import ai.rever.boss.plugin.api.PluginShortcutSpec
-import ai.rever.boss.plugin.api.ShortcutActionProvider
 import ai.rever.boss.keymap.KeymapSettingsManager
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.plugin.api.KeyChordSpec
+import ai.rever.boss.plugin.api.PluginShortcutSpec
+import ai.rever.boss.plugin.api.ShortcutActionProvider
 import ai.rever.boss.utils.SystemUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import java.awt.Canvas
 import java.awt.KeyboardFocusManager
-import java.beans.PropertyChangeEvent
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
+import java.beans.PropertyChangeEvent
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -50,8 +50,11 @@ class ShortcutKeyUpSemanticsTest {
 
     @Suppress("DEPRECATION")
     private val primaryModifierMask =
-        if (SystemUtils.isMacOS) (InputEvent.META_DOWN_MASK or InputEvent.META_MASK)
-        else (InputEvent.CTRL_DOWN_MASK or InputEvent.CTRL_MASK)
+        if (SystemUtils.isMacOS) {
+            (InputEvent.META_DOWN_MASK or InputEvent.META_MASK)
+        } else {
+            (InputEvent.CTRL_DOWN_MASK or InputEvent.CTRL_MASK)
+        }
     private val modifierKeyCode =
         if (SystemUtils.isMacOS) KeyEvent.VK_META else KeyEvent.VK_CONTROL
 
@@ -59,13 +62,14 @@ class ShortcutKeyUpSemanticsTest {
     fun setUp() {
         testScope = CoroutineScope(Dispatchers.Unconfined)
         newTabEventCount.set(0)
-        collectorJob = testScope.launch {
-            MenuActionsHandler.newTabEvents.collect { winId ->
-                if (winId == windowId) {
-                    newTabEventCount.incrementAndGet()
+        collectorJob =
+            testScope.launch {
+                MenuActionsHandler.newTabEvents.collect { winId ->
+                    if (winId == windowId) {
+                        newTabEventCount.incrementAndGet()
+                    }
                 }
             }
-        }
 
         AWTKeyboardInterceptor.install()
         canvas = Canvas()
@@ -98,8 +102,7 @@ class ShortcutKeyUpSemanticsTest {
         testScope.cancel()
     }
 
-    private fun dispatchKeyEvent(event: KeyEvent): Boolean =
-        AWTKeyboardInterceptor.processKeyEvent(event, windowId)
+    private fun dispatchKeyEvent(event: KeyEvent): Boolean = AWTKeyboardInterceptor.processKeyEvent(event, windowId)
 
     @Test
     fun `matching KEY_PRESSED arms pending shortcut and consumes without action dispatch`() {
@@ -117,7 +120,10 @@ class ShortcutKeyUpSemanticsTest {
 
         assertTrue(consumed, "KeyDown matching shortcut must be consumed")
         assertTrue(keyDown.isConsumed, "KeyEvent must be marked consumed")
-        assertTrue(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(), "AWTKeyboardInterceptor must have pending shortcut armed")
+        assertTrue(
+            AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(),
+            "AWTKeyboardInterceptor must have pending shortcut armed",
+        )
         assertEquals(0, newTabEventCount.get(), "Action must not be dispatched on key-down")
     }
 
@@ -149,7 +155,10 @@ class ShortcutKeyUpSemanticsTest {
         assertTrue(consumed, "KeyUp on primary key must be consumed")
         assertTrue(keyUp.isConsumed, "KeyUp event must be marked consumed")
         assertEquals(1, newTabEventCount.get(), "Action must be dispatched exactly once on KeyUp")
-        assertFalse(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(), "Pending shortcut must be cleared after dispatch")
+        assertFalse(
+            AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(),
+            "Pending shortcut must be cleared after dispatch",
+        )
     }
 
     @Test
@@ -214,7 +223,10 @@ class ShortcutKeyUpSemanticsTest {
 
         assertFalse(consumed, "Releasing modifier alone should not be consumed as shortcut execution")
         assertEquals(0, newTabEventCount.get(), "Action must not be dispatched when modifier is released alone")
-        assertFalse(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(), "Pending shortcut must be cancelled on modifier release")
+        assertFalse(
+            AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(),
+            "Pending shortcut must be cancelled on modifier release",
+        )
 
         // Subsequent primary key release does nothing
         val keyUp =
@@ -275,37 +287,64 @@ class ShortcutKeyUpSemanticsTest {
     fun `Shift release cancels and held repeats cannot rearm the action`() {
         val press = KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')
         assertTrue(dispatchKeyEvent(press))
-        assertFalse(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 1, primaryModifierMask,
-            KeyEvent.VK_SHIFT, KeyEvent.CHAR_UNDEFINED)))
+        assertFalse(
+            dispatchKeyEvent(
+                KeyEvent(
+                    canvas,
+                    KeyEvent.KEY_RELEASED,
+                    1,
+                    primaryModifierMask,
+                    KeyEvent.VK_SHIFT,
+                    KeyEvent.CHAR_UNDEFINED,
+                ),
+            ),
+        )
         repeat(3) { assertTrue(dispatchKeyEvent(press)) }
-        assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 2, primaryModifierMask, KeyEvent.VK_T, 'T')))
+        assertTrue(
+            dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 2, primaryModifierMask, KeyEvent.VK_T, 'T')),
+        )
         assertEquals(0, newTabEventCount.get())
     }
 
     @Test
     fun `MRU commits once and cancels a second held Tab when modifier releases first`() {
-        settingsState.value = KeymapSettings.fromBindings(listOf(
-            KeyBinding(actionId = KeymapActions.TAB_NEXT, key = "Tab", modifiers = listOf("Cmd")),
-        )).copy(tabSwitchMode = ai.rever.boss.keymap.model.TabSwitchMode.MRU)
+        settingsState.value =
+            KeymapSettings
+                .fromBindings(
+                    listOf(
+                        KeyBinding(actionId = KeymapActions.TAB_NEXT, key = "Tab", modifiers = listOf("Cmd")),
+                    ),
+                ).copy(tabSwitchMode = ai.rever.boss.keymap.model.TabSwitchMode.MRU)
         val events = mutableListOf<Pair<String, MenuActionsHandler.TabSwitchAction>>()
         val job = testScope.launch { MenuActionsHandler.tabSwitchEvents.collect { events.add(it) } }
+
         fun tab(id: Int) = KeyEvent(canvas, id, 0, primaryModifierMask, KeyEvent.VK_TAB, '\t')
         assertTrue(dispatchKeyEvent(tab(KeyEvent.KEY_PRESSED)))
         assertTrue(events.isEmpty())
         assertTrue(dispatchKeyEvent(tab(KeyEvent.KEY_RELEASED)))
         assertTrue(dispatchKeyEvent(tab(KeyEvent.KEY_PRESSED)))
-        assertFalse(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 1, 0, modifierKeyCode, KeyEvent.CHAR_UNDEFINED)))
+        assertFalse(
+            dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 1, 0, modifierKeyCode, KeyEvent.CHAR_UNDEFINED)),
+        )
         assertTrue(dispatchKeyEvent(tab(KeyEvent.KEY_RELEASED)))
-        assertEquals(listOf(windowId to MenuActionsHandler.TabSwitchAction.NEXT,
-            windowId to MenuActionsHandler.TabSwitchAction.COMMIT), events)
+        assertEquals(
+            listOf(
+                windowId to MenuActionsHandler.TabSwitchAction.NEXT,
+                windowId to MenuActionsHandler.TabSwitchAction.COMMIT,
+            ),
+            events,
+        )
         job.cancel()
     }
 
     @Test
     fun `an unavailable host binding leaves both events unclaimed`() {
-        settingsState.value = KeymapSettings.fromBindings(listOf(
-            KeyBinding(actionId = KeymapActions.QUICK_SWITCHER_OPEN, key = "T", modifiers = listOf("Cmd")),
-        ))
+        settingsState.value =
+            KeymapSettings.fromBindings(
+                listOf(
+                    KeyBinding(actionId = KeymapActions.QUICK_SWITCHER_OPEN, key = "T", modifiers = listOf("Cmd")),
+                ),
+            )
         for (id in listOf(KeyEvent.KEY_PRESSED, KeyEvent.KEY_RELEASED)) {
             val event = KeyEvent(canvas, id, 0, primaryModifierMask, KeyEvent.VK_T, 'T')
             assertFalse(dispatchKeyEvent(event))
@@ -316,16 +355,31 @@ class ShortcutKeyUpSemanticsTest {
 
     @Test
     fun `overlapping chords each fire once on their own release`() {
-        settingsState.value = KeymapSettings.fromBindings(listOf(
-            KeyBinding(actionId = KeymapActions.TAB_NEW, key = "T", modifiers = listOf("Cmd"),
-                alternateKeystrokes = listOf(ai.rever.boss.keymap.model.KeyStroke("N", listOf("Cmd")))),
-        ))
+        settingsState.value =
+            KeymapSettings.fromBindings(
+                listOf(
+                    KeyBinding(
+                        actionId = KeymapActions.TAB_NEW,
+                        key = "T",
+                        modifiers = listOf("Cmd"),
+                        alternateKeystrokes =
+                            listOf(
+                                ai.rever.boss.keymap.model
+                                    .KeyStroke("N", listOf("Cmd")),
+                            ),
+                    ),
+                ),
+            )
         for (key in listOf(KeyEvent.VK_N, KeyEvent.VK_T)) {
-            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, key, key.toChar())))
+            assertTrue(
+                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, key, key.toChar())),
+            )
         }
         assertEquals(0, newTabEventCount.get())
         for ((index, key) in listOf(KeyEvent.VK_N, KeyEvent.VK_T).withIndex()) {
-            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, key, key.toChar())))
+            assertTrue(
+                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, key, key.toChar())),
+            )
             assertEquals(index + 1, newTabEventCount.get())
         }
     }
@@ -334,30 +388,79 @@ class ShortcutKeyUpSemanticsTest {
     fun `plugin defaults and rebinds invoke once and unregistering closes the gate`() {
         val action = "plugin.shortcut-review.run"
         var calls = 0
-        val provider = object : ShortcutActionProvider {
-            override val providerId = "shortcut-review"
-            override fun shortcuts() = listOf(PluginShortcutSpec(action, "Test shortcut",
-                defaultBinding = KeyChordSpec("K", setOf("Cmd"))))
-            override fun onAction(actionId: String, windowId: String?) { calls++ }
-        }
+        val provider =
+            object : ShortcutActionProvider {
+                override val providerId = "shortcut-review"
+
+                override fun shortcuts() =
+                    listOf(
+                        PluginShortcutSpec(
+                            action,
+                            "Test shortcut",
+                            defaultBinding = KeyChordSpec("K", setOf("Cmd")),
+                        ),
+                    )
+
+                override fun onAction(
+                    actionId: String,
+                    windowId: String?,
+                ) {
+                    calls++
+                }
+            }
         PluginShortcutRegistryImpl.register(provider)
         try {
             for (rebound in listOf(false, true)) {
-                settingsState.value = KeymapSettings.fromBindings(if (rebound) listOf(
-                    KeyBinding(actionId = action, key = "K", modifiers = listOf("Cmd")),
-                ) else emptyList())
-                repeat(3) { assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0,
-                    primaryModifierMask, KeyEvent.VK_K, 'K'))) }
+                settingsState.value =
+                    KeymapSettings.fromBindings(
+                        if (rebound) {
+                            listOf(
+                                KeyBinding(actionId = action, key = "K", modifiers = listOf("Cmd")),
+                            )
+                        } else {
+                            emptyList()
+                        },
+                    )
+                repeat(3) {
+                    assertTrue(
+                        dispatchKeyEvent(
+                            KeyEvent(
+                                canvas,
+                                KeyEvent.KEY_PRESSED,
+                                0,
+                                primaryModifierMask,
+                                KeyEvent.VK_K,
+                                'K',
+                            ),
+                        ),
+                    )
+                }
                 assertEquals(if (rebound) 1 else 0, calls)
-                assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0,
-                    primaryModifierMask, KeyEvent.VK_K, 'K')))
+                assertTrue(
+                    dispatchKeyEvent(
+                        KeyEvent(
+                            canvas,
+                            KeyEvent.KEY_RELEASED,
+                            0,
+                            primaryModifierMask,
+                            KeyEvent.VK_K,
+                            'K',
+                        ),
+                    ),
+                )
             }
             assertEquals(2, calls)
-            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')))
+            assertTrue(
+                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')),
+            )
             PluginShortcutRegistryImpl.unregister(provider.providerId)
-            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')))
+            assertTrue(
+                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')),
+            )
             assertEquals(2, calls)
-            assertFalse(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')))
+            assertFalse(
+                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')),
+            )
         } finally {
             PluginShortcutRegistryImpl.unregister(provider.providerId)
         }
@@ -373,17 +476,24 @@ class ShortcutKeyUpSemanticsTest {
 
     @Test
     fun `closing a dispatch gate while held consumes release without emitting the action`() {
-        settingsState.value = KeymapSettings.fromBindings(listOf(
-            KeyBinding(actionId = KeymapActions.TAB_NEXT_POSITIONAL, key = "T", modifiers = listOf("Cmd")),
-        ))
+        settingsState.value =
+            KeymapSettings.fromBindings(
+                listOf(
+                    KeyBinding(actionId = KeymapActions.TAB_NEXT_POSITIONAL, key = "T", modifiers = listOf("Cmd")),
+                ),
+            )
         val events = mutableListOf<Pair<String, MenuActionsHandler.TabSwitchAction>>()
         val job = testScope.launch { MenuActionsHandler.tabSwitchEvents.collect { events.add(it) } }
         MenuActionsHandler.updateActivePanelTabCount(windowId, 2)
         try {
-            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')))
+            assertTrue(
+                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')),
+            )
             assertTrue(events.isEmpty())
             MenuActionsHandler.updateActivePanelTabCount(windowId, 1)
-            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')))
+            assertTrue(
+                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')),
+            )
             assertTrue(events.isEmpty())
         } finally {
             job.cancel()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
@@ -1,0 +1,265 @@
+package ai.rever.boss.window
+
+import ai.rever.boss.keymap.KeymapSettingsManager
+import ai.rever.boss.keymap.model.KeyBinding
+import ai.rever.boss.keymap.model.KeymapActions
+import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.utils.SystemUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.awt.Canvas
+import java.awt.KeyboardFocusManager
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.JFrame
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [AWTKeyboardInterceptor] key release semantics.
+ *
+ * Verifies that:
+ * 1. A matching KEY_PRESSED event arms the chord and is consumed without dispatching the action.
+ * 2. Auto-repeat KEY_PRESSED events are consumed and do not dispatch the action.
+ * 3. The matching KEY_RELEASED event of the primary key dispatches the action and is consumed.
+ * 4. Releasing a modifier alone cancels the pending shortcut and does not dispatch.
+ * 5. Window unregister or clearPendingShortcut cancels the pending shortcut.
+ */
+class ShortcutKeyUpSemanticsTest {
+    private lateinit var frame: JFrame
+    private lateinit var canvas: Canvas
+    private val windowId = "test-window-key-release"
+    private lateinit var testScope: CoroutineScope
+    private val newTabEventCount = AtomicInteger(0)
+    private var collectorJob: Job? = null
+
+    @Suppress("DEPRECATION")
+    private val primaryModifierMask =
+        if (SystemUtils.isMacOS) (InputEvent.META_DOWN_MASK or InputEvent.META_MASK)
+        else (InputEvent.CTRL_DOWN_MASK or InputEvent.CTRL_MASK)
+    private val modifierKeyCode =
+        if (SystemUtils.isMacOS) KeyEvent.VK_META else KeyEvent.VK_CONTROL
+
+    @BeforeTest
+    fun setUp() {
+        testScope = CoroutineScope(Dispatchers.Unconfined)
+        newTabEventCount.set(0)
+        collectorJob = testScope.launch {
+            MenuActionsHandler.newTabEvents.collect { winId ->
+                if (winId == windowId) {
+                    newTabEventCount.incrementAndGet()
+                }
+            }
+        }
+
+        AWTKeyboardInterceptor.install()
+        frame = JFrame("Test Frame")
+        frame.iconImages = BossWindowIcon.images
+        canvas = Canvas()
+        frame.add(canvas)
+        frame.pack()
+        AWTKeyboardInterceptor.registerWindow(frame, windowId)
+        AWTKeyboardInterceptor.clearPendingShortcut()
+
+        // Configure a known test binding
+        val binding =
+            KeyBinding(
+                actionId = KeymapActions.TAB_NEW,
+                key = "T",
+                modifiers = listOf("Cmd"),
+                context = ShortcutContext.GLOBAL,
+                enabled = true,
+            )
+        runBlocking {
+            KeymapSettingsManager.updateSettings(KeymapSettings.fromBindings(listOf(binding)))
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        AWTKeyboardInterceptor.clearPendingShortcut()
+        AWTKeyboardInterceptor.unregisterWindow(frame)
+        AWTKeyboardInterceptor.uninstall()
+        frame.dispose()
+        collectorJob?.cancel()
+        testScope.cancel()
+    }
+
+    private fun dispatchKeyEvent(event: KeyEvent): Boolean =
+        AWTKeyboardInterceptor.processKeyEvent(event)
+
+    @Test
+    fun `matching KEY_PRESSED arms pending shortcut and consumes without action dispatch`() {
+        val keyDown =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_PRESSED,
+                System.currentTimeMillis(),
+                primaryModifierMask,
+                KeyEvent.VK_T,
+                'T',
+            )
+
+        val consumed = dispatchKeyEvent(keyDown)
+
+        assertTrue(consumed, "KeyDown matching shortcut must be consumed")
+        assertTrue(keyDown.isConsumed, "KeyEvent must be marked consumed")
+        assertTrue(AWTKeyboardInterceptor.hasPendingShortcut(), "AWTKeyboardInterceptor must have pending shortcut armed")
+        assertEquals(0, newTabEventCount.get(), "Action must not be dispatched on key-down")
+    }
+
+    @Test
+    fun `matching KEY_RELEASED on primary key dispatches action exactly once`() {
+        val keyDown =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_PRESSED,
+                System.currentTimeMillis(),
+                primaryModifierMask,
+                KeyEvent.VK_T,
+                'T',
+            )
+        dispatchKeyEvent(keyDown)
+        assertEquals(0, newTabEventCount.get(), "Action must not dispatch on KeyDown")
+
+        val keyUp =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_RELEASED,
+                System.currentTimeMillis(),
+                primaryModifierMask,
+                KeyEvent.VK_T,
+                'T',
+            )
+        val consumed = dispatchKeyEvent(keyUp)
+
+        assertTrue(consumed, "KeyUp on primary key must be consumed")
+        assertTrue(keyUp.isConsumed, "KeyUp event must be marked consumed")
+        assertEquals(1, newTabEventCount.get(), "Action must be dispatched exactly once on KeyUp")
+        assertFalse(AWTKeyboardInterceptor.hasPendingShortcut(), "Pending shortcut must be cleared after dispatch")
+    }
+
+    @Test
+    fun `auto-repeat KEY_PRESSED events do not cause multiple dispatches`() {
+        // Simulate 5 auto-repeat key-down events
+        repeat(5) {
+            val keyDown =
+                KeyEvent(
+                    canvas,
+                    KeyEvent.KEY_PRESSED,
+                    System.currentTimeMillis(),
+                    primaryModifierMask,
+                    KeyEvent.VK_T,
+                    'T',
+                )
+            val consumed = dispatchKeyEvent(keyDown)
+            assertTrue(consumed, "Auto-repeat KeyDown must be consumed")
+            assertEquals(0, newTabEventCount.get(), "Auto-repeat must not dispatch action")
+        }
+
+        // Release primary key
+        val keyUp =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_RELEASED,
+                System.currentTimeMillis(),
+                primaryModifierMask,
+                KeyEvent.VK_T,
+                'T',
+            )
+        val consumed = dispatchKeyEvent(keyUp)
+
+        assertTrue(consumed, "KeyUp must be consumed")
+        assertEquals(1, newTabEventCount.get(), "Action must be dispatched exactly once on release")
+    }
+
+    @Test
+    fun `releasing modifier alone does not dispatch action and cancels pending shortcut`() {
+        val keyDown =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_PRESSED,
+                System.currentTimeMillis(),
+                primaryModifierMask,
+                KeyEvent.VK_T,
+                'T',
+            )
+        dispatchKeyEvent(keyDown)
+        assertTrue(AWTKeyboardInterceptor.hasPendingShortcut())
+
+        // Release modifier key alone (e.g. Cmd/Ctrl)
+        val modifierKeyUp =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_RELEASED,
+                System.currentTimeMillis(),
+                0,
+                modifierKeyCode,
+                KeyEvent.CHAR_UNDEFINED,
+            )
+        val consumed = dispatchKeyEvent(modifierKeyUp)
+
+        assertFalse(consumed, "Releasing modifier alone should not be consumed as shortcut execution")
+        assertEquals(0, newTabEventCount.get(), "Action must not be dispatched when modifier is released alone")
+        assertFalse(AWTKeyboardInterceptor.hasPendingShortcut(), "Pending shortcut must be cancelled on modifier release")
+
+        // Subsequent primary key release does nothing
+        val keyUp =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_RELEASED,
+                System.currentTimeMillis(),
+                0,
+                KeyEvent.VK_T,
+                'T',
+            )
+        val keyUpConsumed = dispatchKeyEvent(keyUp)
+
+        assertFalse(keyUpConsumed)
+        assertEquals(0, newTabEventCount.get())
+    }
+
+    @Test
+    fun `clearPendingShortcut cancels pending shortcut on focus loss or window unregister`() {
+        val keyDown =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_PRESSED,
+                System.currentTimeMillis(),
+                primaryModifierMask,
+                KeyEvent.VK_T,
+                'T',
+            )
+        dispatchKeyEvent(keyDown)
+        assertTrue(AWTKeyboardInterceptor.hasPendingShortcut())
+
+        // Reset/cancel pending shortcut
+        AWTKeyboardInterceptor.clearPendingShortcut()
+        assertFalse(AWTKeyboardInterceptor.hasPendingShortcut())
+
+        // Key up after cancellation should not dispatch action
+        val keyUp =
+            KeyEvent(
+                canvas,
+                KeyEvent.KEY_RELEASED,
+                System.currentTimeMillis(),
+                primaryModifierMask,
+                KeyEvent.VK_T,
+                'T',
+            )
+        val consumed = dispatchKeyEvent(keyUp)
+
+        assertFalse(consumed)
+        assertEquals(0, newTabEventCount.get())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
@@ -388,26 +388,7 @@ class ShortcutKeyUpSemanticsTest {
     fun `plugin defaults and rebinds invoke once and unregistering closes the gate`() {
         val action = "plugin.shortcut-review.run"
         var calls = 0
-        val provider =
-            object : ShortcutActionProvider {
-                override val providerId = "shortcut-review"
-
-                override fun shortcuts() =
-                    listOf(
-                        PluginShortcutSpec(
-                            action,
-                            "Test shortcut",
-                            defaultBinding = KeyChordSpec("K", setOf("Cmd")),
-                        ),
-                    )
-
-                override fun onAction(
-                    actionId: String,
-                    windowId: String?,
-                ) {
-                    calls++
-                }
-            }
+        val provider = shortcutProvider(action) { calls++ }
         PluginShortcutRegistryImpl.register(provider)
         try {
             for (rebound in listOf(false, true)) {
@@ -424,47 +405,59 @@ class ShortcutKeyUpSemanticsTest {
                 repeat(3) {
                     assertTrue(
                         dispatchKeyEvent(
-                            KeyEvent(
-                                canvas,
-                                KeyEvent.KEY_PRESSED,
-                                0,
-                                primaryModifierMask,
-                                KeyEvent.VK_K,
-                                'K',
-                            ),
+                            pluginKeyEvent(KeyEvent.KEY_PRESSED),
                         ),
                     )
                 }
                 assertEquals(if (rebound) 1 else 0, calls)
                 assertTrue(
                     dispatchKeyEvent(
-                        KeyEvent(
-                            canvas,
-                            KeyEvent.KEY_RELEASED,
-                            0,
-                            primaryModifierMask,
-                            KeyEvent.VK_K,
-                            'K',
-                        ),
+                        pluginKeyEvent(KeyEvent.KEY_RELEASED),
                     ),
                 )
             }
             assertEquals(2, calls)
             assertTrue(
-                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')),
+                dispatchKeyEvent(pluginKeyEvent(KeyEvent.KEY_PRESSED)),
             )
             PluginShortcutRegistryImpl.unregister(provider.providerId)
             assertTrue(
-                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')),
+                dispatchKeyEvent(pluginKeyEvent(KeyEvent.KEY_RELEASED)),
             )
             assertEquals(2, calls)
             assertFalse(
-                dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')),
+                dispatchKeyEvent(pluginKeyEvent(KeyEvent.KEY_PRESSED)),
             )
         } finally {
             PluginShortcutRegistryImpl.unregister(provider.providerId)
         }
     }
+
+    private fun pluginKeyEvent(eventId: Int) = KeyEvent(canvas, eventId, 0, primaryModifierMask, KeyEvent.VK_K, 'K')
+
+    private fun shortcutProvider(
+        action: String,
+        onInvoke: () -> Unit,
+    ): ShortcutActionProvider =
+        object : ShortcutActionProvider {
+            override val providerId = "shortcut-review"
+
+            override fun shortcuts() =
+                listOf(
+                    PluginShortcutSpec(
+                        action,
+                        "Test shortcut",
+                        defaultBinding = KeyChordSpec("K", setOf("Cmd")),
+                    ),
+                )
+
+            override fun onAction(
+                actionId: String,
+                windowId: String?,
+            ) {
+                onInvoke()
+            }
+        }
 
     @Test
     fun `lost primary release cannot turn a later bare character into an action`() {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
@@ -117,7 +117,7 @@ class ShortcutKeyUpSemanticsTest {
 
         assertTrue(consumed, "KeyDown matching shortcut must be consumed")
         assertTrue(keyDown.isConsumed, "KeyEvent must be marked consumed")
-        assertTrue((AWTKeyboardInterceptor.pendingShortcut != null), "AWTKeyboardInterceptor must have pending shortcut armed")
+        assertTrue(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(), "AWTKeyboardInterceptor must have pending shortcut armed")
         assertEquals(0, newTabEventCount.get(), "Action must not be dispatched on key-down")
     }
 
@@ -149,7 +149,7 @@ class ShortcutKeyUpSemanticsTest {
         assertTrue(consumed, "KeyUp on primary key must be consumed")
         assertTrue(keyUp.isConsumed, "KeyUp event must be marked consumed")
         assertEquals(1, newTabEventCount.get(), "Action must be dispatched exactly once on KeyUp")
-        assertFalse((AWTKeyboardInterceptor.pendingShortcut != null), "Pending shortcut must be cleared after dispatch")
+        assertFalse(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(), "Pending shortcut must be cleared after dispatch")
     }
 
     @Test
@@ -198,7 +198,7 @@ class ShortcutKeyUpSemanticsTest {
                 'T',
             )
         dispatchKeyEvent(keyDown)
-        assertTrue((AWTKeyboardInterceptor.pendingShortcut != null))
+        assertTrue(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty())
 
         // Release modifier key alone (e.g. Cmd/Ctrl)
         val modifierKeyUp =
@@ -214,7 +214,7 @@ class ShortcutKeyUpSemanticsTest {
 
         assertFalse(consumed, "Releasing modifier alone should not be consumed as shortcut execution")
         assertEquals(0, newTabEventCount.get(), "Action must not be dispatched when modifier is released alone")
-        assertFalse((AWTKeyboardInterceptor.pendingShortcut != null), "Pending shortcut must be cancelled on modifier release")
+        assertFalse(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty(), "Pending shortcut must be cancelled on modifier release")
 
         // Subsequent primary key release does nothing
         val keyUp =
@@ -244,7 +244,7 @@ class ShortcutKeyUpSemanticsTest {
                 'T',
             )
         dispatchKeyEvent(keyDown)
-        assertTrue((AWTKeyboardInterceptor.pendingShortcut != null))
+        assertTrue(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty())
 
         // Exercise the listener registered by install without creating or focusing a window.
         val manager = KeyboardFocusManager.getCurrentKeyboardFocusManager()
@@ -253,7 +253,7 @@ class ShortcutKeyUpSemanticsTest {
         val listener = listenerField.get(AWTKeyboardInterceptor) as java.beans.PropertyChangeListener
         assertTrue(manager.getPropertyChangeListeners("focusedWindow").contains(listener))
         listener.propertyChange(PropertyChangeEvent(manager, "focusedWindow", null, null))
-        assertFalse((AWTKeyboardInterceptor.pendingShortcut != null))
+        assertFalse(AWTKeyboardInterceptor.pendingShortcuts.isNotEmpty())
 
         // Key up after cancellation should not dispatch action
         val keyUp =

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
@@ -1,5 +1,9 @@
 package ai.rever.boss.window
 
+import ai.rever.boss.components.plugin.registries.PluginShortcutRegistryImpl
+import ai.rever.boss.plugin.api.KeyChordSpec
+import ai.rever.boss.plugin.api.PluginShortcutSpec
+import ai.rever.boss.plugin.api.ShortcutActionProvider
 import ai.rever.boss.keymap.KeymapSettingsManager
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.KeymapActions
@@ -11,13 +15,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.MutableStateFlow
 import java.awt.Canvas
 import java.awt.KeyboardFocusManager
+import java.beans.PropertyChangeEvent
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.util.concurrent.atomic.AtomicInteger
-import javax.swing.JFrame
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -36,7 +40,8 @@ import kotlin.test.assertTrue
  * 5. Window unregister or clearPendingShortcut cancels the pending shortcut.
  */
 class ShortcutKeyUpSemanticsTest {
-    private lateinit var frame: JFrame
+    private lateinit var previousSettings: KeymapSettings
+    private lateinit var settingsState: MutableStateFlow<KeymapSettings>
     private lateinit var canvas: Canvas
     private val windowId = "test-window-key-release"
     private lateinit var testScope: CoroutineScope
@@ -63,13 +68,14 @@ class ShortcutKeyUpSemanticsTest {
         }
 
         AWTKeyboardInterceptor.install()
-        frame = JFrame("Test Frame")
-        frame.iconImages = BossWindowIcon.images
         canvas = Canvas()
-        frame.add(canvas)
-        frame.pack()
-        AWTKeyboardInterceptor.registerWindow(frame, windowId)
-        AWTKeyboardInterceptor.clearPendingShortcut()
+        AWTKeyboardInterceptor.cancelPendingShortcut()
+        val field = KeymapSettingsManager::class.java.getDeclaredField("_currentSettings")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val state = field.get(KeymapSettingsManager) as MutableStateFlow<KeymapSettings>
+        settingsState = state
+        previousSettings = state.value
 
         // Configure a known test binding
         val binding =
@@ -80,23 +86,20 @@ class ShortcutKeyUpSemanticsTest {
                 context = ShortcutContext.GLOBAL,
                 enabled = true,
             )
-        runBlocking {
-            KeymapSettingsManager.updateSettings(KeymapSettings.fromBindings(listOf(binding)))
-        }
+        settingsState.value = KeymapSettings.fromBindings(listOf(binding))
     }
 
     @AfterTest
     fun tearDown() {
-        AWTKeyboardInterceptor.clearPendingShortcut()
-        AWTKeyboardInterceptor.unregisterWindow(frame)
+        AWTKeyboardInterceptor.cancelPendingShortcut()
         AWTKeyboardInterceptor.uninstall()
-        frame.dispose()
+        settingsState.value = previousSettings
         collectorJob?.cancel()
         testScope.cancel()
     }
 
     private fun dispatchKeyEvent(event: KeyEvent): Boolean =
-        AWTKeyboardInterceptor.processKeyEvent(event)
+        AWTKeyboardInterceptor.processKeyEvent(event, windowId)
 
     @Test
     fun `matching KEY_PRESSED arms pending shortcut and consumes without action dispatch`() {
@@ -114,7 +117,7 @@ class ShortcutKeyUpSemanticsTest {
 
         assertTrue(consumed, "KeyDown matching shortcut must be consumed")
         assertTrue(keyDown.isConsumed, "KeyEvent must be marked consumed")
-        assertTrue(AWTKeyboardInterceptor.hasPendingShortcut(), "AWTKeyboardInterceptor must have pending shortcut armed")
+        assertTrue((AWTKeyboardInterceptor.pendingShortcut != null), "AWTKeyboardInterceptor must have pending shortcut armed")
         assertEquals(0, newTabEventCount.get(), "Action must not be dispatched on key-down")
     }
 
@@ -146,7 +149,7 @@ class ShortcutKeyUpSemanticsTest {
         assertTrue(consumed, "KeyUp on primary key must be consumed")
         assertTrue(keyUp.isConsumed, "KeyUp event must be marked consumed")
         assertEquals(1, newTabEventCount.get(), "Action must be dispatched exactly once on KeyUp")
-        assertFalse(AWTKeyboardInterceptor.hasPendingShortcut(), "Pending shortcut must be cleared after dispatch")
+        assertFalse((AWTKeyboardInterceptor.pendingShortcut != null), "Pending shortcut must be cleared after dispatch")
     }
 
     @Test
@@ -195,7 +198,7 @@ class ShortcutKeyUpSemanticsTest {
                 'T',
             )
         dispatchKeyEvent(keyDown)
-        assertTrue(AWTKeyboardInterceptor.hasPendingShortcut())
+        assertTrue((AWTKeyboardInterceptor.pendingShortcut != null))
 
         // Release modifier key alone (e.g. Cmd/Ctrl)
         val modifierKeyUp =
@@ -211,7 +214,7 @@ class ShortcutKeyUpSemanticsTest {
 
         assertFalse(consumed, "Releasing modifier alone should not be consumed as shortcut execution")
         assertEquals(0, newTabEventCount.get(), "Action must not be dispatched when modifier is released alone")
-        assertFalse(AWTKeyboardInterceptor.hasPendingShortcut(), "Pending shortcut must be cancelled on modifier release")
+        assertFalse((AWTKeyboardInterceptor.pendingShortcut != null), "Pending shortcut must be cancelled on modifier release")
 
         // Subsequent primary key release does nothing
         val keyUp =
@@ -225,7 +228,7 @@ class ShortcutKeyUpSemanticsTest {
             )
         val keyUpConsumed = dispatchKeyEvent(keyUp)
 
-        assertFalse(keyUpConsumed)
+        assertTrue(keyUpConsumed, "The cancelled chord still owns the primary release")
         assertEquals(0, newTabEventCount.get())
     }
 
@@ -241,11 +244,16 @@ class ShortcutKeyUpSemanticsTest {
                 'T',
             )
         dispatchKeyEvent(keyDown)
-        assertTrue(AWTKeyboardInterceptor.hasPendingShortcut())
+        assertTrue((AWTKeyboardInterceptor.pendingShortcut != null))
 
-        // Reset/cancel pending shortcut
-        AWTKeyboardInterceptor.clearPendingShortcut()
-        assertFalse(AWTKeyboardInterceptor.hasPendingShortcut())
+        // Exercise the listener registered by install without creating or focusing a window.
+        val manager = KeyboardFocusManager.getCurrentKeyboardFocusManager()
+        val listenerField = AWTKeyboardInterceptor::class.java.getDeclaredField("focusListener")
+        listenerField.isAccessible = true
+        val listener = listenerField.get(AWTKeyboardInterceptor) as java.beans.PropertyChangeListener
+        assertTrue(manager.getPropertyChangeListeners("focusedWindow").contains(listener))
+        listener.propertyChange(PropertyChangeEvent(manager, "focusedWindow", null, null))
+        assertFalse((AWTKeyboardInterceptor.pendingShortcut != null))
 
         // Key up after cancellation should not dispatch action
         val keyUp =
@@ -261,5 +269,125 @@ class ShortcutKeyUpSemanticsTest {
 
         assertFalse(consumed)
         assertEquals(0, newTabEventCount.get())
+    }
+
+    @Test
+    fun `Shift release cancels and held repeats cannot rearm the action`() {
+        val press = KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')
+        assertTrue(dispatchKeyEvent(press))
+        assertFalse(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 1, primaryModifierMask,
+            KeyEvent.VK_SHIFT, KeyEvent.CHAR_UNDEFINED)))
+        repeat(3) { assertTrue(dispatchKeyEvent(press)) }
+        assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 2, primaryModifierMask, KeyEvent.VK_T, 'T')))
+        assertEquals(0, newTabEventCount.get())
+    }
+
+    @Test
+    fun `MRU commits once and cancels a second held Tab when modifier releases first`() {
+        settingsState.value = KeymapSettings.fromBindings(listOf(
+            KeyBinding(actionId = KeymapActions.TAB_NEXT, key = "Tab", modifiers = listOf("Cmd")),
+        )).copy(tabSwitchMode = ai.rever.boss.keymap.model.TabSwitchMode.MRU)
+        val events = mutableListOf<Pair<String, MenuActionsHandler.TabSwitchAction>>()
+        val job = testScope.launch { MenuActionsHandler.tabSwitchEvents.collect { events.add(it) } }
+        fun tab(id: Int) = KeyEvent(canvas, id, 0, primaryModifierMask, KeyEvent.VK_TAB, '\t')
+        assertTrue(dispatchKeyEvent(tab(KeyEvent.KEY_PRESSED)))
+        assertTrue(events.isEmpty())
+        assertTrue(dispatchKeyEvent(tab(KeyEvent.KEY_RELEASED)))
+        assertTrue(dispatchKeyEvent(tab(KeyEvent.KEY_PRESSED)))
+        assertFalse(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 1, 0, modifierKeyCode, KeyEvent.CHAR_UNDEFINED)))
+        assertTrue(dispatchKeyEvent(tab(KeyEvent.KEY_RELEASED)))
+        assertEquals(listOf(windowId to MenuActionsHandler.TabSwitchAction.NEXT,
+            windowId to MenuActionsHandler.TabSwitchAction.COMMIT), events)
+        job.cancel()
+    }
+
+    @Test
+    fun `an unavailable host binding leaves both events unclaimed`() {
+        settingsState.value = KeymapSettings.fromBindings(listOf(
+            KeyBinding(actionId = KeymapActions.QUICK_SWITCHER_OPEN, key = "T", modifiers = listOf("Cmd")),
+        ))
+        for (id in listOf(KeyEvent.KEY_PRESSED, KeyEvent.KEY_RELEASED)) {
+            val event = KeyEvent(canvas, id, 0, primaryModifierMask, KeyEvent.VK_T, 'T')
+            assertFalse(dispatchKeyEvent(event))
+            assertFalse(event.isConsumed)
+        }
+        assertEquals(0, newTabEventCount.get())
+    }
+
+    @Test
+    fun `overlapping chords each fire once on their own release`() {
+        settingsState.value = KeymapSettings.fromBindings(listOf(
+            KeyBinding(actionId = KeymapActions.TAB_NEW, key = "T", modifiers = listOf("Cmd"),
+                alternateKeystrokes = listOf(ai.rever.boss.keymap.model.KeyStroke("N", listOf("Cmd")))),
+        ))
+        for (key in listOf(KeyEvent.VK_N, KeyEvent.VK_T)) {
+            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, key, key.toChar())))
+        }
+        assertEquals(0, newTabEventCount.get())
+        for ((index, key) in listOf(KeyEvent.VK_N, KeyEvent.VK_T).withIndex()) {
+            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, key, key.toChar())))
+            assertEquals(index + 1, newTabEventCount.get())
+        }
+    }
+
+    @Test
+    fun `plugin defaults and rebinds invoke once and unregistering closes the gate`() {
+        val action = "plugin.shortcut-review.run"
+        var calls = 0
+        val provider = object : ShortcutActionProvider {
+            override val providerId = "shortcut-review"
+            override fun shortcuts() = listOf(PluginShortcutSpec(action, "Test shortcut",
+                defaultBinding = KeyChordSpec("K", setOf("Cmd"))))
+            override fun onAction(actionId: String, windowId: String?) { calls++ }
+        }
+        PluginShortcutRegistryImpl.register(provider)
+        try {
+            for (rebound in listOf(false, true)) {
+                settingsState.value = KeymapSettings.fromBindings(if (rebound) listOf(
+                    KeyBinding(actionId = action, key = "K", modifiers = listOf("Cmd")),
+                ) else emptyList())
+                repeat(3) { assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0,
+                    primaryModifierMask, KeyEvent.VK_K, 'K'))) }
+                assertEquals(if (rebound) 1 else 0, calls)
+                assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0,
+                    primaryModifierMask, KeyEvent.VK_K, 'K')))
+            }
+            assertEquals(2, calls)
+            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')))
+            PluginShortcutRegistryImpl.unregister(provider.providerId)
+            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')))
+            assertEquals(2, calls)
+            assertFalse(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_K, 'K')))
+        } finally {
+            PluginShortcutRegistryImpl.unregister(provider.providerId)
+        }
+    }
+
+    @Test
+    fun `lost primary release cannot turn a later bare character into an action`() {
+        assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')))
+        assertFalse(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 1, 0, KeyEvent.VK_T, 't')))
+        assertFalse(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 2, 0, KeyEvent.VK_T, 't')))
+        assertEquals(0, newTabEventCount.get())
+    }
+
+    @Test
+    fun `closing a dispatch gate while held consumes release without emitting the action`() {
+        settingsState.value = KeymapSettings.fromBindings(listOf(
+            KeyBinding(actionId = KeymapActions.TAB_NEXT_POSITIONAL, key = "T", modifiers = listOf("Cmd")),
+        ))
+        val events = mutableListOf<Pair<String, MenuActionsHandler.TabSwitchAction>>()
+        val job = testScope.launch { MenuActionsHandler.tabSwitchEvents.collect { events.add(it) } }
+        MenuActionsHandler.updateActivePanelTabCount(windowId, 2)
+        try {
+            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_PRESSED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')))
+            assertTrue(events.isEmpty())
+            MenuActionsHandler.updateActivePanelTabCount(windowId, 1)
+            assertTrue(dispatchKeyEvent(KeyEvent(canvas, KeyEvent.KEY_RELEASED, 0, primaryModifierMask, KeyEvent.VK_T, 'T')))
+            assertTrue(events.isEmpty())
+        } finally {
+            job.cancel()
+            MenuActionsHandler.updateActivePanelTabCount(windowId, 0)
+        }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ShortcutKeyUpSemanticsTest.kt
@@ -45,8 +45,11 @@ class ShortcutKeyUpSemanticsTest {
 
     @Suppress("DEPRECATION")
     private val primaryModifierMask =
-        if (SystemUtils.isMacOS) (InputEvent.META_DOWN_MASK or InputEvent.META_MASK)
-        else (InputEvent.CTRL_DOWN_MASK or InputEvent.CTRL_MASK)
+        if (SystemUtils.isMacOS) {
+            InputEvent.META_DOWN_MASK or InputEvent.META_MASK
+        } else {
+            InputEvent.CTRL_DOWN_MASK or InputEvent.CTRL_MASK
+        }
     private val modifierKeyCode =
         if (SystemUtils.isMacOS) KeyEvent.VK_META else KeyEvent.VK_CONTROL
 
@@ -54,13 +57,14 @@ class ShortcutKeyUpSemanticsTest {
     fun setUp() {
         testScope = CoroutineScope(Dispatchers.Unconfined)
         newTabEventCount.set(0)
-        collectorJob = testScope.launch {
-            MenuActionsHandler.newTabEvents.collect { winId ->
-                if (winId == windowId) {
-                    newTabEventCount.incrementAndGet()
+        collectorJob =
+            testScope.launch {
+                MenuActionsHandler.newTabEvents.collect { winId ->
+                    if (winId == windowId) {
+                        newTabEventCount.incrementAndGet()
+                    }
                 }
             }
-        }
 
         AWTKeyboardInterceptor.install()
         frame = JFrame("Test Frame")
@@ -95,8 +99,7 @@ class ShortcutKeyUpSemanticsTest {
         testScope.cancel()
     }
 
-    private fun dispatchKeyEvent(event: KeyEvent): Boolean =
-        AWTKeyboardInterceptor.processKeyEvent(event)
+    private fun dispatchKeyEvent(event: KeyEvent): Boolean = AWTKeyboardInterceptor.processKeyEvent(event)
 
     @Test
     fun `matching KEY_PRESSED arms pending shortcut and consumes without action dispatch`() {
@@ -114,7 +117,10 @@ class ShortcutKeyUpSemanticsTest {
 
         assertTrue(consumed, "KeyDown matching shortcut must be consumed")
         assertTrue(keyDown.isConsumed, "KeyEvent must be marked consumed")
-        assertTrue(AWTKeyboardInterceptor.hasPendingShortcut(), "AWTKeyboardInterceptor must have pending shortcut armed")
+        assertTrue(
+            AWTKeyboardInterceptor.hasPendingShortcut(),
+            "AWTKeyboardInterceptor must have pending shortcut armed",
+        )
         assertEquals(0, newTabEventCount.get(), "Action must not be dispatched on key-down")
     }
 
@@ -211,7 +217,10 @@ class ShortcutKeyUpSemanticsTest {
 
         assertFalse(consumed, "Releasing modifier alone should not be consumed as shortcut execution")
         assertEquals(0, newTabEventCount.get(), "Action must not be dispatched when modifier is released alone")
-        assertFalse(AWTKeyboardInterceptor.hasPendingShortcut(), "Pending shortcut must be cancelled on modifier release")
+        assertFalse(
+            AWTKeyboardInterceptor.hasPendingShortcut(),
+            "Pending shortcut must be cancelled on modifier release",
+        )
 
         // Subsequent primary key release does nothing
         val keyUp =

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -6,6 +6,11 @@ plugins {
 
 group = "ai.rever.boss"
 version = "1.0.0"
+
+kotlin {
+    jvmToolchain(17)
+}
+
 application {
     mainClass.set("ai.rever.boss.ApplicationKt")
     applicationDefaultJvmArgs = listOf("-Dio.ktor.development=${extra["io.ktor.development"] ?: "false"}")


### PR DESCRIPTION
Closes #490.

Holding a bound shortcut previously invoked its action on key-down and repeated it while held. This change claims a supported chord on key-down and invokes it once when its primary key is released. Overlapping chords retain independent pending actions. Dispatch gates are checked without side effects before claiming and rechecked at release; unloaded plugin rebinds fall through.

Modifier-first release cancels the pending chord, including Shift. A cancelled held key stays claimed until its release, so OS repeats cannot re-arm it. Focus loss clears pending state, and window removal only clears that window's chords. MRU cancellation runs before committing the cycle, preventing a second pending Tab from reopening the switcher after commit. A stale chord with different press modifiers or window identity is discarded before a later key can be matched.

The shipped entry point is AWTKeyboardInterceptor. The currently unwired Compose interceptor uses KeymapHandler for the same release/cancellation policy; it resets on focus loss, disposal, and settings/window/context changes, and emits a KeyUp event. Plugin shortcut callbacks now run at release too. Double-Shift search is a separate existing gesture.

Contributor credit:
- @Aditya8369 authored #492's initial key-up implementation across AWT/Compose/KeymapHandler and the action-count/handler tests. Follow-up 2bd7e86f improves formatting and JVM toolchain consistency.
- @Antriksh1984 independently authored #493's shared dispatch probe, focus listener, and release/gate tests. Follow-up f3ae8662 adds independent pending chords, modifier snapshots, release ownership, and additional tests. Both original and follow-up authored commits are retained by cherry-pick in this consolidation; #492's follow-up history is retained by merge.
- Review-agent work resolves integration conflicts, repairs stale-state eviction and MRU/Shift cancellation ordering, preserves claimed-key lifetime, checks plugin registration before claiming, uses concurrent pending/claim collections, resets the common matcher on settings changes, and replaces the display-dependent/persisting test fixture with headless in-memory settings and event-count/order regressions. These repairs are not original contributor work.

Validation: 396 focused desktop tests, zero failures/errors, one pre-existing warm-toolkit skip under headless mode; root ktlintCheck passes. Root detekt still fails on two findings in the agent-integrated result: LargeClass at AWTKeyboardInterceptor.kt:29 and LongMethod at ShortcutKeyUpSemanticsTest.kt:388 (64 lines; limit 60). These are remaining integration/style debt, not unaddressed author runtime defects. The last post-test change only wraps lines; no app was launched. The surviving #492 is not ready and is being handed off as draft; final-head hosted checks remain to be verified.

Manual checks remain: hold/release New Tab in Compose, terminal and browser focus; modifier-first and Shift-first cancellation; overlapping chords; MRU repeated Tab with alternate modifiers; focus loss; unavailable/unloaded plugin shortcuts.
