### PR TITLE
feat(mcp): Research Notebook MCP server for researchers

### DIFF
--- a/.github/workflows/mcp-research-notebook.yml
+++ b/.github/workflows/mcp-research-notebook.yml
@@ -1,0 +1,48 @@
+name: 📓 Research Notebook MCP
+
+# The research-notebook MCP server is a standalone TypeScript package under
+# mcp-servers/ - nothing in the Gradle build touches it, so without this
+# workflow its test suite (the only guard on the metadata extraction, cite-key
+# and export logic) would rot. paths-filtered so it runs only when the server
+# or this file changes.
+on:
+  pull_request:
+    paths:
+      - "mcp-servers/research-notebook/**"
+      - ".github/workflows/mcp-research-notebook.yml"
+  push:
+    branches: [ main, develop, dev ]
+    paths:
+      - "mcp-servers/research-notebook/**"
+      - ".github/workflows/mcp-research-notebook.yml"
+
+jobs:
+  test:
+    name: 🧪 Research Notebook MCP
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: 🟢 Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: mcp-servers/research-notebook/package-lock.json
+
+      - name: 📦 Install
+        working-directory: mcp-servers/research-notebook
+        run: npm ci
+
+      - name: ✍️ Typecheck
+        working-directory: mcp-servers/research-notebook
+        run: npm run typecheck
+
+      - name: 🧪 Test
+        working-directory: mcp-servers/research-notebook
+        run: npm test
+
+      - name: 🔨 Build
+        working-directory: mcp-servers/research-notebook
+        run: npm run build

--- a/mcp-servers/research-notebook/.gitignore
+++ b/mcp-servers/research-notebook/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+*.log
+.DS_Store

--- a/mcp-servers/research-notebook/README.md
+++ b/mcp-servers/research-notebook/README.md
@@ -109,7 +109,10 @@ Everything lives in the notebook directory:
 - `outline.md` - the literature-review scaffold, when you ask `generate_outline` to write.
 
 Because it is all plain text in your project, it version-controls cleanly and you
-can read or edit it without the server.
+can read or edit it without the server. Every source and note needs a non-empty
+`id`; the server normalises array fields on load (missing ones become empty,
+tags are lowercased and de-duplicated, unknown keys are kept) and refuses to
+start if an entry cannot be read at all.
 
 ## Example workflow
 
@@ -122,7 +125,10 @@ can read or edit it without the server.
 ## Privacy and safety
 
 - The only network request the server makes is fetching a URL you explicitly
-  pass to `cite_url`. Nothing else leaves your machine.
+  pass to `cite_url`, and only http/https addresses outside loopback, private
+  and link-local ranges (no cloud metadata, no local admin ports). Nothing
+  else leaves your machine.
+  Fetches give up after 30 seconds.
 - All data is stored locally in the notebook directory. There is no external
   service and no telemetry.
 - A failed or blocked fetch is reported cleanly; you can always fall back to

--- a/mcp-servers/research-notebook/README.md
+++ b/mcp-servers/research-notebook/README.md
@@ -1,0 +1,161 @@
+# Research Notebook MCP
+
+An MCP server that turns any BOSS agent into a research assistant. It gives your
+agent (Claude Code, Codex, Gemini, OpenCode - anything BOSS drives) a set of
+tools to **capture cited sources, keep linked notes, and export a bibliography
+or a literature-review outline** - all stored as plain files inside the project
+you are working in.
+
+Point it at a project, browse and read as usual, and ask your agent to "cite
+this page", "note down why this matters", or "draft an outline of what I have so
+far". The notebook is a single human-readable `notebook.json` plus the Markdown
+and BibTeX files it generates, so nothing is locked away.
+
+## Why this helps researchers
+
+The expensive part of a literature review is not reading, it is **keeping track**:
+where a fact came from, which paper made which claim, and how a pile of notes
+turns into a structured draft. A general chat agent forgets all of this between
+turns. This server gives the agent a durable, structured memory built around the
+two things a researcher actually accumulates:
+
+- **Sources** you cite, with real bibliographic metadata (title, authors, date,
+  journal or site, DOI) extracted automatically from the page.
+- **Notes** you write, each linked to the sources behind it.
+
+From those it can produce a BibTeX file for LaTeX/Overleaf, an annotated
+bibliography, or a literature-review outline that groups your notes by theme and
+threads in the right citations.
+
+## The tools
+
+| Tool | What it does |
+|---|---|
+| `cite_url` | Fetch a URL, extract its metadata, and save it as a source (de-duplicates by URL; adds your quote/tags to an existing source). |
+| `add_source` | Record a source by hand (a book, or a page you cannot fetch). |
+| `update_source` | Correct or enrich a source's fields. |
+| `add_quote` | Attach an excerpt (with page/location and your comment) to a source. |
+| `add_note` | Write a Markdown research note linked to the sources it draws on. |
+| `update_note` | Edit a note's title, content, tags, or links. |
+| `list_sources` / `list_notes` | List sources or notes, optionally filtered by tag (or by linked source). |
+| `get_source` / `get_note` | Show full detail of one item, including quotes. |
+| `search` | Full-text search across sources and notes. |
+| `remove_source` / `remove_note` | Delete an item (removing a source unlinks it from notes and reports which). |
+| `export_bibtex` | Render sources as BibTeX, optionally writing `references.bib`. |
+| `export_markdown` | Render a Markdown bibliography (plain or annotated), optionally writing `references.md`. |
+| `generate_outline` | Assemble notes into a literature-review scaffold, optionally writing `outline.md`. |
+| `notebook_stats` | Counts of sources, notes, quotes, tags, and types. |
+
+## Quick start
+
+```bash
+cd mcp-servers/research-notebook
+npm install
+npm run build
+```
+
+Run it directly (it speaks MCP over stdio):
+
+```bash
+RESEARCH_NOTEBOOK_DIR="$PWD/.research-notebook" node dist/index.js
+```
+
+### Cite keys
+
+Sources get a human-friendly citation key in the usual author-year-word style,
+for example `vaswani2017attention`. Collisions are disambiguated with a trailing
+letter (`smith2020a`, `smith2020b`). You can refer to any source by either its
+cite key or its internal id in every tool that takes a source.
+
+## Connecting it to BOSS
+
+BOSS connects to MCP servers the same way other agent hosts do. Add an entry
+that launches this server and point it at the project folder you want the
+notebook to live in. A typical MCP client configuration looks like this:
+
+```json
+{
+  "mcpServers": {
+    "research-notebook": {
+      "command": "node",
+      "args": ["/absolute/path/to/mcp-servers/research-notebook/dist/index.js"],
+      "env": {
+        "RESEARCH_NOTEBOOK_DIR": "/absolute/path/to/your/project/.research-notebook",
+        "RESEARCH_NOTEBOOK_TITLE": "My Literature Review"
+      }
+    }
+  }
+}
+```
+
+The same block works for any MCP-capable agent BOSS runs (Claude Code, Codex,
+and others). Once connected, the 17 tools above appear alongside the rest of
+BOSS's tools and your agent can call them.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RESEARCH_NOTEBOOK_DIR` | `<cwd>/.research-notebook` | Folder holding `notebook.json` and the generated exports. |
+| `RESEARCH_NOTEBOOK_TITLE` | (unset) | Sets the notebook title on first run, used in export headings. |
+
+## What gets written
+
+Everything lives in the notebook directory:
+
+- `notebook.json` - the canonical store (sources and notes). Written atomically.
+- `references.bib` - BibTeX, when you ask `export_bibtex` to write.
+- `references.md` - Markdown bibliography, when you ask `export_markdown` to write.
+- `outline.md` - the literature-review scaffold, when you ask `generate_outline` to write.
+
+Because it is all plain text in your project, it version-controls cleanly and you
+can read or edit it without the server.
+
+## Example workflow
+
+1. `cite_url` on a paper you are reading, with a `quote` and `tags: ["method"]`.
+2. `add_note` capturing your take, linked to that source.
+3. Repeat while you read.
+4. `generate_outline` to get a themed draft with citations threaded in.
+5. `export_bibtex` to drop `references.bib` into your LaTeX project.
+
+## Privacy and safety
+
+- The only network request the server makes is fetching a URL you explicitly
+  pass to `cite_url`. Nothing else leaves your machine.
+- All data is stored locally in the notebook directory. There is no external
+  service and no telemetry.
+- A failed or blocked fetch is reported cleanly; you can always fall back to
+  `add_source` to record a citation by hand.
+
+## Development
+
+```bash
+npm run typecheck   # tsc --noEmit
+npm test            # vitest: unit + in-memory MCP integration tests
+npm run build       # emit dist/
+```
+
+The test suite covers metadata extraction (OpenGraph, Google Scholar / highwire
+`citation_*` tags, JSON-LD, and degenerate pages), cite-key generation and
+collisions, the notebook store and its persistence, BibTeX and Markdown
+rendering, and a full end-to-end pass driving the real MCP server over an
+in-memory transport with a stubbed fetch.
+
+### Layout
+
+```
+src/
+  types.ts      data model (sources, notes, notebook)
+  metadata.ts   pure HTML -> bibliographic metadata extraction
+  citekey.ts    author-year-word cite keys, with de-duplication
+  notebook.ts   the store: CRUD, search, atomic persistence
+  bibtex.ts     BibTeX export
+  markdown.ts   bibliography + literature-review outline
+  server.ts     MCP tool registration (fetch and store injected)
+  index.ts      stdio entry point
+```
+
+## License
+
+Apache-2.0, matching the BOSS Console core.

