### PR TITLE
Update host API pin for native model catalog support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -154,7 +154,7 @@ intellij-platform = "243.21565.199"
 # implementor. Every addition also carries a default body, so no existing implementor
 # gains an abstract member. The host needs the bump only so a plugin calling these
 # resolves them against the api the host loads, rather than finding them absent.
-boss-plugin-api = "1.0.88"
+boss-plugin-api = "1.0.89"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Preserve the host API pin used by the tested native-harness debug build (1.0.88 -> 1.0.89).
- The host must compile the new availableModels members because these interfaces are host-implemented.
- Streaming itself is an additive API companion and loads from the shared plugin API layer.

## Validation
- Debug host compiled and launched successfully via reused BossTerm.
- Verified runtime API1.0.90, Gateway1.1.10 and Fluck1.0.113 loaded.
- No host-wide clean test suite claimed.

## Draft blockers
- Depends on https://github.com/risa-labs-inc/boss-plugin-api/pull/54.
- This pin is the local development value, not a claim that API1.0.89 has been published. Align it with the actual compatible release tag (including the API release workflow's version increment) before merge.
- Coordinate the released host version with minimum-host gates in Gateway/consumer plugins.
- Reconcile newer origin/main before merge; no release requested here.

## Companion PRs
- API: https://github.com/risa-labs-inc/boss-plugin-api/pull/54
- Host: https://github.com/risa-labs-inc/BossConsole/pull/494
- Gateway: https://github.com/risa-labs-inc/boss-plugin-ai-gateway/pull/6
- Secret Manager: https://github.com/risa-labs-inc/boss-plugin-secret-manager/pull/26
- Fluck: https://github.com/risa-labs-inc/boss-plugin-fluck-agent/pull/151