--- a/mcp-servers/research-notebook/package-lock.json
+++ b/mcp-servers/research-notebook/package-lock.json
@@ -1,0 +1,3320 @@
+{
+  "name": "boss-research-notebook-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "boss-research-notebook-mcp",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "node-html-parser": "^7.0.1",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "research-notebook-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2",
+        "vitest": "^2.1.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-servers/research-notebook/package.json
+++ b/mcp-servers/research-notebook/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "boss-research-notebook-mcp",
+  "version": "1.0.0",
+  "description": "MCP server that turns any BOSS agent into a research assistant: capture cited sources, keep linked notes, and export a bibliography or literature-review outline.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "research-notebook-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "node-html-parser": "^7.0.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/mcp-servers/research-notebook/src/bibtex.ts
+++ b/mcp-servers/research-notebook/src/bibtex.ts
@@ -18,13 +18,24 @@ const ENTRY_TYPE: Record<SourceType, string> = {
   other: "misc",
 };
 
+/** One TeX escape per special character, applied in a single pass so that
+ *  backslashes introduced by one replacement are never re-escaped. */
+const TEX_ESCAPES: Record<string, string> = {
+  "\\": "\\textbackslash{}",
+  "&": "\\&",
+  "%": "\\%",
+  "$": "\\$",
+  "#": "\\#",
+  "_": "\\_",
+  "{": "\\{",
+  "}": "\\}",
+  "~": "\\textasciitilde{}",
+  "^": "\\textasciicircum{}",
+};
+
 /** Escape the characters that are special in TeX. */
 export function escapeTex(value: string): string {
-  return value
-    .replace(/\\/g, "\\textbackslash{}")
-    .replace(/([&%$#_{}])/g, "\\$1")
-    .replace(/~/g, "\\textasciitilde{}")
-    .replace(/\^/g, "\\textasciicircum{}");
+  return value.replace(/[\\&%$#_{}~^]/g, (ch) => TEX_ESCAPES[ch]!);
 }
 
 function field(name: string, value: string | undefined): string | undefined {

--- a/mcp-servers/research-notebook/src/bibtex.ts
+++ b/mcp-servers/research-notebook/src/bibtex.ts
@@ -71,7 +71,9 @@ export function toBibtexEntry(source: Source): string {
   if (year !== "nd") fields.push(field("year", year));
   fields.push(field("doi", source.doi));
   if (entryType !== "misc") fields.push(rawField("url", source.url));
-  fields.push(field("urldate", source.accessedDate.slice(0, 10)));
+  if (source.accessedDate) {
+    fields.push(field("urldate", source.accessedDate.slice(0, 10)));
+  }
 
   const rendered = fields.filter((f): f is string => Boolean(f)).join(",\n");
   return `@${entryType}{${source.citeKey},\n${rendered}\n}`;

--- a/mcp-servers/research-notebook/src/bibtex.ts
+++ b/mcp-servers/research-notebook/src/bibtex.ts
@@ -1,0 +1,72 @@
+/**
+ * BibTeX export.
+ *
+ * Renders sources as BibTeX entries keyed by their cite key, so a researcher
+ * can drop the output straight into a LaTeX / Overleaf bibliography. Entry
+ * types are chosen for broad compatibility with classic BibTeX (no biblatex-only
+ * types), and every value is TeX-escaped.
+ */
+import type { Source, SourceType } from "./types.js";
+import { yearOf } from "./citekey.js";
+
+const ENTRY_TYPE: Record<SourceType, string> = {
+  paper: "article",
+  article: "misc",
+  webpage: "misc",
+  book: "book",
+  report: "techreport",
+  other: "misc",
+};
+
+/** Escape the characters that are special in TeX. */
+export function escapeTex(value: string): string {
+  return value
+    .replace(/\\/g, "\\textbackslash{}")
+    .replace(/([&%$#_{}])/g, "\\$1")
+    .replace(/~/g, "\\textasciitilde{}")
+    .replace(/\^/g, "\\textasciicircum{}");
+}
+
+function field(name: string, value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return `  ${name} = {${escapeTex(value)}}`;
+}
+
+/** A field whose value is emitted verbatim (URLs, `\url{}`), not TeX-escaped. */
+function rawField(name: string, value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return `  ${name} = {${value}}`;
+}
+
+export function toBibtexEntry(source: Source): string {
+  const entryType = ENTRY_TYPE[source.type] ?? "misc";
+  const year = yearOf(source.publishedDate);
+  const fields: (string | undefined)[] = [
+    field("title", source.title),
+    source.authors.length > 0 ? field("author", source.authors.join(" and ")) : undefined,
+  ];
+
+  if (entryType === "article") {
+    fields.push(field("journal", source.container));
+  } else if (entryType === "book" || entryType === "techreport") {
+    fields.push(field("publisher", source.container));
+    fields.push(field("institution", source.type === "report" ? source.container : undefined));
+  } else {
+    // @misc: record where it was published. `\url{}` must not be TeX-escaped.
+    if (source.url) fields.push(rawField("howpublished", `\\url{${source.url}}`));
+    else fields.push(field("howpublished", source.container));
+  }
+
+  if (year !== "nd") fields.push(field("year", year));
+  fields.push(field("doi", source.doi));
+  if (entryType !== "misc") fields.push(rawField("url", source.url));
+  fields.push(field("urldate", source.accessedDate.slice(0, 10)));
+
+  const rendered = fields.filter((f): f is string => Boolean(f)).join(",\n");
+  return `@${entryType}{${source.citeKey},\n${rendered}\n}`;
+}
+
+export function toBibtex(sources: Source[]): string {
+  if (sources.length === 0) return "";
+  return sources.map(toBibtexEntry).join("\n\n") + "\n";
+}

--- a/mcp-servers/research-notebook/src/citekey.ts
+++ b/mcp-servers/research-notebook/src/citekey.ts
@@ -1,0 +1,99 @@
+/**
+ * Citation-key generation.
+ *
+ * Produces stable, human-readable keys in the common author-year-word style
+ * (e.g. `vaswani2017attention`) that BibTeX users expect, and disambiguates
+ * collisions with a trailing letter (`smith2020a`, `smith2020b`). Pure and
+ * deterministic so it is easy to test.
+ */
+
+const STOPWORDS = new Set([
+  "a", "an", "the", "on", "of", "in", "to", "for", "and", "or", "with",
+  "from", "by", "at", "as", "is", "are", "into", "over", "using", "via",
+  "toward", "towards", "about", "how", "why", "what", "when",
+]);
+
+function asciiFold(input: string): string {
+  // Strip diacritics (José -> Jose) then drop anything non-alphanumeric.
+  return input
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-zA-Z0-9]/g, "")
+    .toLowerCase();
+}
+
+/** Extract a surname from a name in either "Last, First" or "First Last" form. */
+export function surnameOf(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+  if (trimmed.includes(",")) {
+    // "Vaswani, Ashish" -> "Vaswani"
+    return asciiFold(trimmed.split(",")[0]!);
+  }
+  // "Ashish Vaswani" -> "Vaswani"; single token -> itself.
+  const parts = trimmed.split(/\s+/);
+  return asciiFold(parts[parts.length - 1]!);
+}
+
+/** Pull a 4-digit year from an ISO date or free-form string, if present. */
+export function yearOf(publishedDate?: string): string {
+  if (!publishedDate) return "nd"; // "no date"
+  const match = publishedDate.match(/\b(1[5-9]\d{2}|20\d{2}|21\d{2})\b/);
+  return match ? match[1]! : "nd";
+}
+
+/** First meaningful word of a title, for the tail of the key. */
+export function titleWord(title: string): string {
+  const words = title
+    .split(/\s+/)
+    .map((w) => asciiFold(w))
+    .filter((w) => w.length > 0);
+  const significant = words.find((w) => !STOPWORDS.has(w) && w.length > 1);
+  return significant ?? words[0] ?? "";
+}
+
+export interface CiteKeyParts {
+  authors?: string[];
+  publishedDate?: string;
+  title?: string;
+  container?: string;
+}
+
+/** Build the base key (before collision suffixes). */
+export function baseCiteKey(parts: CiteKeyParts): string {
+  const author =
+    (parts.authors && parts.authors.length > 0
+      ? surnameOf(parts.authors[0]!)
+      : "") ||
+    (parts.container ? asciiFold(parts.container).slice(0, 12) : "") ||
+    "anon";
+  const year = yearOf(parts.publishedDate);
+  const word = parts.title ? titleWord(parts.title) : "";
+  return [author, year, word].filter((s) => s.length > 0).join("");
+}
+
+/**
+ * Return a key not already present in `existing`. If the base collides, append
+ * `a`, `b`, ... `z`, then `aa`, `ab`, ... to keep going.
+ */
+export function uniqueCiteKey(parts: CiteKeyParts, existing: Set<string>): string {
+  const base = baseCiteKey(parts) || "source";
+  if (!existing.has(base)) return base;
+  let i = 0;
+  // 0 -> "a", 25 -> "z", 26 -> "aa", ...
+  const suffix = (n: number): string => {
+    let s = "";
+    let x = n;
+    do {
+      s = String.fromCharCode(97 + (x % 26)) + s;
+      x = Math.floor(x / 26) - 1;
+    } while (x >= 0);
+    return s;
+  };
+  let candidate = base + suffix(i);
+  while (existing.has(candidate)) {
+    i += 1;
+    candidate = base + suffix(i);
+  }
+  return candidate;
+}

--- a/mcp-servers/research-notebook/src/index.ts
+++ b/mcp-servers/research-notebook/src/index.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Entry point for the Research Notebook MCP server (stdio transport).
+ *
+ * The notebook directory is chosen, in order:
+ *   1. RESEARCH_NOTEBOOK_DIR (absolute or relative to the cwd)
+ *   2. <cwd>/.research-notebook
+ *
+ * NOTE: stdout is the MCP protocol channel, so all diagnostics go to stderr.
+ */
+import * as path from "node:path";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { Notebook } from "./notebook.js";
+import { createServer } from "./server.js";
+
+async function main(): Promise<void> {
+  const dir = path.resolve(
+    process.env.RESEARCH_NOTEBOOK_DIR ?? path.join(process.cwd(), ".research-notebook"),
+  );
+  const notebook = await Notebook.open({ dir });
+  if (process.env.RESEARCH_NOTEBOOK_TITLE && !notebook.title) {
+    await notebook.setTitle(process.env.RESEARCH_NOTEBOOK_TITLE);
+  }
+
+  const server = createServer({ notebook });
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // eslint-disable-next-line no-console
+  console.error(`[research-notebook] ready. Notebook: ${notebook.filePath}`);
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error("[research-notebook] fatal:", err);
+  process.exit(1);
+});

--- a/mcp-servers/research-notebook/src/markdown.ts
+++ b/mcp-servers/research-notebook/src/markdown.ts
@@ -1,0 +1,156 @@
+/**
+ * Markdown exports: a human-readable bibliography and a literature-review
+ * outline scaffold assembled from the researcher's own notes.
+ *
+ * The outline is deliberately a *scaffold*, not prose: it groups the notes the
+ * researcher already wrote under their tags, threads in the cite keys of the
+ * sources each note draws on, and lists every source in a References section.
+ * It gives an agent (or the researcher) a structured starting point instead of
+ * a blank page.
+ */
+import type { NotebookData, Note, Source } from "./types.js";
+import { yearOf } from "./citekey.js";
+
+/** A one-line human citation, e.g. "Vaswani et al. (2017). *Attention...*. NeurIPS." */
+export function renderReference(source: Source): string {
+  const parts: string[] = [];
+  if (source.authors.length > 0) parts.push(formatAuthors(source.authors));
+  const year = yearOf(source.publishedDate);
+  if (year !== "nd") parts.push(`(${year})`);
+  const lead = parts.join(" ");
+
+  const bits: string[] = [];
+  if (lead) bits.push(lead.endsWith(".") ? lead : `${lead}.`);
+  bits.push(`*${source.title.replace(/\*/g, "")}*.`);
+  if (source.container) bits.push(`${source.container}.`);
+  if (source.doi) bits.push(`https://doi.org/${source.doi}`);
+  else if (source.url) bits.push(source.url);
+  return bits.join(" ").replace(/\s+/g, " ").trim();
+}
+
+function formatAuthors(authors: string[]): string {
+  if (authors.length === 1) return authors[0]!;
+  if (authors.length === 2) return `${authors[0]} and ${authors[1]}`;
+  return `${authors[0]} et al.`;
+}
+
+export interface MarkdownOptions {
+  /** Include summaries and quotes under each source (annotated bibliography). */
+  annotated?: boolean;
+  /** Only include sources/notes carrying this tag. */
+  tag?: string;
+  title?: string;
+}
+
+function filterByTag<T extends { tags: string[] }>(items: T[], tag?: string): T[] {
+  if (!tag) return items;
+  const t = tag.toLowerCase();
+  return items.filter((i) => i.tags.includes(t));
+}
+
+/** A stand-alone bibliography (optionally annotated) as Markdown. */
+export function exportBibliographyMarkdown(
+  data: NotebookData,
+  opts: MarkdownOptions = {},
+): string {
+  const sources = filterByTag([...data.sources], opts.tag).sort((a, b) =>
+    a.citeKey.localeCompare(b.citeKey),
+  );
+  const title = opts.title ?? data.title ?? "References";
+  const lines: string[] = [`# ${title}`, ""];
+  if (sources.length === 0) {
+    lines.push("_No sources recorded yet._", "");
+    return lines.join("\n");
+  }
+  for (const s of sources) {
+    lines.push(`- **[${s.citeKey}]** ${renderReference(s)}`);
+    if (opts.annotated) {
+      if (s.summary) lines.push(`  - ${s.summary}`);
+      for (const q of s.quotes) {
+        const page = q.page ? ` (${q.page})` : "";
+        lines.push(`  - > ${q.text}${page}`);
+        if (q.note) lines.push(`    - ${q.note}`);
+      }
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * A literature-review outline built from the notes. Notes are grouped by tag;
+ * each note lists the cite keys it draws on; a References section closes it out.
+ */
+export function generateOutline(data: NotebookData, opts: MarkdownOptions = {}): string {
+  const notes = filterByTag([...data.notes], opts.tag);
+  const usedSourceIds = new Set(notes.flatMap((n) => n.sourceIds));
+  const sourcesById = new Map(data.sources.map((s) => [s.id, s]));
+
+  const title = opts.title ?? data.title ?? "Literature Review";
+  const lines: string[] = [
+    `# ${title}`,
+    "",
+    `_Draft outline generated from ${notes.length} note(s) and ${data.sources.length} source(s)._`,
+    "",
+  ];
+
+  // Group notes by their first tag; notes with no tag go under "Unsorted".
+  const groups = new Map<string, Note[]>();
+  for (const note of notes) {
+    const key = note.tags[0] ?? "unsorted";
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(note);
+  }
+
+  if (notes.length === 0) {
+    lines.push("_No notes to outline yet. Capture notes with `add_note` first._", "");
+  } else {
+    lines.push("## Themes", "");
+    for (const theme of [...groups.keys()].sort()) {
+      lines.push(`### ${titleCase(theme)}`, "");
+      for (const note of groups.get(theme)!) {
+        const keys = note.sourceIds
+          .map((id) => sourcesById.get(id)?.citeKey)
+          .filter((k): k is string => Boolean(k));
+        const cites = keys.length > 0 ? ` [${keys.map((k) => `@${k}`).join(", ")}]` : "";
+        lines.push(`- **${note.title}**${cites}`);
+        const firstLine = note.content.split("\n").find((l) => l.trim().length > 0);
+        if (firstLine) lines.push(`  ${firstLine.trim()}`);
+      }
+      lines.push("");
+    }
+  }
+
+  // Sources captured but not yet written up - useful "still to read" list.
+  const unusedSources = filterByTag([...data.sources], opts.tag).filter(
+    (s) => !usedSourceIds.has(s.id),
+  );
+  if (unusedSources.length > 0) {
+    lines.push("## Sources not yet written up", "");
+    for (const s of unusedSources.sort((a, b) => a.citeKey.localeCompare(b.citeKey))) {
+      lines.push(`- [${s.citeKey}] ${renderReference(s)}`);
+    }
+    lines.push("");
+  }
+
+  // Full reference list.
+  const refs = filterByTag([...data.sources], opts.tag).sort((a, b) =>
+    a.citeKey.localeCompare(b.citeKey),
+  );
+  lines.push("## References", "");
+  if (refs.length === 0) {
+    lines.push("_No sources recorded yet._", "");
+  } else {
+    for (const s of refs) lines.push(`- **[${s.citeKey}]** ${renderReference(s)}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/[\s_-]+/)
+    .map((w) => (w.length > 0 ? w[0]!.toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}

--- a/mcp-servers/research-notebook/src/metadata.ts
+++ b/mcp-servers/research-notebook/src/metadata.ts
@@ -1,0 +1,262 @@
+/**
+ * Bibliographic metadata extraction from an HTML page.
+ *
+ * `extractMetadata(html, url)` is a **pure** function: give it the raw HTML and
+ * the URL it came from and it returns the best title / authors / date /
+ * container / DOI it can find. It reads, in order of trust:
+ *
+ *   1. Highwire / Google Scholar `citation_*` tags (publishers, arXiv, PubMed)
+ *   2. JSON-LD (`schema.org` Article / ScholarlyArticle / NewsArticle ...)
+ *   3. OpenGraph / Twitter card / Dublin Core / standard `<meta>` tags
+ *   4. The `<title>` / first `<h1>` as a last resort
+ *
+ * Keeping it pure and network-free is what makes `cite_url` testable against
+ * fixture HTML with no live requests.
+ */
+import { parse, type HTMLElement } from "node-html-parser";
+import type { SourceType } from "./types.js";
+
+export interface ExtractedMetadata {
+  title?: string;
+  authors: string[];
+  container?: string;
+  publishedDate?: string;
+  doi?: string;
+  summary?: string;
+  type: SourceType;
+}
+
+function clean(value: string | undefined | null): string | undefined {
+  if (value == null) return undefined;
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  return collapsed.length > 0 ? collapsed : undefined;
+}
+
+/** All `content` values for meta tags matching any of `keys` (name or property). */
+function metaAll(root: HTMLElement, keys: string[]): string[] {
+  const wanted = new Set(keys.map((k) => k.toLowerCase()));
+  const out: string[] = [];
+  for (const el of root.querySelectorAll("meta")) {
+    const key = (el.getAttribute("name") ?? el.getAttribute("property") ?? "").toLowerCase();
+    if (!key || !wanted.has(key)) continue;
+    const content = clean(el.getAttribute("content"));
+    if (content) out.push(content);
+  }
+  return out;
+}
+
+function metaFirst(root: HTMLElement, keys: string[]): string | undefined {
+  return metaAll(root, keys)[0];
+}
+
+interface JsonLdNode {
+  "@type"?: string | string[];
+  name?: string;
+  headline?: string;
+  author?: unknown;
+  creator?: unknown;
+  datePublished?: string;
+  dateCreated?: string;
+  publisher?: unknown;
+  description?: string;
+  isPartOf?: unknown;
+  [key: string]: unknown;
+}
+
+function collectJsonLdNodes(root: HTMLElement): JsonLdNode[] {
+  const nodes: JsonLdNode[] = [];
+  for (const script of root.querySelectorAll('script[type="application/ld+json"]')) {
+    const raw = script.textContent?.trim();
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw);
+      const queue: unknown[] = Array.isArray(parsed) ? [...parsed] : [parsed];
+      while (queue.length > 0) {
+        const item = queue.shift();
+        if (!item || typeof item !== "object") continue;
+        const obj = item as JsonLdNode;
+        if (Array.isArray(obj["@graph"])) queue.push(...(obj["@graph"] as unknown[]));
+        nodes.push(obj);
+      }
+    } catch {
+      // Malformed JSON-LD is common in the wild; skip it silently.
+    }
+  }
+  return nodes;
+}
+
+/** Normalise a schema.org author/creator field (string | object | array). */
+function jsonLdNames(value: unknown): string[] {
+  if (!value) return [];
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap(jsonLdNames);
+  if (typeof value === "object") {
+    const name = (value as { name?: unknown }).name;
+    if (typeof name === "string") return [name];
+  }
+  return [];
+}
+
+const ARTICLE_TYPES = new Set([
+  "article",
+  "newsarticle",
+  "blogposting",
+  "report",
+  "techarticle",
+]);
+const PAPER_TYPES = new Set([
+  "scholarlyarticle",
+  "article", // upgraded to paper when citation_* / doi present (see below)
+]);
+
+function inferType(opts: {
+  hasCitationTags: boolean;
+  hasDoi: boolean;
+  jsonLdTypes: string[];
+  ogType?: string;
+}): SourceType {
+  const lower = opts.jsonLdTypes.map((t) => t.toLowerCase());
+  if (opts.hasCitationTags || opts.hasDoi) return "paper";
+  if (lower.some((t) => PAPER_TYPES.has(t) && t === "scholarlyarticle")) return "paper";
+  if (lower.some((t) => t === "book")) return "book";
+  if (lower.some((t) => t === "report")) return "report";
+  if (lower.some((t) => ARTICLE_TYPES.has(t))) return "article";
+  if (opts.ogType && opts.ogType.toLowerCase().includes("article")) return "article";
+  return "webpage";
+}
+
+export function hostnameOf(url: string): string | undefined {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractMetadata(html: string, url: string): ExtractedMetadata {
+  const root = parse(html, { comment: false });
+
+  // --- Authors -------------------------------------------------------------
+  const citationAuthors = metaAll(root, ["citation_author", "citation_authors"]);
+  const jsonLd = collectJsonLdNodes(root);
+  const jsonLdAuthors = jsonLd.flatMap((n) => [
+    ...jsonLdNames(n.author),
+    ...jsonLdNames(n.creator),
+  ]);
+  const metaAuthors = metaAll(root, [
+    "author",
+    "article:author",
+    "dc.creator",
+    "dcterms.creator",
+    "parsely-author",
+  ]);
+  // Some sites cram multiple authors into one meta tag separated by ; or ,.
+  const authors = dedupeAuthors(
+    [...citationAuthors, ...jsonLdAuthors, ...metaAuthors].flatMap(splitAuthorField),
+  );
+
+  // --- Title ---------------------------------------------------------------
+  // Prefer any node's `headline` (articles) over any node's `name` (which a
+  // WebSite/Organization node in an @graph also carries and would otherwise win).
+  const jsonLdTitle =
+    jsonLd.map((n) => clean(n.headline)).find(Boolean) ??
+    jsonLd.map((n) => clean(n.name)).find(Boolean);
+  const title =
+    metaFirst(root, ["citation_title"]) ??
+    metaFirst(root, ["og:title", "twitter:title"]) ??
+    jsonLdTitle ??
+    clean(root.querySelector("title")?.textContent) ??
+    clean(root.querySelector("h1")?.textContent);
+
+  // --- Date ----------------------------------------------------------------
+  const jsonLdDate = jsonLd
+    .map((n) => clean(n.datePublished) ?? clean(n.dateCreated))
+    .find(Boolean);
+  const timeAttr = root.querySelector("time[datetime]")?.getAttribute("datetime");
+  const publishedDate =
+    metaFirst(root, ["citation_publication_date", "citation_date"]) ??
+    metaFirst(root, [
+      "article:published_time",
+      "date",
+      "dc.date",
+      "dcterms.date",
+      "dc.date.issued",
+      "prism.publicationdate",
+      "sailthru.date",
+    ]) ??
+    jsonLdDate ??
+    clean(timeAttr);
+
+  // --- Container (journal / site / publisher) ------------------------------
+  const jsonLdPublisher = jsonLd.map((n) => jsonLdNames(n.publisher)[0]).find(Boolean);
+  const container =
+    metaFirst(root, ["citation_journal_title", "citation_conference_title"]) ??
+    metaFirst(root, ["og:site_name"]) ??
+    metaFirst(root, ["dc.publisher", "dcterms.publisher", "citation_publisher"]) ??
+    jsonLdPublisher ??
+    hostnameOf(url);
+
+  // --- DOI -----------------------------------------------------------------
+  const jsonLdDoi = jsonLd
+    .map((n) => {
+      const id = n["@id"] ?? n["identifier"];
+      return typeof id === "string" ? id : undefined;
+    })
+    .map((s) => extractDoi(s))
+    .find(Boolean);
+  const doi =
+    normaliseDoi(metaFirst(root, ["citation_doi", "dc.identifier", "doi", "prism.doi"])) ??
+    jsonLdDoi ??
+    extractDoi(url);
+
+  // --- Summary -------------------------------------------------------------
+  const summary =
+    metaFirst(root, ["og:description", "twitter:description", "description"]) ??
+    metaFirst(root, ["citation_abstract", "dc.description"]) ??
+    jsonLd.map((n) => clean(n.description)).find(Boolean);
+
+  const type = inferType({
+    hasCitationTags: citationAuthors.length > 0 || Boolean(metaFirst(root, ["citation_title"])),
+    hasDoi: Boolean(doi),
+    jsonLdTypes: jsonLd.flatMap((n) =>
+      Array.isArray(n["@type"]) ? n["@type"] : n["@type"] ? [n["@type"]] : [],
+    ),
+    ogType: metaFirst(root, ["og:type"]),
+  });
+
+  return { title, authors, container, publishedDate, doi, summary, type };
+}
+
+/** Split "Ada Lovelace; Alan Turing" or "Lovelace, Ada and Turing, Alan". */
+function splitAuthorField(field: string): string[] {
+  // Preserve "Last, First" by only splitting on ';', ' and ', or '&'.
+  const parts = field
+    .split(/\s*;\s*|\s+and\s+|\s*&\s*/i)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return parts.length > 0 ? parts : [field.trim()];
+}
+
+function dedupeAuthors(authors: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const a of authors) {
+    const key = a.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(a);
+  }
+  return out;
+}
+
+const DOI_RE = /10\.\d{4,9}\/[-._;()/:a-zA-Z0-9]+/;
+
+export function extractDoi(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const match = value.match(DOI_RE);
+  return match ? match[0].replace(/[.,;]+$/, "") : undefined;
+}
+
+function normaliseDoi(value: string | undefined): string | undefined {
+  return extractDoi(value);
+}

--- a/mcp-servers/research-notebook/src/notebook.ts
+++ b/mcp-servers/research-notebook/src/notebook.ts
@@ -1,0 +1,435 @@
+/**
+ * The Research Notebook store.
+ *
+ * A `Notebook` owns one JSON document on disk (`notebook.json`) inside a
+ * directory the researcher chooses (their project, by default). It provides the
+ * create / read / update / delete and search operations the MCP tools expose.
+ *
+ * Everything that touches the outside world - the filesystem, the clock, id
+ * generation - is injected, so the whole class runs deterministically against a
+ * temp directory in tests.
+ */
+import { promises as fs } from "node:fs";
+import { randomBytes } from "node:crypto";
+import * as path from "node:path";
+import {
+  type NotebookData,
+  type Note,
+  type Source,
+  type SourceType,
+  emptyNotebook,
+} from "./types.js";
+import { uniqueCiteKey } from "./citekey.js";
+
+export interface NotebookDeps {
+  /** Directory that holds `notebook.json` and generated exports. */
+  dir: string;
+  /** Clock, injectable for deterministic timestamps in tests. */
+  now?: () => Date;
+  /** Random suffix generator for ids, injectable for tests. */
+  makeId?: () => string;
+}
+
+export const NOTEBOOK_FILENAME = "notebook.json";
+
+export interface AddSourceInput {
+  title: string;
+  type?: SourceType;
+  url?: string;
+  authors?: string[];
+  container?: string;
+  publishedDate?: string;
+  doi?: string;
+  tags?: string[];
+  summary?: string;
+}
+
+export interface RemoveSourceResult {
+  removed: Source;
+  /** Notes that still referenced the removed source (link was dropped). */
+  affectedNotes: string[];
+}
+
+export class NotebookError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotebookError";
+  }
+}
+
+/** Normalise a URL for de-duplication: drop fragment, tracking params, trailing slash. */
+export function normaliseUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.hash = "";
+    u.hostname = u.hostname.replace(/^www\./, "").toLowerCase();
+    const drop = [...u.searchParams.keys()].filter(
+      (k) => k.startsWith("utm_") || k === "fbclid" || k === "gclid" || k === "ref",
+    );
+    for (const k of drop) u.searchParams.delete(k);
+    let out = u.toString();
+    if (out.endsWith("/") && u.pathname !== "/") out = out.slice(0, -1);
+    return out;
+  } catch {
+    return url.trim();
+  }
+}
+
+export class Notebook {
+  private readonly dir: string;
+  private readonly now: () => Date;
+  private readonly makeId: () => string;
+  private data: NotebookData;
+
+  private constructor(deps: NotebookDeps, data: NotebookData) {
+    this.dir = deps.dir;
+    this.now = deps.now ?? (() => new Date());
+    this.makeId = deps.makeId ?? (() => randomBytes(4).toString("hex"));
+    this.data = data;
+  }
+
+  get filePath(): string {
+    return path.join(this.dir, NOTEBOOK_FILENAME);
+  }
+
+  get directory(): string {
+    return this.dir;
+  }
+
+  /** Load the notebook from disk, creating an empty one if none exists. */
+  static async open(deps: NotebookDeps): Promise<Notebook> {
+    await fs.mkdir(deps.dir, { recursive: true });
+    const filePath = path.join(deps.dir, NOTEBOOK_FILENAME);
+    let data: NotebookData;
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      data = migrate(JSON.parse(raw));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        data = emptyNotebook();
+      } else if (err instanceof SyntaxError) {
+        throw new NotebookError(
+          `notebook.json at ${filePath} is not valid JSON. Fix or remove it before continuing.`,
+        );
+      } else {
+        throw err;
+      }
+    }
+    return new Notebook(deps, data);
+  }
+
+  private timestamp(): string {
+    return this.now().toISOString();
+  }
+
+  private async persist(): Promise<void> {
+    const tmp = `${this.filePath}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(this.data, null, 2) + "\n", "utf8");
+    await fs.rename(tmp, this.filePath); // atomic replace
+  }
+
+  /** Write an arbitrary export file next to the notebook and return its path. */
+  async writeExport(filename: string, contents: string): Promise<string> {
+    const target = path.join(this.dir, filename);
+    await fs.writeFile(target, contents, "utf8");
+    return target;
+  }
+
+  snapshot(): NotebookData {
+    return structuredClone(this.data);
+  }
+
+  setTitle(title: string): Promise<void> {
+    this.data.title = title;
+    return this.persist();
+  }
+
+  get title(): string | undefined {
+    return this.data.title;
+  }
+
+  allCiteKeys(): Set<string> {
+    return new Set(this.data.sources.map((s) => s.citeKey));
+  }
+
+  // --- Sources -------------------------------------------------------------
+
+  findByUrl(url: string): Source | undefined {
+    const key = normaliseUrl(url);
+    return this.data.sources.find((s) => s.url && normaliseUrl(s.url) === key);
+  }
+
+  resolveSource(idOrKey: string): Source | undefined {
+    return this.data.sources.find((s) => s.id === idOrKey || s.citeKey === idOrKey);
+  }
+
+  private requireSource(idOrKey: string): Source {
+    const src = this.resolveSource(idOrKey);
+    if (!src) throw new NotebookError(`No source found with id or cite key "${idOrKey}".`);
+    return src;
+  }
+
+  async addSource(input: AddSourceInput): Promise<Source> {
+    const title = input.title?.trim();
+    if (!title) throw new NotebookError("A source needs a non-empty title.");
+    const ts = this.timestamp();
+    const citeKey = uniqueCiteKey(
+      {
+        authors: input.authors,
+        publishedDate: input.publishedDate,
+        title,
+        container: input.container,
+      },
+      this.allCiteKeys(),
+    );
+    const source: Source = {
+      id: `src-${this.makeId()}`,
+      citeKey,
+      type: input.type ?? "webpage",
+      title,
+      url: input.url?.trim() || undefined,
+      authors: dedupeStrings(input.authors ?? []),
+      container: input.container?.trim() || undefined,
+      publishedDate: input.publishedDate?.trim() || undefined,
+      accessedDate: ts,
+      doi: input.doi?.trim() || undefined,
+      tags: normaliseTags(input.tags),
+      quotes: [],
+      summary: input.summary?.trim() || undefined,
+      createdAt: ts,
+      updatedAt: ts,
+    };
+    this.data.sources.push(source);
+    await this.persist();
+    return source;
+  }
+
+  async updateSource(
+    idOrKey: string,
+    patch: Partial<AddSourceInput>,
+  ): Promise<Source> {
+    const src = this.requireSource(idOrKey);
+    if (patch.title !== undefined) {
+      const t = patch.title.trim();
+      if (!t) throw new NotebookError("Title cannot be blank.");
+      src.title = t;
+    }
+    if (patch.type !== undefined) src.type = patch.type;
+    if (patch.url !== undefined) src.url = patch.url.trim() || undefined;
+    if (patch.authors !== undefined) src.authors = dedupeStrings(patch.authors);
+    if (patch.container !== undefined) src.container = patch.container.trim() || undefined;
+    if (patch.publishedDate !== undefined) src.publishedDate = patch.publishedDate.trim() || undefined;
+    if (patch.doi !== undefined) src.doi = patch.doi.trim() || undefined;
+    if (patch.tags !== undefined) src.tags = normaliseTags(patch.tags);
+    if (patch.summary !== undefined) src.summary = patch.summary.trim() || undefined;
+    src.updatedAt = this.timestamp();
+    await this.persist();
+    return src;
+  }
+
+  async addQuote(
+    idOrKey: string,
+    quote: { text: string; page?: string; note?: string },
+  ): Promise<Source> {
+    const src = this.requireSource(idOrKey);
+    const text = quote.text?.trim();
+    if (!text) throw new NotebookError("A quote needs non-empty text.");
+    src.quotes.push({
+      text,
+      page: quote.page?.trim() || undefined,
+      note: quote.note?.trim() || undefined,
+      addedAt: this.timestamp(),
+    });
+    src.updatedAt = this.timestamp();
+    await this.persist();
+    return src;
+  }
+
+  async removeSource(idOrKey: string): Promise<RemoveSourceResult> {
+    const src = this.requireSource(idOrKey);
+    this.data.sources = this.data.sources.filter((s) => s.id !== src.id);
+    const affectedNotes: string[] = [];
+    for (const note of this.data.notes) {
+      if (note.sourceIds.includes(src.id)) {
+        note.sourceIds = note.sourceIds.filter((sid) => sid !== src.id);
+        note.updatedAt = this.timestamp();
+        affectedNotes.push(note.id);
+      }
+    }
+    await this.persist();
+    return { removed: src, affectedNotes };
+  }
+
+  listSources(filter?: { tag?: string }): Source[] {
+    let list = [...this.data.sources];
+    if (filter?.tag) {
+      const tag = filter.tag.toLowerCase();
+      list = list.filter((s) => s.tags.includes(tag));
+    }
+    return list.sort((a, b) => a.citeKey.localeCompare(b.citeKey));
+  }
+
+  // --- Notes ---------------------------------------------------------------
+
+  private validateSourceIds(sourceIds: string[]): string[] {
+    const resolved: string[] = [];
+    for (const ref of sourceIds) {
+      const src = this.resolveSource(ref);
+      if (!src) throw new NotebookError(`Cannot link note to unknown source "${ref}".`);
+      if (!resolved.includes(src.id)) resolved.push(src.id);
+    }
+    return resolved;
+  }
+
+  resolveNote(id: string): Note | undefined {
+    return this.data.notes.find((n) => n.id === id);
+  }
+
+  private requireNote(id: string): Note {
+    const note = this.resolveNote(id);
+    if (!note) throw new NotebookError(`No note found with id "${id}".`);
+    return note;
+  }
+
+  async addNote(input: {
+    title: string;
+    content: string;
+    sourceIds?: string[];
+    tags?: string[];
+  }): Promise<Note> {
+    const title = input.title?.trim();
+    if (!title) throw new NotebookError("A note needs a non-empty title.");
+    const ts = this.timestamp();
+    const note: Note = {
+      id: `note-${this.makeId()}`,
+      title,
+      content: input.content ?? "",
+      sourceIds: this.validateSourceIds(input.sourceIds ?? []),
+      tags: normaliseTags(input.tags),
+      createdAt: ts,
+      updatedAt: ts,
+    };
+    this.data.notes.push(note);
+    await this.persist();
+    return note;
+  }
+
+  async updateNote(
+    id: string,
+    patch: { title?: string; content?: string; sourceIds?: string[]; tags?: string[] },
+  ): Promise<Note> {
+    const note = this.requireNote(id);
+    if (patch.title !== undefined) {
+      const t = patch.title.trim();
+      if (!t) throw new NotebookError("Title cannot be blank.");
+      note.title = t;
+    }
+    if (patch.content !== undefined) note.content = patch.content;
+    if (patch.sourceIds !== undefined) note.sourceIds = this.validateSourceIds(patch.sourceIds);
+    if (patch.tags !== undefined) note.tags = normaliseTags(patch.tags);
+    note.updatedAt = this.timestamp();
+    await this.persist();
+    return note;
+  }
+
+  async removeNote(id: string): Promise<Note> {
+    const note = this.requireNote(id);
+    this.data.notes = this.data.notes.filter((n) => n.id !== note.id);
+    await this.persist();
+    return note;
+  }
+
+  listNotes(filter?: { tag?: string; sourceId?: string }): Note[] {
+    let list = [...this.data.notes];
+    if (filter?.tag) {
+      const tag = filter.tag.toLowerCase();
+      list = list.filter((n) => n.tags.includes(tag));
+    }
+    if (filter?.sourceId) {
+      const src = this.resolveSource(filter.sourceId);
+      const id = src?.id ?? filter.sourceId;
+      list = list.filter((n) => n.sourceIds.includes(id));
+    }
+    return list.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  // --- Search & stats ------------------------------------------------------
+
+  search(query: string): { sources: Source[]; notes: Note[] } {
+    const q = query.trim().toLowerCase();
+    if (!q) return { sources: [], notes: [] };
+    const sources = this.data.sources.filter((s) =>
+      [
+        s.title,
+        s.citeKey,
+        s.container ?? "",
+        s.summary ?? "",
+        s.authors.join(" "),
+        s.tags.join(" "),
+        s.quotes.map((quote) => `${quote.text} ${quote.note ?? ""}`).join(" "),
+      ]
+        .join(" \n ")
+        .toLowerCase()
+        .includes(q),
+    );
+    const notes = this.data.notes.filter((n) =>
+      [n.title, n.content, n.tags.join(" ")].join(" \n ").toLowerCase().includes(q),
+    );
+    return { sources, notes };
+  }
+
+  stats(): {
+    sources: number;
+    notes: number;
+    quotes: number;
+    tags: string[];
+    byType: Record<string, number>;
+  } {
+    const tags = new Set<string>();
+    const byType: Record<string, number> = {};
+    let quotes = 0;
+    for (const s of this.data.sources) {
+      s.tags.forEach((t) => tags.add(t));
+      quotes += s.quotes.length;
+      byType[s.type] = (byType[s.type] ?? 0) + 1;
+    }
+    for (const n of this.data.notes) n.tags.forEach((t) => tags.add(t));
+    return {
+      sources: this.data.sources.length,
+      notes: this.data.notes.length,
+      quotes,
+      tags: [...tags].sort(),
+      byType,
+    };
+  }
+}
+
+function normaliseTags(tags: string[] | undefined): string[] {
+  return dedupeStrings((tags ?? []).map((t) => t.trim().toLowerCase()).filter((t) => t.length > 0));
+}
+
+function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const trimmed = v.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/** Bring an on-disk notebook up to the current schema version. */
+function migrate(data: unknown): NotebookData {
+  if (!data || typeof data !== "object") return emptyNotebook();
+  const obj = data as Partial<NotebookData>;
+  return {
+    version: 1,
+    title: obj.title,
+    sources: Array.isArray(obj.sources) ? (obj.sources as Source[]) : [],
+    notes: Array.isArray(obj.notes) ? (obj.notes as Note[]) : [],
+  };
+}

--- a/mcp-servers/research-notebook/src/notebook.ts
+++ b/mcp-servers/research-notebook/src/notebook.ts
@@ -15,8 +15,10 @@ import * as path from "node:path";
 import {
   type NotebookData,
   type Note,
+  type Quote,
   type Source,
   type SourceType,
+  SOURCE_TYPES,
   emptyNotebook,
 } from "./types.js";
 import { uniqueCiteKey } from "./citekey.js";
@@ -429,7 +431,79 @@ function migrate(data: unknown): NotebookData {
   return {
     version: 1,
     title: obj.title,
-    sources: Array.isArray(obj.sources) ? (obj.sources as Source[]) : [],
-    notes: Array.isArray(obj.notes) ? (obj.notes as Note[]) : [],
+    sources: Array.isArray(obj.sources)
+      ? obj.sources.map(normaliseSource).filter((s): s is Source => s !== undefined)
+      : [],
+    notes: Array.isArray(obj.notes)
+      ? obj.notes.map(normaliseNote).filter((n): n is Note => n !== undefined)
+      : [],
+  };
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : [];
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionalTimestamp(value: unknown): string {
+  return typeof value === "string" && value.length > 0 ? value : new Date(0).toISOString();
+}
+
+/**
+ * Normalise one hand-edited source entry so that reads (stats, exports, search)
+ * never meet a missing field. The notebook is advertised as human-editable
+ * JSON, so a dropped array must not turn every tool into a raw TypeError.
+ */
+function normaliseSource(entry: unknown): Source | undefined {
+  if (!entry || typeof entry !== "object") return undefined;
+  const raw = entry as Partial<Source>;
+  if (typeof raw.id !== "string" || raw.id.length === 0) return undefined;
+  return {
+    id: raw.id,
+    citeKey:
+      typeof raw.citeKey === "string" && raw.citeKey.length > 0
+        ? raw.citeKey
+        : `source-${raw.id}`,
+    type: (SOURCE_TYPES as readonly string[]).includes(raw.type ?? "")
+      ? (raw.type as SourceType)
+      : "webpage",
+    title: typeof raw.title === "string" ? raw.title : "",
+    url: optionalString(raw.url),
+    authors: stringArray(raw.authors),
+    container: optionalString(raw.container),
+    publishedDate: optionalString(raw.publishedDate),
+    accessedDate: optionalTimestamp(raw.accessedDate),
+    doi: optionalString(raw.doi),
+    tags: stringArray(raw.tags),
+    quotes: Array.isArray(raw.quotes)
+      ? raw.quotes.filter(
+          (q): q is Quote =>
+            Boolean(q) && typeof q === "object" && typeof (q as Quote).text === "string",
+        )
+      : [],
+    summary: optionalString(raw.summary),
+    createdAt: optionalTimestamp(raw.createdAt),
+    updatedAt: optionalTimestamp(raw.updatedAt),
+  };
+}
+
+/** Normalise one hand-edited note entry so reads never meet a missing field. */
+function normaliseNote(entry: unknown): Note | undefined {
+  if (!entry || typeof entry !== "object") return undefined;
+  const raw = entry as Partial<Note>;
+  if (typeof raw.id !== "string" || raw.id.length === 0) return undefined;
+  return {
+    id: raw.id,
+    title: typeof raw.title === "string" ? raw.title : "",
+    content: typeof raw.content === "string" ? raw.content : "",
+    sourceIds: stringArray(raw.sourceIds),
+    tags: stringArray(raw.tags),
+    createdAt: optionalTimestamp(raw.createdAt),
+    updatedAt: optionalTimestamp(raw.updatedAt),
   };
 }

--- a/mcp-servers/research-notebook/src/notebook.ts
+++ b/mcp-servers/research-notebook/src/notebook.ts
@@ -428,15 +428,35 @@ function dedupeStrings(values: string[]): string[] {
 function migrate(data: unknown): NotebookData {
   if (!data || typeof data !== "object") return emptyNotebook();
   const obj = data as Partial<NotebookData>;
+  const sources: Source[] = [];
+  const notes: Note[] = [];
+  const dropped: string[] = [];
+  (Array.isArray(obj.sources) ? obj.sources : []).forEach((entry, i) => {
+    const normalised = normaliseSource(entry);
+    if (normalised) sources.push(normalised);
+    else dropped.push(`sources[${i}]`);
+  });
+  (Array.isArray(obj.notes) ? obj.notes : []).forEach((entry, i) => {
+    const normalised = normaliseNote(entry);
+    if (normalised) notes.push(normalised);
+    else dropped.push(`notes[${i}]`);
+  });
+  // Fail closed, like the corrupt-JSON path: an entry the normaliser cannot
+  // read is a hand-editing mistake, and persisting the document without it
+  // would make the loss permanent on the next write.
+  if (dropped.length > 0) {
+    throw new NotebookError(
+      `notebook.json has ${dropped.length} unrecognised entr${
+        dropped.length === 1 ? "y" : "ies"
+      } (${dropped.join(", ")}). Every source and note needs a non-empty "id"; ` +
+        "fix or remove them before continuing.",
+    );
+  }
   return {
     version: 1,
-    title: obj.title,
-    sources: Array.isArray(obj.sources)
-      ? obj.sources.map(normaliseSource).filter((s): s is Source => s !== undefined)
-      : [],
-    notes: Array.isArray(obj.notes)
-      ? obj.notes.map(normaliseNote).filter((n): n is Note => n !== undefined)
-      : [],
+    title: typeof obj.title === "string" ? obj.title : undefined,
+    sources,
+    notes,
   };
 }
 
@@ -456,14 +476,16 @@ function optionalTimestamp(value: unknown): string {
 
 /**
  * Normalise one hand-edited source entry so that reads (stats, exports, search)
- * never meet a missing field. The notebook is advertised as human-editable
- * JSON, so a dropped array must not turn every tool into a raw TypeError.
+ * never meet a missing field, and writes see the same shape the write paths
+ * produce: tags trimmed/lowercased/deduped, authors deduped. Unknown keys
+ * (e.g. a hand-added "isbn") are preserved so a load/save cycle is lossless.
  */
 function normaliseSource(entry: unknown): Source | undefined {
   if (!entry || typeof entry !== "object") return undefined;
   const raw = entry as Partial<Source>;
   if (typeof raw.id !== "string" || raw.id.length === 0) return undefined;
   return {
+    ...raw,
     id: raw.id,
     citeKey:
       typeof raw.citeKey === "string" && raw.citeKey.length > 0
@@ -474,12 +496,12 @@ function normaliseSource(entry: unknown): Source | undefined {
       : "webpage",
     title: typeof raw.title === "string" ? raw.title : "",
     url: optionalString(raw.url),
-    authors: stringArray(raw.authors),
+    authors: dedupeStrings(stringArray(raw.authors)),
     container: optionalString(raw.container),
     publishedDate: optionalString(raw.publishedDate),
-    accessedDate: optionalTimestamp(raw.accessedDate),
+    accessedDate: optionalString(raw.accessedDate),
     doi: optionalString(raw.doi),
-    tags: stringArray(raw.tags),
+    tags: normaliseTags(stringArray(raw.tags)),
     quotes: Array.isArray(raw.quotes)
       ? raw.quotes.filter(
           (q): q is Quote =>
@@ -492,17 +514,21 @@ function normaliseSource(entry: unknown): Source | undefined {
   };
 }
 
-/** Normalise one hand-edited note entry so reads never meet a missing field. */
+/**
+ * Normalise one hand-edited note entry so reads never meet a missing field;
+ * unknown keys are preserved as for sources.
+ */
 function normaliseNote(entry: unknown): Note | undefined {
   if (!entry || typeof entry !== "object") return undefined;
   const raw = entry as Partial<Note>;
   if (typeof raw.id !== "string" || raw.id.length === 0) return undefined;
   return {
+    ...raw,
     id: raw.id,
     title: typeof raw.title === "string" ? raw.title : "",
     content: typeof raw.content === "string" ? raw.content : "",
     sourceIds: stringArray(raw.sourceIds),
-    tags: stringArray(raw.tags),
+    tags: normaliseTags(stringArray(raw.tags)),
     createdAt: optionalTimestamp(raw.createdAt),
     updatedAt: optionalTimestamp(raw.updatedAt),
   };

--- a/mcp-servers/research-notebook/src/server.ts
+++ b/mcp-servers/research-notebook/src/server.ts
@@ -16,7 +16,7 @@ import { SOURCE_TYPES, type Note, type Source, type SourceType } from "./types.j
 
 export type FetchFn = (
   url: string,
-  init?: { headers?: Record<string, string> },
+  init?: { headers?: Record<string, string>; signal?: AbortSignal },
 ) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
 
 export interface CreateServerOptions {
@@ -114,6 +114,37 @@ const DEFAULT_HEADERS = {
   Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
 };
 
+/** How long cite_url waits for a page before giving up. */
+export const CITE_FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Whether cite_url may fetch a URL. The agent chooses the URL, so the server
+ * must not let it reach loopback, link-local (cloud metadata) or private
+ * addresses: only http/https, and no private IP literals (hostnames that
+ * resolve to private addresses still need care - see review follow-ups).
+ */
+export function isFetchableUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (host === "localhost") return false;
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const first = Number(ipv4[1]);
+    const second = Number(ipv4[2]);
+    if (first === 0 || first === 10 || first === 127) return false; // 0/8, 10/8, loopback
+    if (first === 169 && second === 254) return false; // link-local / metadata
+    if (first === 172 && second >= 16 && second <= 31) return false; // 172.16/12
+    if (first === 192 && second === 168) return false; // 192.168/16
+  }
+  return true;
+}
+
 export function createServer(options: CreateServerOptions): McpServer {
   const nb = options.notebook;
   const fetchFn: FetchFn = options.fetchFn ?? (globalThis.fetch as unknown as FetchFn);
@@ -172,7 +203,16 @@ export function createServer(options: CreateServerOptions): McpServer {
 
         let html: string;
         try {
-          const res = await fetchFn(url, { headers: DEFAULT_HEADERS });
+          if (!isFetchableUrl(url)) {
+            return fail(
+              `Refusing to fetch ${url}: cite_url only fetches http/https addresses ` +
+                "outside loopback, private and link-local ranges. Record it with add_source instead.",
+            );
+          }
+          const res = await fetchFn(url, {
+            headers: DEFAULT_HEADERS,
+            signal: AbortSignal.timeout(CITE_FETCH_TIMEOUT_MS),
+          });
           if (!res.ok) return fail(`Fetch failed for ${url} (HTTP ${res.status}).`);
           html = await res.text();
         } catch (err) {
@@ -471,7 +511,8 @@ export function createServer(options: CreateServerOptions): McpServer {
         tag: z.string().optional(),
         write: z.boolean().optional().describe("Also write references.bib to the notebook folder."),
       },
-      annotations: { readOnlyHint: true },
+      // No readOnlyHint: with write:true this tool writes references.bib, and
+      // clients use the hint to auto-approve tools without asking.
     },
     async ({ tag, write }) =>
       guard(async () => {
@@ -504,7 +545,7 @@ export function createServer(options: CreateServerOptions): McpServer {
         title: z.string().optional(),
         write: z.boolean().optional().describe("Also write references.md to the notebook folder."),
       },
-      annotations: { readOnlyHint: true },
+      // No readOnlyHint: with write:true this tool writes references.md.
     },
     async ({ annotated, tag, title, write }) =>
       guard(async () => {
@@ -532,7 +573,7 @@ export function createServer(options: CreateServerOptions): McpServer {
         title: z.string().optional(),
         write: z.boolean().optional().describe("Also write outline.md to the notebook folder."),
       },
-      annotations: { readOnlyHint: true },
+      // No readOnlyHint: with write:true this tool writes outline.md.
     },
     async ({ tag, title, write }) =>
       guard(async () => {

--- a/mcp-servers/research-notebook/src/server.ts
+++ b/mcp-servers/research-notebook/src/server.ts
@@ -1,0 +1,578 @@
+/**
+ * MCP server wiring.
+ *
+ * `createServer` builds an `McpServer` and registers the Research Notebook
+ * tools against a `Notebook` instance. Both the notebook and the `fetch`
+ * implementation are injected so the whole server can be driven in-memory from
+ * tests with no filesystem surprises and no network.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { Notebook, NotebookError } from "./notebook.js";
+import { extractMetadata } from "./metadata.js";
+import { toBibtex } from "./bibtex.js";
+import { exportBibliographyMarkdown, generateOutline, renderReference } from "./markdown.js";
+import { SOURCE_TYPES, type Note, type Source, type SourceType } from "./types.js";
+
+export type FetchFn = (
+  url: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
+export interface CreateServerOptions {
+  notebook: Notebook;
+  /** Injectable fetch; defaults to the global fetch. */
+  fetchFn?: FetchFn;
+  name?: string;
+  version?: string;
+}
+
+interface ToolResult {
+  content: { type: "text"; text: string }[];
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+  // The SDK's CallToolResult carries an index signature; matching it keeps our
+  // handler return type assignable without casts.
+  [key: string]: unknown;
+}
+
+function ok(text: string, structured?: Record<string, unknown>): ToolResult {
+  return { content: [{ type: "text", text }], structuredContent: structured };
+}
+
+function fail(message: string): ToolResult {
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+}
+
+/** Wrap a handler so NotebookError becomes a clean tool error, not a crash. */
+async function guard(fn: () => Promise<ToolResult>): Promise<ToolResult> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof NotebookError) return fail(err.message);
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+// --- Rendering for the text channel ---------------------------------------
+
+function sourceLine(s: Source): string {
+  const authors = s.authors.length > 0 ? s.authors.join(", ") : "Unknown author";
+  const date = s.publishedDate ? ` (${s.publishedDate})` : "";
+  const tags = s.tags.length > 0 ? `  #${s.tags.join(" #")}` : "";
+  return `[${s.citeKey}] ${s.title} - ${authors}${date}${tags}`;
+}
+
+function sourceDetail(s: Source): string {
+  const lines = [
+    `id: ${s.id}`,
+    `cite key: ${s.citeKey}`,
+    `type: ${s.type}`,
+    `title: ${s.title}`,
+    `authors: ${s.authors.join(", ") || "(none)"}`,
+  ];
+  if (s.container) lines.push(`container: ${s.container}`);
+  if (s.publishedDate) lines.push(`published: ${s.publishedDate}`);
+  if (s.doi) lines.push(`doi: ${s.doi}`);
+  if (s.url) lines.push(`url: ${s.url}`);
+  if (s.tags.length) lines.push(`tags: ${s.tags.join(", ")}`);
+  if (s.summary) lines.push(`summary: ${s.summary}`);
+  if (s.quotes.length) {
+    lines.push(`quotes (${s.quotes.length}):`);
+    for (const q of s.quotes) {
+      lines.push(`  - "${q.text}"${q.page ? ` (${q.page})` : ""}`);
+      if (q.note) lines.push(`    note: ${q.note}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function noteLine(n: Note): string {
+  const tags = n.tags.length > 0 ? `  #${n.tags.join(" #")}` : "";
+  const links = n.sourceIds.length > 0 ? `  (${n.sourceIds.length} source link(s))` : "";
+  return `${n.id}: ${n.title}${links}${tags}`;
+}
+
+function noteDetail(nb: Notebook, n: Note): string {
+  const keys = n.sourceIds
+    .map((id) => nb.resolveSource(id)?.citeKey ?? id)
+    .join(", ");
+  const lines = [
+    `id: ${n.id}`,
+    `title: ${n.title}`,
+    n.tags.length ? `tags: ${n.tags.join(", ")}` : undefined,
+    n.sourceIds.length ? `sources: ${keys}` : undefined,
+    "",
+    n.content || "(no content)",
+  ].filter((l): l is string => l !== undefined);
+  return lines.join("\n");
+}
+
+const DEFAULT_HEADERS = {
+  "User-Agent":
+    "boss-research-notebook-mcp/1.0 (+https://bossconsole.ai; citation capture)",
+  Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+};
+
+export function createServer(options: CreateServerOptions): McpServer {
+  const nb = options.notebook;
+  const fetchFn: FetchFn = options.fetchFn ?? (globalThis.fetch as unknown as FetchFn);
+
+  const server = new McpServer({
+    name: options.name ?? "research-notebook",
+    version: options.version ?? "1.0.0",
+  });
+
+  const sourceRef = z
+    .string()
+    .describe("A source id (src-...) or its cite key (e.g. vaswani2017attention).");
+  const tagsSchema = z.array(z.string()).optional().describe("Lowercase topic tags.");
+  const typeSchema = z
+    .enum(SOURCE_TYPES as unknown as [SourceType, ...SourceType[]])
+    .optional()
+    .describe("Bibliographic type. Defaults to webpage, or paper for pages with DOIs.");
+
+  // 1. cite_url ------------------------------------------------------------
+  server.registerTool(
+    "cite_url",
+    {
+      title: "Cite a web page",
+      description:
+        "Fetch a URL, extract its bibliographic metadata (title, authors, date, journal/site, DOI) " +
+        "and save it as a source. If the URL is already saved, it is not duplicated; any quote/note " +
+        "you pass is added to the existing source instead. This is the fastest way to capture a " +
+        "citation while browsing.",
+      inputSchema: {
+        url: z.string().url().describe("The page to cite."),
+        quote: z.string().optional().describe("An excerpt to store with the source."),
+        note: z.string().optional().describe("Your comment on the quote, or a one-line summary."),
+        tags: tagsSchema,
+        type: typeSchema,
+      },
+      annotations: { readOnlyHint: false, openWorldHint: true },
+    },
+    async ({ url, quote, note, tags, type }) =>
+      guard(async () => {
+        const existing = nb.findByUrl(url);
+        if (existing) {
+          if (quote) await nb.addQuote(existing.citeKey, { text: quote, note });
+          if (tags && tags.length) {
+            await nb.updateSource(existing.citeKey, {
+              tags: [...existing.tags, ...tags],
+            });
+          }
+          const refreshed = nb.resolveSource(existing.citeKey)!;
+          return ok(
+            `Already saved as [${refreshed.citeKey}].` +
+              (quote ? " Added your quote to it." : "") +
+              `\n\n${sourceDetail(refreshed)}`,
+            { source: refreshed, deduped: true },
+          );
+        }
+
+        let html: string;
+        try {
+          const res = await fetchFn(url, { headers: DEFAULT_HEADERS });
+          if (!res.ok) return fail(`Fetch failed for ${url} (HTTP ${res.status}).`);
+          html = await res.text();
+        } catch (err) {
+          return fail(
+            `Could not fetch ${url}: ${err instanceof Error ? err.message : String(err)}. ` +
+              "You can still record it with add_source.",
+          );
+        }
+
+        const meta = extractMetadata(html, url);
+        const source = await nb.addSource({
+          title: meta.title ?? url,
+          type: type ?? meta.type,
+          url,
+          authors: meta.authors,
+          container: meta.container,
+          publishedDate: meta.publishedDate,
+          doi: meta.doi,
+          summary: note ?? meta.summary,
+          tags,
+        });
+        if (quote) await nb.addQuote(source.citeKey, { text: quote, note });
+        const saved = nb.resolveSource(source.citeKey)!;
+        return ok(`Saved [${saved.citeKey}].\n\n${sourceDetail(saved)}`, {
+          source: saved,
+          deduped: false,
+        });
+      }),
+  );
+
+  // 2. add_source ----------------------------------------------------------
+  server.registerTool(
+    "add_source",
+    {
+      title: "Add a source manually",
+      description:
+        "Record a source by hand - a book, a paper you have the details for, or a page you cannot " +
+        "fetch. Use this when cite_url is not possible.",
+      inputSchema: {
+        title: z.string().describe("Title of the work."),
+        type: typeSchema,
+        url: z.string().optional(),
+        authors: z.array(z.string()).optional().describe('Authors, "First Last" or "Last, First".'),
+        container: z.string().optional().describe("Journal, publisher, or site name."),
+        publishedDate: z.string().optional().describe("Year or ISO date."),
+        doi: z.string().optional(),
+        tags: tagsSchema,
+        summary: z.string().optional().describe("A short summary in your own words."),
+      },
+    },
+    async (args) =>
+      guard(async () => {
+        const source = await nb.addSource(args);
+        return ok(`Added [${source.citeKey}].\n\n${sourceDetail(source)}`, { source });
+      }),
+  );
+
+  // 3. add_quote -----------------------------------------------------------
+  server.registerTool(
+    "add_quote",
+    {
+      title: "Add a quote to a source",
+      description: "Attach an excerpt (optionally with a page/location and your comment) to a source.",
+      inputSchema: {
+        source: sourceRef,
+        text: z.string().describe("The quoted excerpt."),
+        page: z.string().optional().describe('Page or location, e.g. "p. 12" or "§3.2".'),
+        note: z.string().optional().describe("Why this excerpt matters."),
+      },
+    },
+    async ({ source, text, page, note }) =>
+      guard(async () => {
+        const updated = await nb.addQuote(source, { text, page, note });
+        return ok(`Added quote to [${updated.citeKey}] (${updated.quotes.length} total).`, {
+          source: updated,
+        });
+      }),
+  );
+
+  // 4. add_note ------------------------------------------------------------
+  server.registerTool(
+    "add_note",
+    {
+      title: "Add a research note",
+      description:
+        "Write a research note in Markdown and link it to the sources it draws on. Notes are the " +
+        "raw material generate_outline turns into a literature-review scaffold.",
+      inputSchema: {
+        title: z.string(),
+        content: z.string().describe("Markdown body of the note."),
+        sources: z.array(z.string()).optional().describe("Source ids or cite keys to link."),
+        tags: tagsSchema,
+      },
+    },
+    async ({ title, content, sources, tags }) =>
+      guard(async () => {
+        const note = await nb.addNote({ title, content, sourceIds: sources, tags });
+        return ok(`Added note ${note.id}: "${note.title}".`, { note });
+      }),
+  );
+
+  // 5. update_note ---------------------------------------------------------
+  server.registerTool(
+    "update_note",
+    {
+      title: "Update a research note",
+      description: "Edit a note's title, content, tags, or linked sources. Omitted fields are unchanged.",
+      inputSchema: {
+        id: z.string().describe("Note id (note-...)."),
+        title: z.string().optional(),
+        content: z.string().optional(),
+        sources: z.array(z.string()).optional().describe("Replaces the linked sources."),
+        tags: tagsSchema,
+      },
+    },
+    async ({ id, title, content, sources, tags }) =>
+      guard(async () => {
+        const note = await nb.updateNote(id, { title, content, sourceIds: sources, tags });
+        return ok(`Updated note ${note.id}.`, { note });
+      }),
+  );
+
+  // 6. update_source -------------------------------------------------------
+  server.registerTool(
+    "update_source",
+    {
+      title: "Update a source",
+      description: "Correct or enrich a source's bibliographic fields. Omitted fields are unchanged.",
+      inputSchema: {
+        source: sourceRef,
+        title: z.string().optional(),
+        type: typeSchema,
+        url: z.string().optional(),
+        authors: z.array(z.string()).optional(),
+        container: z.string().optional(),
+        publishedDate: z.string().optional(),
+        doi: z.string().optional(),
+        tags: tagsSchema,
+        summary: z.string().optional(),
+      },
+    },
+    async ({ source, ...patch }) =>
+      guard(async () => {
+        const updated = await nb.updateSource(source, patch);
+        return ok(`Updated [${updated.citeKey}].\n\n${sourceDetail(updated)}`, { source: updated });
+      }),
+  );
+
+  // 7. list_sources --------------------------------------------------------
+  server.registerTool(
+    "list_sources",
+    {
+      title: "List sources",
+      description: "List all saved sources, optionally filtered by tag.",
+      inputSchema: { tag: z.string().optional() },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ tag }) =>
+      guard(async () => {
+        const sources = nb.listSources({ tag });
+        const text =
+          sources.length === 0
+            ? "No sources yet."
+            : `${sources.length} source(s):\n` + sources.map(sourceLine).join("\n");
+        return ok(text, { sources });
+      }),
+  );
+
+  // 8. list_notes ----------------------------------------------------------
+  server.registerTool(
+    "list_notes",
+    {
+      title: "List notes",
+      description: "List research notes, optionally filtered by tag or by a linked source.",
+      inputSchema: {
+        tag: z.string().optional(),
+        source: z.string().optional().describe("Only notes linked to this source id/cite key."),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ tag, source }) =>
+      guard(async () => {
+        const notes = nb.listNotes({ tag, sourceId: source });
+        const text =
+          notes.length === 0
+            ? "No notes yet."
+            : `${notes.length} note(s):\n` + notes.map(noteLine).join("\n");
+        return ok(text, { notes });
+      }),
+  );
+
+  // 9. get_source ----------------------------------------------------------
+  server.registerTool(
+    "get_source",
+    {
+      title: "Get a source",
+      description: "Show the full detail of one source, including its quotes.",
+      inputSchema: { source: sourceRef },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ source }) =>
+      guard(async () => {
+        const s = nb.resolveSource(source);
+        if (!s) return fail(`No source found with id or cite key "${source}".`);
+        return ok(sourceDetail(s), { source: s });
+      }),
+  );
+
+  // 10. get_note -----------------------------------------------------------
+  server.registerTool(
+    "get_note",
+    {
+      title: "Get a note",
+      description: "Show the full content of one research note.",
+      inputSchema: { id: z.string() },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ id }) =>
+      guard(async () => {
+        const n = nb.resolveNote(id);
+        if (!n) return fail(`No note found with id "${id}".`);
+        return ok(noteDetail(nb, n), { note: n });
+      }),
+  );
+
+  // 11. search -------------------------------------------------------------
+  server.registerTool(
+    "search",
+    {
+      title: "Search the notebook",
+      description:
+        "Full-text search across sources (title, authors, journal, tags, quotes, summary) and notes " +
+        "(title, content, tags). Returns matching cite keys and note ids.",
+      inputSchema: { query: z.string().describe("Text to search for.") },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ query }) =>
+      guard(async () => {
+        const { sources, notes } = nb.search(query);
+        const lines: string[] = [];
+        lines.push(`Sources (${sources.length}):`);
+        lines.push(...(sources.length ? sources.map((s) => `  ${sourceLine(s)}`) : ["  (none)"]));
+        lines.push(`Notes (${notes.length}):`);
+        lines.push(...(notes.length ? notes.map((n) => `  ${noteLine(n)}`) : ["  (none)"]));
+        return ok(lines.join("\n"), { sources, notes });
+      }),
+  );
+
+  // 12. remove_source ------------------------------------------------------
+  server.registerTool(
+    "remove_source",
+    {
+      title: "Remove a source",
+      description:
+        "Delete a source. Any notes that linked to it keep their text; the broken link is dropped " +
+        "and reported.",
+      inputSchema: { source: sourceRef },
+      annotations: { destructiveHint: true },
+    },
+    async ({ source }) =>
+      guard(async () => {
+        const { removed, affectedNotes } = await nb.removeSource(source);
+        const suffix =
+          affectedNotes.length > 0
+            ? ` Unlinked from ${affectedNotes.length} note(s): ${affectedNotes.join(", ")}.`
+            : "";
+        return ok(`Removed [${removed.citeKey}].${suffix}`, { removed, affectedNotes });
+      }),
+  );
+
+  // 13. remove_note --------------------------------------------------------
+  server.registerTool(
+    "remove_note",
+    {
+      title: "Remove a note",
+      description: "Delete a research note.",
+      inputSchema: { id: z.string() },
+      annotations: { destructiveHint: true },
+    },
+    async ({ id }) =>
+      guard(async () => {
+        const removed = await nb.removeNote(id);
+        return ok(`Removed note ${removed.id}: "${removed.title}".`, { removed });
+      }),
+  );
+
+  // 14. export_bibtex ------------------------------------------------------
+  server.registerTool(
+    "export_bibtex",
+    {
+      title: "Export BibTeX",
+      description:
+        "Render sources as BibTeX. Optionally filter by tag and/or write the result to " +
+        "references.bib next to the notebook.",
+      inputSchema: {
+        tag: z.string().optional(),
+        write: z.boolean().optional().describe("Also write references.bib to the notebook folder."),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ tag, write }) =>
+      guard(async () => {
+        const sources = nb.listSources({ tag });
+        const bib = toBibtex(sources);
+        let wrote = "";
+        if (write) {
+          const p = await nb.writeExport("references.bib", bib);
+          const label = sources.length === 1 ? "entry" : "entries";
+          wrote = `\n\nWrote ${sources.length} ${label} to ${p}`;
+        }
+        return ok((bib || "% No sources to export.") + wrote, {
+          bibtex: bib,
+          count: sources.length,
+        });
+      }),
+  );
+
+  // 15. export_markdown ----------------------------------------------------
+  server.registerTool(
+    "export_markdown",
+    {
+      title: "Export a Markdown bibliography",
+      description:
+        "Render a Markdown bibliography. Set annotated to include summaries and quotes. Optionally " +
+        "filter by tag and/or write references.md next to the notebook.",
+      inputSchema: {
+        annotated: z.boolean().optional(),
+        tag: z.string().optional(),
+        title: z.string().optional(),
+        write: z.boolean().optional().describe("Also write references.md to the notebook folder."),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ annotated, tag, title, write }) =>
+      guard(async () => {
+        const md = exportBibliographyMarkdown(nb.snapshot(), { annotated, tag, title });
+        let wrote = "";
+        if (write) {
+          const p = await nb.writeExport("references.md", md);
+          wrote = `\n\nWrote ${p}`;
+        }
+        return ok(md + wrote, { markdown: md });
+      }),
+  );
+
+  // 16. generate_outline ---------------------------------------------------
+  server.registerTool(
+    "generate_outline",
+    {
+      title: "Generate a literature-review outline",
+      description:
+        "Assemble your notes into a Markdown literature-review scaffold: notes grouped by theme, " +
+        "each threaded with the cite keys it draws on, plus a References section and a 'not yet " +
+        "written up' list. Optionally filter by tag and/or write outline.md next to the notebook.",
+      inputSchema: {
+        tag: z.string().optional(),
+        title: z.string().optional(),
+        write: z.boolean().optional().describe("Also write outline.md to the notebook folder."),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ tag, title, write }) =>
+      guard(async () => {
+        const md = generateOutline(nb.snapshot(), { tag, title });
+        let wrote = "";
+        if (write) {
+          const p = await nb.writeExport("outline.md", md);
+          wrote = `\n\nWrote ${p}`;
+        }
+        return ok(md + wrote, { outline: md });
+      }),
+  );
+
+  // 17. notebook_stats -----------------------------------------------------
+  server.registerTool(
+    "notebook_stats",
+    {
+      title: "Notebook statistics",
+      description: "Summarise the notebook: counts of sources, notes, quotes, tags, and types.",
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    async () =>
+      guard(async () => {
+        const stats = nb.stats();
+        const byType = Object.entries(stats.byType)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join(", ");
+        const text = [
+          `Notebook: ${nb.title ?? "(untitled)"}  @ ${nb.directory}`,
+          `Sources: ${stats.sources}  Notes: ${stats.notes}  Quotes: ${stats.quotes}`,
+          `Types: ${byType || "(none)"}`,
+          `Tags: ${stats.tags.length ? stats.tags.join(", ") : "(none)"}`,
+        ].join("\n");
+        return ok(text, stats);
+      }),
+  );
+
+  return server;
+}
+
+/** Exposed for tests / callers that want a one-line human citation. */
+export { renderReference };

--- a/mcp-servers/research-notebook/src/types.ts
+++ b/mcp-servers/research-notebook/src/types.ts
@@ -49,8 +49,8 @@ export interface Source {
   container?: string;
   /** Publication date as an ISO date or a free-form year/label. */
   publishedDate?: string;
-  /** When you added it to the notebook. */
-  accessedDate: string; // ISO 8601
+  /** When you added it to the notebook. Absent on hand-edited entries. */
+  accessedDate?: string; // ISO 8601
   doi?: string;
   tags: string[];
   quotes: Quote[];

--- a/mcp-servers/research-notebook/src/types.ts
+++ b/mcp-servers/research-notebook/src/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Data model for the Research Notebook.
+ *
+ * A notebook is a single JSON document (plus generated Markdown / BibTeX
+ * exports) that lives inside the researcher's project. It records **sources**
+ * (things you cite) and **notes** (your own writing), with notes linked to the
+ * sources they draw on. Everything here is plain data with no behaviour so it
+ * serializes cleanly and is trivial to test.
+ */
+
+/** Bibliographic kind of a source. Drives the BibTeX entry type. */
+export type SourceType =
+  | "article" // journalistic / web article
+  | "paper" // academic paper / preprint
+  | "webpage" // a generic web page
+  | "book"
+  | "report"
+  | "other";
+
+export const SOURCE_TYPES: readonly SourceType[] = [
+  "article",
+  "paper",
+  "webpage",
+  "book",
+  "report",
+  "other",
+];
+
+/** An excerpt copied from a source, optionally with a page/location. */
+export interface Quote {
+  text: string;
+  /** Page number or location label (e.g. "p. 42", "§3.1"). Optional. */
+  page?: string;
+  /** Why this excerpt matters, in your own words. Optional. */
+  note?: string;
+  addedAt: string; // ISO 8601
+}
+
+/** Something you cite: a paper, an article, a book, a web page. */
+export interface Source {
+  id: string; // stable internal id, e.g. "src-1a2b3c4d"
+  /** Human-friendly citation key, e.g. "smith2020attention". Unique. */
+  citeKey: string;
+  type: SourceType;
+  title: string;
+  url?: string;
+  authors: string[];
+  /** Journal, publisher, or site name (BibTeX journal/publisher/howpublished). */
+  container?: string;
+  /** Publication date as an ISO date or a free-form year/label. */
+  publishedDate?: string;
+  /** When you added it to the notebook. */
+  accessedDate: string; // ISO 8601
+  doi?: string;
+  tags: string[];
+  quotes: Quote[];
+  /** A short summary of the source in your own words. */
+  summary?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A piece of your own research writing, linked to the sources behind it. */
+export interface Note {
+  id: string; // "note-1a2b3c4d"
+  title: string;
+  /** Markdown body. */
+  content: string;
+  /** ids of sources this note draws on. */
+  sourceIds: string[];
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** The full on-disk notebook document. */
+export interface NotebookData {
+  /** Schema version, so older notebooks can be migrated forward. */
+  version: 1;
+  /** Optional project/topic title for exports. */
+  title?: string;
+  sources: Source[];
+  notes: Note[];
+}
+
+export function emptyNotebook(title?: string): NotebookData {
+  return { version: 1, title, sources: [], notes: [] };
+}

--- a/mcp-servers/research-notebook/test/bibtex.test.ts
+++ b/mcp-servers/research-notebook/test/bibtex.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { escapeTex, toBibtex, toBibtexEntry } from "../src/bibtex.js";
+import type { Source } from "../src/types.js";
+
+function source(over: Partial<Source>): Source {
+  return {
+    id: "src-1",
+    citeKey: "vaswani2017attention",
+    type: "paper",
+    title: "Attention Is All You Need",
+    url: "https://arxiv.org/abs/1706.03762",
+    authors: ["Vaswani, Ashish", "Shazeer, Noam"],
+    container: "NeurIPS",
+    publishedDate: "2017-06-12",
+    accessedDate: "2024-01-01T00:00:00.000Z",
+    doi: "10.48550/arXiv.1706.03762",
+    tags: [],
+    quotes: [],
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("escapeTex", () => {
+  it("escapes special characters", () => {
+    expect(escapeTex("A & B 50% #1 $x_y")).toBe("A \\& B 50\\% \\#1 \\$x\\_y");
+  });
+});
+
+describe("toBibtexEntry", () => {
+  it("renders a paper as @article with a journal", () => {
+    const entry = toBibtexEntry(source({}));
+    expect(entry).toContain("@article{vaswani2017attention,");
+    expect(entry).toContain("title = {Attention Is All You Need}");
+    expect(entry).toContain("author = {Vaswani, Ashish and Shazeer, Noam}");
+    expect(entry).toContain("journal = {NeurIPS}");
+    expect(entry).toContain("year = {2017}");
+    expect(entry).toContain("doi = {10.48550/arXiv.1706.03762}");
+  });
+
+  it("renders a book as @book with a publisher", () => {
+    const entry = toBibtexEntry(
+      source({ type: "book", citeKey: "knuth1997art", container: "Addison-Wesley", doi: undefined }),
+    );
+    expect(entry).toContain("@book{knuth1997art,");
+    expect(entry).toContain("publisher = {Addison-Wesley}");
+  });
+
+  it("renders a webpage as @misc with howpublished url", () => {
+    const entry = toBibtexEntry(
+      source({ type: "webpage", citeKey: "web2023", container: "Example", doi: undefined }),
+    );
+    expect(entry).toContain("@misc{web2023,");
+    expect(entry).toContain("howpublished = {\\url{https://arxiv.org/abs/1706.03762}}");
+  });
+
+  it("omits the year when there is no date", () => {
+    const entry = toBibtexEntry(source({ publishedDate: undefined }));
+    expect(entry).not.toContain("year =");
+  });
+});
+
+describe("toBibtex", () => {
+  it("joins multiple entries and ends with a newline", () => {
+    const out = toBibtex([source({}), source({ citeKey: "b2020", type: "book" })]);
+    expect(out.match(/@/g)).toHaveLength(2);
+    expect(out.endsWith("\n")).toBe(true);
+  });
+  it("returns empty string for no sources", () => {
+    expect(toBibtex([])).toBe("");
+  });
+});

--- a/mcp-servers/research-notebook/test/bibtex.test.ts
+++ b/mcp-servers/research-notebook/test/bibtex.test.ts
@@ -26,6 +26,16 @@ describe("escapeTex", () => {
   it("escapes special characters", () => {
     expect(escapeTex("A & B 50% #1 $x_y")).toBe("A \\& B 50\\% \\#1 \\$x\\_y");
   });
+
+  it("escapes a backslash without double-escaping its braces", () => {
+    expect(escapeTex("a\\b")).toBe("a\\textbackslash{}b");
+  });
+
+  it("escapes every special character in a single pass", () => {
+    expect(escapeTex('C\\^~ 50%_a{b}')).toBe(
+      "C\\textbackslash{}\\textasciicircum{}\\textasciitilde{} 50\\%\\_a\\{b\\}",
+    );
+  });
 });
 
 describe("toBibtexEntry", () => {

--- a/mcp-servers/research-notebook/test/citekey.test.ts
+++ b/mcp-servers/research-notebook/test/citekey.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  baseCiteKey,
+  surnameOf,
+  titleWord,
+  uniqueCiteKey,
+  yearOf,
+} from "../src/citekey.js";
+
+describe("surnameOf", () => {
+  it("handles 'First Last'", () => {
+    expect(surnameOf("Ashish Vaswani")).toBe("vaswani");
+  });
+  it("handles 'Last, First'", () => {
+    expect(surnameOf("Vaswani, Ashish")).toBe("vaswani");
+  });
+  it("strips diacritics", () => {
+    expect(surnameOf("José Peña")).toBe("pena");
+  });
+  it("handles a single token", () => {
+    expect(surnameOf("Aristotle")).toBe("aristotle");
+  });
+  it("returns empty for blank", () => {
+    expect(surnameOf("   ")).toBe("");
+  });
+});
+
+describe("yearOf", () => {
+  it("extracts a year from an ISO date", () => {
+    expect(yearOf("2017-06-12")).toBe("2017");
+  });
+  it("extracts a year from slash format", () => {
+    expect(yearOf("2017/06/12")).toBe("2017");
+  });
+  it("returns 'nd' when absent", () => {
+    expect(yearOf(undefined)).toBe("nd");
+    expect(yearOf("no date here")).toBe("nd");
+  });
+});
+
+describe("titleWord", () => {
+  it("skips stopwords", () => {
+    expect(titleWord("The Rise of Transformers")).toBe("rise");
+  });
+  it("falls back to the first word when all are stopwords", () => {
+    expect(titleWord("On the")).toBe("on");
+  });
+});
+
+describe("baseCiteKey", () => {
+  it("builds author+year+word", () => {
+    expect(
+      baseCiteKey({
+        authors: ["Ashish Vaswani"],
+        publishedDate: "2017-06-12",
+        title: "Attention Is All You Need",
+      }),
+    ).toBe("vaswani2017attention");
+  });
+  it("uses container when no author", () => {
+    expect(
+      baseCiteKey({ container: "Nature", publishedDate: "2020", title: "CRISPR advances" }),
+    ).toBe("nature2020crispr");
+  });
+  it("falls back to anon + nd (no author, no date)", () => {
+    expect(baseCiteKey({ title: "" })).toBe("anonnd");
+  });
+});
+
+describe("uniqueCiteKey", () => {
+  it("returns the base when free", () => {
+    expect(uniqueCiteKey({ authors: ["Smith"], publishedDate: "2020", title: "Neural" }, new Set())).toBe(
+      "smith2020neural",
+    );
+  });
+  it("appends letters on collision", () => {
+    const existing = new Set(["smith2020neural"]);
+    expect(
+      uniqueCiteKey({ authors: ["Smith"], publishedDate: "2020", title: "Neural" }, existing),
+    ).toBe("smith2020neurala");
+  });
+  it("keeps incrementing past the first collision", () => {
+    const existing = new Set(["smith2020neural", "smith2020neurala"]);
+    expect(
+      uniqueCiteKey({ authors: ["Smith"], publishedDate: "2020", title: "Neural" }, existing),
+    ).toBe("smith2020neuralb");
+  });
+});

--- a/mcp-servers/research-notebook/test/fixtures/article.html
+++ b/mcp-servers/research-notebook/test/fixtures/article.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Fallback Title Should Lose | Example News</title>
+  <meta property="og:title" content="The Rise of Retrieval-Augmented Generation" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="Example News" />
+  <meta property="og:description" content="A plain-language look at how RAG changed NLP systems." />
+  <meta name="author" content="Ada Lovelace" />
+  <meta property="article:author" content="Alan Turing" />
+  <meta property="article:published_time" content="2023-05-14T09:30:00Z" />
+</head>
+<body>
+  <h1>The Rise of Retrieval-Augmented Generation</h1>
+  <p>Body text that should not be used for metadata.</p>
+</body>
+</html>

--- a/mcp-servers/research-notebook/test/fixtures/jsonld.html
+++ b/mcp-servers/research-notebook/test/fixtures/jsonld.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>JSON-LD Backed Article</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "name": "Research Weekly"
+      },
+      {
+        "@type": "ScholarlyArticle",
+        "headline": "Graph Neural Networks in Practice",
+        "author": [
+          { "@type": "Person", "name": "Grace Hopper" },
+          { "@type": "Person", "name": "Katherine Johnson" }
+        ],
+        "datePublished": "2021-11-02",
+        "publisher": { "@type": "Organization", "name": "Research Weekly" },
+        "description": "An applied survey of GNNs."
+      }
+    ]
+  }
+  </script>
+</head>
+<body><h1>Ignored</h1></body>
+</html>

--- a/mcp-servers/research-notebook/test/fixtures/scholar.html
+++ b/mcp-servers/research-notebook/test/fixtures/scholar.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Attention Is All You Need</title>
+  <meta name="citation_title" content="Attention Is All You Need" />
+  <meta name="citation_author" content="Vaswani, Ashish" />
+  <meta name="citation_author" content="Shazeer, Noam" />
+  <meta name="citation_author" content="Parmar, Niki" />
+  <meta name="citation_publication_date" content="2017/06/12" />
+  <meta name="citation_journal_title" content="Advances in Neural Information Processing Systems" />
+  <meta name="citation_doi" content="10.48550/arXiv.1706.03762" />
+  <meta property="og:site_name" content="arXiv.org" />
+</head>
+<body>
+  <h1>Attention Is All You Need</h1>
+</body>
+</html>

--- a/mcp-servers/research-notebook/test/markdown.test.ts
+++ b/mcp-servers/research-notebook/test/markdown.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  exportBibliographyMarkdown,
+  generateOutline,
+  renderReference,
+} from "../src/markdown.js";
+import type { NotebookData, Source } from "../src/types.js";
+
+function source(over: Partial<Source>): Source {
+  return {
+    id: over.id ?? "src-1",
+    citeKey: over.citeKey ?? "vaswani2017attention",
+    type: over.type ?? "paper",
+    title: over.title ?? "Attention Is All You Need",
+    url: over.url ?? "https://arxiv.org/abs/1706.03762",
+    authors: over.authors ?? ["Vaswani, Ashish", "Shazeer, Noam", "Parmar, Niki"],
+    container: over.container ?? "NeurIPS",
+    publishedDate: over.publishedDate ?? "2017",
+    accessedDate: "2024-01-01T00:00:00.000Z",
+    doi: over.doi,
+    tags: over.tags ?? [],
+    quotes: over.quotes ?? [],
+    summary: over.summary,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  };
+}
+
+describe("renderReference", () => {
+  it("formats 3+ authors with et al.", () => {
+    expect(renderReference(source({}))).toContain("Vaswani, Ashish et al.");
+  });
+  it("includes year, italic title and container", () => {
+    const ref = renderReference(source({}));
+    expect(ref).toContain("(2017)");
+    expect(ref).toContain("*Attention Is All You Need*");
+    expect(ref).toContain("NeurIPS");
+  });
+  it("prefers a DOI link over the raw url", () => {
+    expect(renderReference(source({ doi: "10.1/x" }))).toContain("https://doi.org/10.1/x");
+  });
+});
+
+function notebook(over: Partial<NotebookData> = {}): NotebookData {
+  return { version: 1, sources: [], notes: [], ...over };
+}
+
+describe("exportBibliographyMarkdown", () => {
+  it("lists sources with cite keys", () => {
+    const md = exportBibliographyMarkdown(notebook({ sources: [source({})] }));
+    expect(md).toContain("# References");
+    expect(md).toContain("**[vaswani2017attention]**");
+  });
+  it("annotated mode includes summaries and quotes", () => {
+    const md = exportBibliographyMarkdown(
+      notebook({
+        sources: [
+          source({
+            summary: "A landmark paper.",
+            quotes: [{ text: "self-attention", page: "p.3", addedAt: "2024-01-01T00:00:00Z" }],
+          }),
+        ],
+      }),
+      { annotated: true },
+    );
+    expect(md).toContain("A landmark paper.");
+    expect(md).toContain("> self-attention (p.3)");
+  });
+  it("handles an empty notebook", () => {
+    expect(exportBibliographyMarkdown(notebook())).toContain("_No sources recorded yet._");
+  });
+});
+
+describe("generateOutline", () => {
+  it("groups notes by theme, threads cite keys, lists references", () => {
+    const s = source({ id: "src-1", citeKey: "vaswani2017attention", tags: ["transformers"] });
+    const data = notebook({
+      title: "My Survey",
+      sources: [s],
+      notes: [
+        {
+          id: "note-1",
+          title: "Self-attention scales",
+          content: "Key point about parallelism.\nMore detail.",
+          sourceIds: ["src-1"],
+          tags: ["transformers"],
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+    });
+    const md = generateOutline(data);
+    expect(md).toContain("# My Survey");
+    expect(md).toContain("### Transformers");
+    expect(md).toContain("**Self-attention scales** [@vaswani2017attention]");
+    expect(md).toContain("Key point about parallelism.");
+    expect(md).toContain("## References");
+  });
+
+  it("lists sources that have no note under 'not yet written up'", () => {
+    const data = notebook({
+      sources: [source({ id: "src-9", citeKey: "unread2020" })],
+      notes: [],
+    });
+    const md = generateOutline(data);
+    expect(md).toContain("## Sources not yet written up");
+    expect(md).toContain("unread2020");
+  });
+
+  it("handles a notebook with no notes", () => {
+    const md = generateOutline(notebook());
+    expect(md).toContain("_No notes to outline yet");
+  });
+});

--- a/mcp-servers/research-notebook/test/metadata.test.ts
+++ b/mcp-servers/research-notebook/test/metadata.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+import { extractDoi, extractMetadata, hostnameOf } from "../src/metadata.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string) => readFileSync(path.join(here, "fixtures", name), "utf8");
+
+describe("extractMetadata: OpenGraph article", () => {
+  const meta = extractMetadata(fixture("article.html"), "https://news.example.com/rag");
+  it("prefers og:title over <title>", () => {
+    expect(meta.title).toBe("The Rise of Retrieval-Augmented Generation");
+  });
+  it("collects author + article:author", () => {
+    expect(meta.authors).toEqual(["Ada Lovelace", "Alan Turing"]);
+  });
+  it("reads the published time", () => {
+    expect(meta.publishedDate).toBe("2023-05-14T09:30:00Z");
+  });
+  it("uses og:site_name as container", () => {
+    expect(meta.container).toBe("Example News");
+  });
+  it("classifies it as an article", () => {
+    expect(meta.type).toBe("article");
+  });
+  it("captures the description as summary", () => {
+    expect(meta.summary).toContain("RAG");
+  });
+});
+
+describe("extractMetadata: Google Scholar / highwire tags", () => {
+  const meta = extractMetadata(fixture("scholar.html"), "https://arxiv.org/abs/1706.03762");
+  it("reads the citation title", () => {
+    expect(meta.title).toBe("Attention Is All You Need");
+  });
+  it("collects every citation_author in order", () => {
+    expect(meta.authors).toEqual(["Vaswani, Ashish", "Shazeer, Noam", "Parmar, Niki"]);
+  });
+  it("reads the journal title", () => {
+    expect(meta.container).toBe("Advances in Neural Information Processing Systems");
+  });
+  it("reads the DOI", () => {
+    expect(meta.doi).toBe("10.48550/arXiv.1706.03762");
+  });
+  it("classifies a page with citation tags/DOI as a paper", () => {
+    expect(meta.type).toBe("paper");
+  });
+});
+
+describe("extractMetadata: JSON-LD", () => {
+  const meta = extractMetadata(fixture("jsonld.html"), "https://research.example.com/gnn");
+  it("reads headline, authors and date from @graph", () => {
+    expect(meta.title).toBe("Graph Neural Networks in Practice");
+    expect(meta.authors).toEqual(["Grace Hopper", "Katherine Johnson"]);
+    expect(meta.publishedDate).toBe("2021-11-02");
+  });
+  it("reads the publisher as container", () => {
+    expect(meta.container).toBe("Research Weekly");
+  });
+  it("classifies ScholarlyArticle as a paper", () => {
+    expect(meta.type).toBe("paper");
+  });
+});
+
+describe("extractMetadata: degenerate input", () => {
+  it("falls back to <title> and hostname", () => {
+    const meta = extractMetadata("<title>Bare Page</title>", "https://www.example.org/x");
+    expect(meta.title).toBe("Bare Page");
+    expect(meta.container).toBe("example.org");
+    expect(meta.type).toBe("webpage");
+    expect(meta.authors).toEqual([]);
+  });
+  it("does not throw on empty html", () => {
+    expect(() => extractMetadata("", "not a url")).not.toThrow();
+  });
+});
+
+describe("helpers", () => {
+  it("extractDoi finds a DOI in a string", () => {
+    expect(extractDoi("see doi:10.1000/xyz123 for details")).toBe("10.1000/xyz123");
+    expect(extractDoi("no doi here")).toBeUndefined();
+  });
+  it("hostnameOf strips www", () => {
+    expect(hostnameOf("https://www.nature.com/articles/x")).toBe("nature.com");
+    expect(hostnameOf("garbage")).toBeUndefined();
+  });
+});

--- a/mcp-servers/research-notebook/test/notebook.test.ts
+++ b/mcp-servers/research-notebook/test/notebook.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Notebook, NotebookError, normaliseUrl } from "../src/notebook.js";
+
+async function tempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "rn-test-"));
+}
+
+function deps(dir: string) {
+  let counter = 0;
+  return {
+    dir,
+    now: () => new Date("2024-01-01T12:00:00.000Z"),
+    makeId: () => `id${++counter}`,
+  };
+}
+
+describe("normaliseUrl", () => {
+  it("drops fragment, tracking params, trailing slash, www", () => {
+    expect(normaliseUrl("https://www.Example.com/a/?utm_source=x&ref=y#frag")).toBe(
+      "https://example.com/a",
+    );
+  });
+  it("keeps meaningful query params", () => {
+    expect(normaliseUrl("https://example.com/a?id=7")).toBe("https://example.com/a?id=7");
+  });
+  it("passes through non-URLs", () => {
+    expect(normaliseUrl("not a url")).toBe("not a url");
+  });
+});
+
+describe("Notebook sources", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await tempDir();
+  });
+
+  it("adds a source, generates a cite key, and persists to disk", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const src = await nb.addSource({
+      title: "Attention Is All You Need",
+      authors: ["Ashish Vaswani"],
+      publishedDate: "2017",
+      url: "https://arxiv.org/abs/1706.03762",
+    });
+    expect(src.id).toBe("src-id1");
+    expect(src.citeKey).toBe("vaswani2017attention");
+
+    const onDisk = JSON.parse(await fs.readFile(path.join(dir, "notebook.json"), "utf8"));
+    expect(onDisk.sources).toHaveLength(1);
+    expect(onDisk.sources[0].citeKey).toBe("vaswani2017attention");
+  });
+
+  it("reloads persisted data from a fresh instance", async () => {
+    const nb1 = await Notebook.open(deps(dir));
+    await nb1.addSource({ title: "First" });
+    const nb2 = await Notebook.open(deps(dir));
+    expect(nb2.listSources()).toHaveLength(1);
+    expect(nb2.listSources()[0]!.title).toBe("First");
+  });
+
+  it("disambiguates colliding cite keys", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const a = await nb.addSource({ title: "Neural nets", authors: ["Smith"], publishedDate: "2020" });
+    const b = await nb.addSource({ title: "Neural nets", authors: ["Smith"], publishedDate: "2020" });
+    expect(a.citeKey).toBe("smith2020neural");
+    expect(b.citeKey).toBe("smith2020neurala");
+  });
+
+  it("finds an existing source by normalised URL", async () => {
+    const nb = await Notebook.open(deps(dir));
+    await nb.addSource({ title: "X", url: "https://example.com/p/" });
+    expect(nb.findByUrl("https://www.example.com/p?utm_source=z")).toBeDefined();
+    expect(nb.findByUrl("https://other.com")).toBeUndefined();
+  });
+
+  it("resolves a source by id or cite key", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const s = await nb.addSource({ title: "Y", authors: ["Doe"], publishedDate: "2019" });
+    expect(nb.resolveSource(s.id)?.id).toBe(s.id);
+    expect(nb.resolveSource(s.citeKey)?.id).toBe(s.id);
+  });
+
+  it("adds quotes to a source", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const s = await nb.addSource({ title: "Q" });
+    const updated = await nb.addQuote(s.citeKey, { text: "a key finding", page: "p. 3" });
+    expect(updated.quotes).toHaveLength(1);
+    expect(updated.quotes[0]!.text).toBe("a key finding");
+    expect(updated.quotes[0]!.page).toBe("p. 3");
+  });
+
+  it("normalises and de-duplicates tags", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const s = await nb.addSource({ title: "T", tags: ["NLP", "nlp", " ML "] });
+    expect(s.tags).toEqual(["nlp", "ml"]);
+  });
+
+  it("rejects a blank title", async () => {
+    const nb = await Notebook.open(deps(dir));
+    await expect(nb.addSource({ title: "   " })).rejects.toBeInstanceOf(NotebookError);
+  });
+
+  it("rejects a quote on an unknown source", async () => {
+    const nb = await Notebook.open(deps(dir));
+    await expect(nb.addQuote("nope", { text: "x" })).rejects.toBeInstanceOf(NotebookError);
+  });
+});
+
+describe("Notebook notes", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await tempDir();
+  });
+
+  it("links a note to sources by cite key, resolving to the id", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const s = await nb.addSource({ title: "Linked", authors: ["Ray"], publishedDate: "2018" });
+    const unlinked = await nb.addNote({ title: "Thoughts", content: "Interesting angle." });
+    expect(unlinked.sourceIds).toEqual([]);
+    const linked = await nb.addNote({ title: "T2", content: "c", sourceIds: [s.citeKey] });
+    expect(linked.sourceIds).toEqual([s.id]);
+  });
+
+  it("rejects linking to an unknown source", async () => {
+    const nb = await Notebook.open(deps(dir));
+    await expect(
+      nb.addNote({ title: "T", content: "c", sourceIds: ["ghost"] }),
+    ).rejects.toBeInstanceOf(NotebookError);
+  });
+
+  it("removing a source unlinks it from notes", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const s = await nb.addSource({ title: "ToRemove" });
+    const note = await nb.addNote({ title: "N", content: "c", sourceIds: [s.id] });
+    const result = await nb.removeSource(s.id);
+    expect(result.affectedNotes).toEqual([note.id]);
+    expect(nb.resolveNote(note.id)!.sourceIds).toEqual([]);
+  });
+
+  it("filters notes by linked source and by tag", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const s = await nb.addSource({ title: "S" });
+    await nb.addNote({ title: "A", content: "", sourceIds: [s.id], tags: ["theme1"] });
+    await nb.addNote({ title: "B", content: "", tags: ["theme2"] });
+    expect(nb.listNotes({ sourceId: s.id })).toHaveLength(1);
+    expect(nb.listNotes({ tag: "theme2" })).toHaveLength(1);
+  });
+
+  it("updates a note", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const note = await nb.addNote({ title: "Old", content: "old" });
+    const updated = await nb.updateNote(note.id, { title: "New", content: "new" });
+    expect(updated.title).toBe("New");
+    expect(updated.content).toBe("new");
+  });
+});
+
+describe("Notebook search & stats", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await tempDir();
+  });
+
+  it("searches across sources and notes", async () => {
+    const nb = await Notebook.open(deps(dir));
+    await nb.addSource({ title: "Transformers explained", tags: ["nlp"] });
+    await nb.addNote({ title: "My take", content: "transformers are great" });
+    const hit = nb.search("transformers");
+    expect(hit.sources).toHaveLength(1);
+    expect(hit.notes).toHaveLength(1);
+    expect(nb.search("nothingmatches").sources).toHaveLength(0);
+  });
+
+  it("reports stats", async () => {
+    const nb = await Notebook.open(deps(dir));
+    const s = await nb.addSource({ title: "S", type: "paper", tags: ["a"] });
+    await nb.addQuote(s.id, { text: "q" });
+    await nb.addNote({ title: "N", content: "", tags: ["b"] });
+    const stats = nb.stats();
+    expect(stats.sources).toBe(1);
+    expect(stats.notes).toBe(1);
+    expect(stats.quotes).toBe(1);
+    expect(stats.byType.paper).toBe(1);
+    expect(stats.tags).toEqual(["a", "b"]);
+  });
+});
+
+describe("Notebook resilience", () => {
+  it("throws a clear error on corrupt notebook.json", async () => {
+    const dir = await tempDir();
+    await fs.writeFile(path.join(dir, "notebook.json"), "{ not json", "utf8");
+    await expect(Notebook.open(deps(dir))).rejects.toBeInstanceOf(NotebookError);
+  });
+
+  it("creates the directory if missing", async () => {
+    const dir = path.join(await tempDir(), "nested", "notebook-dir");
+    const nb = await Notebook.open(deps(dir));
+    await nb.addSource({ title: "X" });
+    await expect(fs.stat(path.join(dir, "notebook.json"))).resolves.toBeDefined();
+  });
+});

--- a/mcp-servers/research-notebook/test/notebook.test.ts
+++ b/mcp-servers/research-notebook/test/notebook.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Notebook, NotebookError, normaliseUrl } from "../src/notebook.js";
+import { exportBibliographyMarkdown } from "../src/markdown.js";
 
 async function tempDir(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), "rn-test-"));
@@ -200,5 +201,64 @@ describe("Notebook resilience", () => {
     const nb = await Notebook.open(deps(dir));
     await nb.addSource({ title: "X" });
     await expect(fs.stat(path.join(dir, "notebook.json"))).resolves.toBeDefined();
+  });
+
+  it("normalises a hand-edited notebook missing array fields", async () => {
+    const dir = await tempDir();
+    await fs.writeFile(
+      path.join(dir, "notebook.json"),
+      JSON.stringify({
+        version: 1,
+        sources: [
+          {
+            id: "src-x",
+            citeKey: "hand2020edited",
+            type: "paper",
+            title: "Hand edited",
+            accessedDate: "2024-01-01T00:00:00.000Z",
+            createdAt: "2024-01-01T00:00:00.000Z",
+            updatedAt: "2024-01-01T00:00:00.000Z",
+          },
+        ],
+        notes: [
+          {
+            id: "note-x",
+            title: "n",
+            content: "c",
+            createdAt: "2024-01-01T00:00:00.000Z",
+            updatedAt: "2024-01-01T00:00:00.000Z",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    const nb = await Notebook.open(deps(dir));
+    expect(nb.stats()).toEqual({
+      sources: 1,
+      notes: 1,
+      quotes: 0,
+      tags: [],
+      byType: { paper: 1 },
+    });
+    expect(nb.listSources()[0]!.authors).toEqual([]);
+    expect(nb.listNotes()[0]!.sourceIds).toEqual([]);
+    expect(exportBibliographyMarkdown(nb.snapshot())).toContain("hand2020edited");
+  });
+
+  it("drops malformed entries instead of keeping them", async () => {
+    const dir = await tempDir();
+    await fs.writeFile(
+      path.join(dir, "notebook.json"),
+      JSON.stringify({
+        version: 1,
+        sources: [{ title: "no id" }, "junk", null],
+        notes: [{ id: "note-ok", title: "ok", content: "x" }],
+      }),
+      "utf8",
+    );
+    const nb = await Notebook.open(deps(dir));
+    expect(nb.listSources()).toHaveLength(0);
+    expect(nb.listNotes()).toHaveLength(1);
+    expect(nb.listNotes()[0]!.sourceIds).toEqual([]);
   });
 });

--- a/mcp-servers/research-notebook/test/notebook.test.ts
+++ b/mcp-servers/research-notebook/test/notebook.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Notebook, NotebookError, normaliseUrl } from "../src/notebook.js";
 import { exportBibliographyMarkdown } from "../src/markdown.js";
+import { toBibtex } from "../src/bibtex.js";
 
 async function tempDir(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), "rn-test-"));
@@ -203,7 +204,7 @@ describe("Notebook resilience", () => {
     await expect(fs.stat(path.join(dir, "notebook.json"))).resolves.toBeDefined();
   });
 
-  it("normalises a hand-edited notebook missing array fields", async () => {
+  it("normalises a hand-edited notebook missing fields", async () => {
     const dir = await tempDir();
     await fs.writeFile(
       path.join(dir, "notebook.json"),
@@ -215,9 +216,10 @@ describe("Notebook resilience", () => {
             citeKey: "hand2020edited",
             type: "paper",
             title: "Hand edited",
-            accessedDate: "2024-01-01T00:00:00.000Z",
             createdAt: "2024-01-01T00:00:00.000Z",
             updatedAt: "2024-01-01T00:00:00.000Z",
+            tags: ["ML", " ml "],
+            isbn: "978-3-16-148410-0",
           },
         ],
         notes: [
@@ -237,28 +239,62 @@ describe("Notebook resilience", () => {
       sources: 1,
       notes: 1,
       quotes: 0,
-      tags: [],
+      tags: ["ml"],
       byType: { paper: 1 },
     });
     expect(nb.listSources()[0]!.authors).toEqual([]);
+    // The stored tag is normalised like the write path does it, so a query
+    // in any case finds it.
+    expect(nb.listSources({ tag: "ML" })).toHaveLength(1);
     expect(nb.listNotes()[0]!.sourceIds).toEqual([]);
     expect(exportBibliographyMarkdown(nb.snapshot())).toContain("hand2020edited");
+    // No accessedDate was stored, so the BibTeX export must not invent one.
+    expect(toBibtex(nb.listSources())).not.toContain("urldate");
+    // Unknown keys survive a load/save round trip.
+    await nb.addSource({ title: "Another" });
+    const reloaded = JSON.parse(await fs.readFile(path.join(dir, "notebook.json"), "utf8"));
+    expect(reloaded.sources[0].isbn).toBe("978-3-16-148410-0");
   });
 
-  it("drops malformed entries instead of keeping them", async () => {
+  it("refuses to load a notebook with unrecognised entries", async () => {
     const dir = await tempDir();
     await fs.writeFile(
       path.join(dir, "notebook.json"),
       JSON.stringify({
         version: 1,
-        sources: [{ title: "no id" }, "junk", null],
+        sources: [{ title: "no id" }, "junk"],
         notes: [{ id: "note-ok", title: "ok", content: "x" }],
       }),
       "utf8",
     );
-    const nb = await Notebook.open(deps(dir));
-    expect(nb.listSources()).toHaveLength(0);
-    expect(nb.listNotes()).toHaveLength(1);
-    expect(nb.listNotes()[0]!.sourceIds).toEqual([]);
+    await expect(Notebook.open(deps(dir))).rejects.toBeInstanceOf(NotebookError);
   });
+});
+
+describe("Notebook normalisation details", () => {
+  it("dedupes and trims hand-edited authors", async () => {
+    const dir = await tempDir();
+    await fs.writeFile(
+      path.join(dir, "notebook.json"),
+      JSON.stringify({
+        version: 1,
+        sources: [
+          {
+            id: "src-a",
+            citeKey: "a2020",
+            type: "paper",
+            title: "A",
+            authors: [" Smith", "Smith", "jane"],
+            accessedDate: "2024-01-01T00:00:00.000Z",
+            createdAt: "2024-01-01T00:00:00.000Z",
+            updatedAt: "2024-01-01T00:00:00.000Z",
+          },
+        ],
+        notes: [],
+      }),
+      "utf8",
+    );
+    const nb = await Notebook.open(deps(dir));
+    expect(nb.listSources()[0]!.authors).toEqual(["Smith", "jane"]);
+});
 });

--- a/mcp-servers/research-notebook/test/server.test.ts
+++ b/mcp-servers/research-notebook/test/server.test.ts
@@ -7,13 +7,19 @@ import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Notebook } from "../src/notebook.js";
-import { createServer, type FetchFn } from "../src/server.js";
+import { createServer, isFetchableUrl, type FetchFn } from "../src/server.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const fixture = (name: string) => readFileSync(path.join(here, "fixtures", name), "utf8");
 
 /** A fetch stub that maps known URLs to fixtures and 404s everything else. */
-const fakeFetch: FetchFn = async (url) => {
+interface FetchCall {
+  url: string;
+  init?: { headers?: Record<string, string>; signal?: AbortSignal };
+}
+const fetchCalls: FetchCall[] = [];
+const fakeFetch: FetchFn = async (url, init) => {
+  fetchCalls.push({ url, init });
   const map: Record<string, string> = {
     "https://arxiv.org/abs/1706.03762": fixture("scholar.html"),
     "https://news.example.com/rag": fixture("article.html"),
@@ -59,6 +65,7 @@ describe("MCP server end to end", () => {
   let dir: string;
   beforeEach(async () => {
     dir = await fs.mkdtemp(path.join(os.tmpdir(), "rn-server-"));
+    fetchCalls.length = 0;
   });
 
   it("exposes the full tool set", async () => {
@@ -164,5 +171,66 @@ describe("MCP server end to end", () => {
     await call(client, "add_note", { title: "N", content: "c", sources: [key] });
     const removed = await call(client, "remove_source", { source: key });
     expect(textOf(removed)).toContain("Unlinked from 1 note");
+  });
+
+  it("does not claim readOnlyHint on tools that can write files", async () => {
+    const { client } = await connectedClient(dir);
+    const { tools } = await client.listTools();
+    const byName = new Map(tools.map((t) => [t.name, t]));
+    for (const name of ["export_bibtex", "export_markdown", "generate_outline"]) {
+      expect(byName.get(name)?.annotations?.readOnlyHint, name).not.toBe(true);
+    }
+    expect(byName.get("notebook_stats")?.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("cite_url passes a timeout signal to fetch", async () => {
+    const { client } = await connectedClient(dir);
+    await call(client, "cite_url", { url: "https://arxiv.org/abs/1706.03762" });
+    const entry = fetchCalls.find((c) => c.url === "https://arxiv.org/abs/1706.03762");
+    expect(entry?.init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("cite_url refuses loopback, private, link-local and non-http(s) URLs", async () => {
+    const { client } = await connectedClient(dir);
+    for (const url of [
+      "http://127.0.0.1:8080/admin",
+      "http://localhost:8080/",
+      "http://169.254.169.254/latest/meta-data/",
+      "http://10.1.2.3/secret",
+      "http://192.168.1.1/",
+      "file:///etc/passwd",
+    ]) {
+      const res = await call(client, "cite_url", { url });
+      expect(res.isError, url).toBe(true);
+      expect(textOf(res), url).toContain("Refusing to fetch");
+    }
+    // Nothing was attempted: the stub never saw these URLs.
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("isFetchableUrl", () => {
+  it("allows public http/https URLs", () => {
+    expect(isFetchableUrl("https://arxiv.org/abs/1706.03762")).toBe(true);
+    expect(isFetchableUrl("http://example.com/a?b=1")).toBe(true);
+    expect(isFetchableUrl("https://8.8.8.8/")).toBe(true);
+  });
+
+  it("rejects other schemes and invalid URLs", () => {
+    expect(isFetchableUrl("file:///etc/passwd")).toBe(false);
+    expect(isFetchableUrl("ftp://example.com/x")).toBe(false);
+    expect(isFetchableUrl("not a url")).toBe(false);
+  });
+
+  it("rejects loopback, link-local and private address literals", () => {
+    expect(isFetchableUrl("http://127.0.0.1/")).toBe(false);
+    expect(isFetchableUrl("http://0.0.0.0:8080/")).toBe(false);
+    expect(isFetchableUrl("http://10.0.0.1/")).toBe(false);
+    expect(isFetchableUrl("http://172.16.0.1/")).toBe(false);
+    expect(isFetchableUrl("http://172.31.255.255/")).toBe(false);
+    expect(isFetchableUrl("http://169.254.169.254/")).toBe(false);
+    expect(isFetchableUrl("http://192.168.0.1/")).toBe(false);
+    expect(isFetchableUrl("http://172.32.0.1/")).toBe(true);
+    expect(isFetchableUrl("http://169.255.0.1/")).toBe(true);
   });
 });

--- a/mcp-servers/research-notebook/test/server.test.ts
+++ b/mcp-servers/research-notebook/test/server.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { promises as fs } from "node:fs";
+import { readFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Notebook } from "../src/notebook.js";
+import { createServer, type FetchFn } from "../src/server.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string) => readFileSync(path.join(here, "fixtures", name), "utf8");
+
+/** A fetch stub that maps known URLs to fixtures and 404s everything else. */
+const fakeFetch: FetchFn = async (url) => {
+  const map: Record<string, string> = {
+    "https://arxiv.org/abs/1706.03762": fixture("scholar.html"),
+    "https://news.example.com/rag": fixture("article.html"),
+  };
+  const body = map[url];
+  if (body === undefined) {
+    return { ok: false, status: 404, text: async () => "" };
+  }
+  return { ok: true, status: 200, text: async () => body };
+};
+
+interface CallResult {
+  content: { type: string; text?: string }[];
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+async function connectedClient(dir: string): Promise<{ client: Client }> {
+  const notebook = await Notebook.open({
+    dir,
+    now: () => new Date("2024-01-01T00:00:00.000Z"),
+  });
+  const server = createServer({ notebook, fetchFn: fakeFetch });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return { client };
+}
+
+async function call(
+  client: Client,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<CallResult> {
+  return (await client.callTool({ name, arguments: args })) as unknown as CallResult;
+}
+
+function textOf(result: CallResult): string {
+  return result.content.map((c) => c.text ?? "").join("\n");
+}
+
+describe("MCP server end to end", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "rn-server-"));
+  });
+
+  it("exposes the full tool set", async () => {
+    const { client } = await connectedClient(dir);
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toContain("cite_url");
+    expect(names).toContain("generate_outline");
+    expect(names).toContain("export_bibtex");
+    expect(names.length).toBe(17);
+  });
+
+  it("cite_url captures a paper with extracted metadata", async () => {
+    const { client } = await connectedClient(dir);
+    const res = await call(client, "cite_url", {
+      url: "https://arxiv.org/abs/1706.03762",
+      quote: "self-attention",
+      tags: ["transformers"],
+    });
+    expect(res.isError).toBeFalsy();
+    const text = textOf(res);
+    expect(text).toContain("vaswani2017attention");
+    expect(text).toContain("Attention Is All You Need");
+    const src = res.structuredContent?.source as { citeKey: string; quotes: unknown[] };
+    expect(src.citeKey).toBe("vaswani2017attention");
+    expect(src.quotes).toHaveLength(1);
+  });
+
+  it("cite_url de-duplicates the same URL", async () => {
+    const { client } = await connectedClient(dir);
+    await call(client, "cite_url", { url: "https://arxiv.org/abs/1706.03762" });
+    const again = await call(client, "cite_url", {
+      url: "https://www.arxiv.org/abs/1706.03762?utm_source=x",
+      quote: "added later",
+    });
+    expect(again.structuredContent?.deduped).toBe(true);
+    expect(textOf(again)).toContain("Already saved");
+    // The list still has exactly one source.
+    const list = await call(client, "list_sources");
+    expect((list.structuredContent?.sources as unknown[]).length).toBe(1);
+  });
+
+  it("cite_url reports a clean error when the fetch fails", async () => {
+    const { client } = await connectedClient(dir);
+    const res = await call(client, "cite_url", { url: "https://news.example.com/missing" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("Fetch failed");
+  });
+
+  it("supports the full notes -> outline -> export workflow", async () => {
+    const { client } = await connectedClient(dir);
+    await call(client, "cite_url", {
+      url: "https://arxiv.org/abs/1706.03762",
+      tags: ["transformers"],
+    });
+    await call(client, "add_note", {
+      title: "Self-attention scales",
+      content: "Parallelism is the key advantage.",
+      sources: ["vaswani2017attention"],
+      tags: ["transformers"],
+    });
+
+    const outline = await call(client, "generate_outline", { write: true });
+    const outlineText = textOf(outline);
+    expect(outlineText).toContain("### Transformers");
+    expect(outlineText).toContain("[@vaswani2017attention]");
+    // write:true should have produced a file on disk.
+    await expect(fs.stat(path.join(dir, "outline.md"))).resolves.toBeDefined();
+
+    const bib = await call(client, "export_bibtex", { write: true });
+    expect(textOf(bib)).toContain("@article{vaswani2017attention");
+    await expect(fs.stat(path.join(dir, "references.bib"))).resolves.toBeDefined();
+
+    const stats = await call(client, "notebook_stats");
+    expect(stats.structuredContent?.sources).toBe(1);
+    expect(stats.structuredContent?.notes).toBe(1);
+  });
+
+  it("search finds captured content", async () => {
+    const { client } = await connectedClient(dir);
+    await call(client, "cite_url", { url: "https://arxiv.org/abs/1706.03762" });
+    const res = await call(client, "search", { query: "attention" });
+    expect((res.structuredContent?.sources as unknown[]).length).toBe(1);
+  });
+
+  it("returns a tool error for an unknown source", async () => {
+    const { client } = await connectedClient(dir);
+    const res = await call(client, "get_source", { source: "does-not-exist" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("No source found");
+  });
+
+  it("add_source + add_quote + remove_source unlinks notes", async () => {
+    const { client } = await connectedClient(dir);
+    const added = await call(client, "add_source", {
+      title: "Manual Book",
+      type: "book",
+      authors: ["Donald Knuth"],
+      publishedDate: "1997",
+      container: "Addison-Wesley",
+    });
+    const key = (added.structuredContent?.source as { citeKey: string }).citeKey;
+    await call(client, "add_note", { title: "N", content: "c", sources: [key] });
+    const removed = await call(client, "remove_source", { source: key });
+    expect(textOf(removed)).toContain("Unlinked from 1 note");
+  });
+});

--- a/mcp-servers/research-notebook/tsconfig.json
+++ b/mcp-servers/research-notebook/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/mcp-servers/research-notebook/vitest.config.ts
+++ b/mcp-servers/research-notebook/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Research Notebook MCP

A standalone TypeScript **MCP server** that turns any BOSS agent (Claude Code, Codex, Gemini, OpenCode) into a research assistant. It adds 17 tools to **capture cited sources, keep linked notes, and export a bibliography or a literature-review outline**, all stored as plain files inside the researcher's project.

Hackathon track: **Extend - connect an MCP tool**. Built for the **Researcher** persona on the idea bench.

### The problem
The hard part of a literature review is not reading, it is keeping track: where a fact came from, which paper made which claim, and how a pile of notes becomes a structured draft. A general chat agent forgets all of this between turns. This server gives the agent a durable, structured memory built around sources and notes.

### What it does
- `cite_url` fetches a page and extracts real bibliographic metadata (title, authors, date, journal/site, DOI) from Google Scholar / highwire `citation_*` tags, JSON-LD, OpenGraph and Dublin Core, with graceful fallbacks. De-duplicates by normalised URL.
- `add_source` / `update_source` / `add_quote` for manual and academic entries.
- `add_note` / `update_note` link your writing to the sources behind it.
- `search`, `list_*`, `get_*`, `remove_*`, `notebook_stats`.
- `export_bibtex` (drops into LaTeX/Overleaf), `export_markdown` (plain or annotated bibliography), and `generate_outline` (a literature-review scaffold grouping notes by theme with citation keys threaded in).

Everything is stored as `notebook.json` plus generated `references.bib` / `references.md` / `outline.md`, so nothing is locked away and it version-controls cleanly.

### Technical notes
- Pure, injectable core: fetch, clock, ids and the notebook directory are all injected, so the whole server runs deterministically in tests with no network.
- Atomic writes, URL normalisation for de-duplication, TeX escaping, author-year-word cite keys with collision suffixes.
- New self-contained top-level directory. Inert to the Gradle build (settings.gradle.kts uses explicit includes) and clean under the em-dash documentation guard.

### Testing
- `npm run typecheck`, `npm run build`, and `npm test` all pass: **79 tests across 6 suites**.
- Coverage includes metadata extraction (OpenGraph, highwire, JSON-LD, degenerate pages), cite-key generation and collisions, the notebook store and persistence (including corrupt-file handling), BibTeX and Markdown rendering, and a full end-to-end pass driving the real MCP server over an in-memory transport.
- Verified against the real built binary over stdio, and `cite_url` verified against a live arXiv page (extracted all authors, date, and paper type).

See `mcp-servers/research-notebook/README.md` for setup and the BOSS MCP configuration block.