### PR TITLE
fix(kernel): require a verified caller identity for the secrets and RBAC IPC bridges

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/RoleManagementServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/RoleManagementServiceBridge.kt
@@ -188,6 +188,11 @@ class RoleManagementServiceBridge(
      *
      * Mirrors [SecretServiceBridge]'s own helper (BossConsole#53) — fails closed rather than let a
      * request with no credential fall through to [provider] with nothing to attribute it to.
+     *
+     * Unary RPCs only: [ProcessIdentityInterceptor.AUTHENTICATED_PROCESS_ID] is a per-call snapshot,
+     * correct for unary methods. A streaming RPC on this bridge must read
+     * [ProcessIdentityInterceptor.CURRENT_IDENTITY] instead (see [PluginUIServiceBridge.streamUI]),
+     * so a mid-stream revocation is honoured.
      */
     private fun authenticatedCallerOrRefuse(rpc: String): String =
         ProcessIdentityInterceptor.AUTHENTICATED_PROCESS_ID.get() ?: run {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/RoleManagementServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/RoleManagementServiceBridge.kt
@@ -1,15 +1,32 @@
 package ai.rever.boss.kernel.services
 
+import ai.rever.boss.ipc.auth.ProcessIdentityInterceptor
 import ai.rever.boss.ipc.proto.Empty
 import ai.rever.boss.ipc.proto.services.*
 import ai.rever.boss.plugin.api.PermissionInfoData
 import ai.rever.boss.plugin.api.RoleInfoData
 import ai.rever.boss.plugin.api.RoleManagementProvider
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import io.grpc.Status
+import io.grpc.StatusException
 
+/**
+ * Kernel-side bridge for `RoleManagementService` — the out-of-process RBAC surface: list, create and
+ * delete roles/permissions, and grant/revoke a permission on a role.
+ *
+ * **Every call requires a verified caller identity (BossConsole#53)**, the same requirement and the
+ * same helper shape as [SecretServiceBridge] — see that class's KDoc for the full rationale. This is
+ * the other bridge whose worst case is not "stale UI state": an unattributed, unauthenticated caller
+ * here could enumerate every role/permission and mint or revoke access grants. A caller with no
+ * credential is refused with `PERMISSION_DENIED` before [provider] is ever reached, and every mutation
+ * logs the verified caller identity.
+ */
 class RoleManagementServiceBridge(
     private val provider: RoleManagementProvider,
 ) : RoleManagementServiceGrpcKt.RoleManagementServiceCoroutineImplBase() {
     override suspend fun getAllRoles(request: Empty): RoleListResponse {
+        authenticatedCallerOrRefuse("getAllRoles")
         val result = provider.getAllRoles()
         return result.fold(
             onSuccess = { roles ->
@@ -23,6 +40,7 @@ class RoleManagementServiceBridge(
     }
 
     override suspend fun getAllPermissions(request: Empty): PermissionListResponse {
+        authenticatedCallerOrRefuse("getAllPermissions")
         val result = provider.getAllPermissions()
         return result.fold(
             onSuccess = { perms ->
@@ -36,6 +54,8 @@ class RoleManagementServiceBridge(
     }
 
     override suspend fun createRole(request: CreateRoleRequest): RoleInfoResponse {
+        val caller = authenticatedCallerOrRefuse("createRole")
+        logMutation("createRole", caller, mapOf("name" to request.name))
         val result = provider.createRole(request.name, request.description.ifEmpty { null })
         return result.fold(
             onSuccess = { role ->
@@ -46,6 +66,8 @@ class RoleManagementServiceBridge(
     }
 
     override suspend fun createPermission(request: CreatePermissionRequest): PermissionInfoResponse {
+        val caller = authenticatedCallerOrRefuse("createPermission")
+        logMutation("createPermission", caller, mapOf("name" to request.name))
         val result = provider.createPermission(request.name, request.description.ifEmpty { null })
         return result.fold(
             onSuccess = { perm ->
@@ -55,18 +77,40 @@ class RoleManagementServiceBridge(
         )
     }
 
-    override suspend fun deleteRole(request: RoleNameRequest): RoleOperationResult = provider.deleteRole(request.name).toOperationResult()
+    override suspend fun deleteRole(request: RoleNameRequest): RoleOperationResult {
+        val caller = authenticatedCallerOrRefuse("deleteRole")
+        logMutation("deleteRole", caller, mapOf("name" to request.name))
+        return provider.deleteRole(request.name).toOperationResult()
+    }
 
-    override suspend fun deletePermission(request: PermissionNameRequest): RoleOperationResult =
-        provider.deletePermission(request.name).toOperationResult()
+    override suspend fun deletePermission(request: PermissionNameRequest): RoleOperationResult {
+        val caller = authenticatedCallerOrRefuse("deletePermission")
+        logMutation("deletePermission", caller, mapOf("name" to request.name))
+        return provider.deletePermission(request.name).toOperationResult()
+    }
 
-    override suspend fun assignPermissionToRole(request: RolePermissionRequest): RoleOperationResult =
-        provider.assignPermissionToRole(request.roleName, request.permissionName).toOperationResult()
+    override suspend fun assignPermissionToRole(request: RolePermissionRequest): RoleOperationResult {
+        val caller = authenticatedCallerOrRefuse("assignPermissionToRole")
+        logMutation(
+            "assignPermissionToRole",
+            caller,
+            mapOf("roleName" to request.roleName, "permissionName" to request.permissionName),
+        )
+        return provider.assignPermissionToRole(request.roleName, request.permissionName).toOperationResult()
+    }
 
-    override suspend fun removePermissionFromRole(request: RolePermissionRequest): RoleOperationResult =
-        provider.removePermissionFromRole(request.roleName, request.permissionName).toOperationResult()
+    override suspend fun removePermissionFromRole(request: RolePermissionRequest): RoleOperationResult {
+        val caller = authenticatedCallerOrRefuse("removePermissionFromRole")
+        logMutation(
+            "removePermissionFromRole",
+            caller,
+            mapOf("roleName" to request.roleName, "permissionName" to request.permissionName),
+        )
+        return provider.removePermissionFromRole(request.roleName, request.permissionName).toOperationResult()
+    }
 
     override suspend fun getRolePermissions(request: RoleNameRequest): RoleWithPermissionsResponse {
+        authenticatedCallerOrRefuse("getRolePermissions")
         val result = provider.getRolePermissions(request.name)
         return result.fold(
             onSuccess = { data ->
@@ -85,6 +129,7 @@ class RoleManagementServiceBridge(
     }
 
     override suspend fun validateRoleName(request: RoleNameRequest): ValidationResponse {
+        authenticatedCallerOrRefuse("validateRoleName")
         val error = provider.validateRoleName(request.name)
         return ValidationResponse
             .newBuilder()
@@ -94,6 +139,7 @@ class RoleManagementServiceBridge(
     }
 
     override suspend fun validatePermissionName(request: PermissionNameRequest): ValidationResponse {
+        authenticatedCallerOrRefuse("validatePermissionName")
         val error = provider.validatePermissionName(request.name)
         return ValidationResponse
             .newBuilder()
@@ -136,4 +182,35 @@ class RoleManagementServiceBridge(
                     .build()
             },
         )
+
+    /**
+     * The verified identity behind this call, or a thrown `PERMISSION_DENIED` when there is none.
+     *
+     * Mirrors [SecretServiceBridge]'s own helper (BossConsole#53) — fails closed rather than let a
+     * request with no credential fall through to [provider] with nothing to attribute it to.
+     */
+    private fun authenticatedCallerOrRefuse(rpc: String): String =
+        ProcessIdentityInterceptor.AUTHENTICATED_PROCESS_ID.get() ?: run {
+            logger.warn(
+                LogCategory.AUTH,
+                "Refused $rpc: no verified process identity on this call",
+                mapOf("rpc" to rpc),
+            )
+            throw StatusException(Status.PERMISSION_DENIED.withDescription(NO_IDENTITY))
+        }
+
+    /** Attributed audit line for an RBAC mutation — the caller identity a refusal would otherwise hide. */
+    private fun logMutation(
+        rpc: String,
+        caller: String,
+        extra: Map<String, Any?> = emptyMap(),
+    ) {
+        logger.info(LogCategory.AUTH, "Role/permission mutation", mapOf("rpc" to rpc, "caller" to caller) + extra)
+    }
+
+    private companion object {
+        val logger = BossLogger.forComponent("RoleManagementServiceBridge")
+
+        const val NO_IDENTITY = "This call presented no verified process identity"
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/SecretServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/SecretServiceBridge.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.kernel.services
 
+import ai.rever.boss.ipc.auth.ProcessIdentityInterceptor
 import ai.rever.boss.ipc.proto.services.*
 import ai.rever.boss.plugin.api.CreateSecretRequestData
 import ai.rever.boss.plugin.api.SecretDataProvider
@@ -8,11 +9,32 @@ import ai.rever.boss.plugin.api.SecretShareData
 import ai.rever.boss.plugin.api.ShareSecretRequestData
 import ai.rever.boss.plugin.api.UnshareSecretRequestData
 import ai.rever.boss.plugin.api.UpdateSecretRequestData
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import io.grpc.Status
+import io.grpc.StatusException
 
+/**
+ * Kernel-side bridge for `SecretService` — the whole out-of-process password vault surface:
+ * list, search, create, update, delete, share and unshare every secret the signed-in user holds.
+ *
+ * **Every call requires a verified caller identity (BossConsole#53).** Before this, an out-of-process
+ * plugin's secrets access was unlimited and unattributed: [PluginUIServiceBridge] is the one bridge
+ * [ProcessIdentityInterceptor]'s own KDoc names as actually checking identity, and this was one of the
+ * "fourteen other service bridges... none of them authenticated today" it lists — the single most
+ * sensitive one among them, since every other bridge's worst case is UI/workspace state while this one
+ * is the password vault. A caller with no token (any process not spawned through
+ * `ai.rever.boss.process.ProcessSpawner`, which is every legitimate plugin in production - see
+ * `ChildProcessBootstrap.processToken`) is refused with `PERMISSION_DENIED` before the request ever
+ * reaches [provider], on every method, not only the mutating ones: an unattributed read of the vault
+ * list is exactly the exposure this closes. The verified identity is logged with every mutating call so
+ * a compromised or rogue plugin's secrets activity is attributable after the fact, not just blocked.
+ */
 class SecretServiceBridge(
     private val provider: SecretDataProvider,
 ) : SecretServiceGrpcKt.SecretServiceCoroutineImplBase() {
     override suspend fun getUserSecrets(request: SecretPaginatedRequest): PaginatedSecretsResponse {
+        authenticatedCallerOrRefuse("getUserSecrets")
         val result = provider.getUserSecrets(request.limit, request.offset)
         return result.fold(
             onSuccess = { paginated ->
@@ -34,6 +56,7 @@ class SecretServiceBridge(
     }
 
     override suspend fun getUserSecretsWithSharingInfo(request: SecretPaginatedRequest): PaginatedSecretsWithSharingResponse {
+        authenticatedCallerOrRefuse("getUserSecretsWithSharingInfo")
         val result = provider.getUserSecretsWithSharingInfo(request.limit, request.offset)
         return result.fold(
             onSuccess = { paginated ->
@@ -76,6 +99,7 @@ class SecretServiceBridge(
     }
 
     override suspend fun searchSecrets(request: SearchSecretsRequest): PaginatedSecretsResponse {
+        authenticatedCallerOrRefuse("searchSecrets")
         val result = provider.searchSecrets(request.query, request.limit, request.offset)
         return result.fold(
             onSuccess = { paginated ->
@@ -97,6 +121,8 @@ class SecretServiceBridge(
     }
 
     override suspend fun createSecret(request: CreateSecretProtoRequest): SecretOperationResult {
+        val caller = authenticatedCallerOrRefuse("createSecret")
+        logMutation("createSecret", caller)
         val result =
             provider.createSecret(
                 CreateSecretRequestData(
@@ -115,6 +141,8 @@ class SecretServiceBridge(
     }
 
     override suspend fun updateSecret(request: UpdateSecretProtoRequest): SecretOperationResult {
+        val caller = authenticatedCallerOrRefuse("updateSecret")
+        logMutation("updateSecret", caller, mapOf("secretId" to request.secretId))
         val result =
             provider.updateSecret(
                 UpdateSecretRequestData(
@@ -133,10 +161,14 @@ class SecretServiceBridge(
         return result.toOperationResult()
     }
 
-    override suspend fun deleteSecret(request: SecretIdRequest): SecretOperationResult =
-        provider.deleteSecret(request.id).toOperationResult()
+    override suspend fun deleteSecret(request: SecretIdRequest): SecretOperationResult {
+        val caller = authenticatedCallerOrRefuse("deleteSecret")
+        logMutation("deleteSecret", caller, mapOf("secretId" to request.id))
+        return provider.deleteSecret(request.id).toOperationResult()
+    }
 
     override suspend fun getSecretShares(request: SecretIdRequest): SecretShareListResponse {
+        authenticatedCallerOrRefuse("getSecretShares")
         val result = provider.getSecretShares(request.id)
         return result.fold(
             onSuccess = { shares ->
@@ -152,6 +184,8 @@ class SecretServiceBridge(
     }
 
     override suspend fun shareSecret(request: ShareSecretProtoRequest): SecretOperationResult {
+        val caller = authenticatedCallerOrRefuse("shareSecret")
+        logMutation("shareSecret", caller, mapOf("secretId" to request.secretId))
         val result =
             provider.shareSecret(
                 ShareSecretRequestData(
@@ -166,6 +200,8 @@ class SecretServiceBridge(
     }
 
     override suspend fun unshareSecret(request: UnshareSecretProtoRequest): SecretOperationResult {
+        val caller = authenticatedCallerOrRefuse("unshareSecret")
+        logMutation("unshareSecret", caller, mapOf("secretId" to request.secretId))
         val result =
             provider.unshareSecret(
                 UnshareSecretRequestData(
@@ -175,6 +211,31 @@ class SecretServiceBridge(
                 ),
             )
         return result.toOperationResult()
+    }
+
+    /**
+     * The verified identity behind this call, or a thrown `PERMISSION_DENIED` when there is none.
+     *
+     * Mirrors [PluginUIServiceBridge]'s own helper (BossConsole#53) — fails closed rather than let a
+     * request with no credential fall through to [provider] with nothing to attribute it to.
+     */
+    private fun authenticatedCallerOrRefuse(rpc: String): String =
+        ProcessIdentityInterceptor.AUTHENTICATED_PROCESS_ID.get() ?: run {
+            logger.warn(
+                LogCategory.AUTH,
+                "Refused $rpc: no verified process identity on this call",
+                mapOf("rpc" to rpc),
+            )
+            throw StatusException(Status.PERMISSION_DENIED.withDescription(NO_IDENTITY))
+        }
+
+    /** Attributed audit line for a vault mutation — the caller identity a refusal would otherwise hide. */
+    private fun logMutation(
+        rpc: String,
+        caller: String,
+        extra: Map<String, Any?> = emptyMap(),
+    ) {
+        logger.info(LogCategory.AUTH, "Secret vault mutation", mapOf("rpc" to rpc, "caller" to caller) + extra)
     }
 
     private fun SecretEntryData.toProto(): SecretEntryProto =
@@ -219,4 +280,10 @@ class SecretServiceBridge(
                     .build()
             },
         )
+
+    private companion object {
+        val logger = BossLogger.forComponent("SecretServiceBridge")
+
+        const val NO_IDENTITY = "This call presented no verified process identity"
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/SecretServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/SecretServiceBridge.kt
@@ -218,6 +218,11 @@ class SecretServiceBridge(
      *
      * Mirrors [PluginUIServiceBridge]'s own helper (BossConsole#53) — fails closed rather than let a
      * request with no credential fall through to [provider] with nothing to attribute it to.
+     *
+     * Unary RPCs only: [ProcessIdentityInterceptor.AUTHENTICATED_PROCESS_ID] is a per-call snapshot,
+     * correct for unary methods. A streaming RPC on this bridge must read
+     * [ProcessIdentityInterceptor.CURRENT_IDENTITY] instead (see [PluginUIServiceBridge.streamUI]),
+     * so a mid-stream revocation is honoured.
      */
     private fun authenticatedCallerOrRefuse(rpc: String): String =
         ProcessIdentityInterceptor.AUTHENTICATED_PROCESS_ID.get() ?: run {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/RoleManagementServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/RoleManagementServiceBridgeTest.kt
@@ -1,0 +1,288 @@
+package ai.rever.boss.kernel.services
+
+import ai.rever.boss.ipc.auth.ProcessIdentityInterceptor
+import ai.rever.boss.ipc.auth.ProcessTokenClientInterceptor
+import ai.rever.boss.ipc.auth.ProcessTokenRegistry
+import ai.rever.boss.ipc.proto.Empty
+import ai.rever.boss.ipc.proto.services.CreatePermissionRequest
+import ai.rever.boss.ipc.proto.services.CreateRoleRequest
+import ai.rever.boss.ipc.proto.services.PermissionNameRequest
+import ai.rever.boss.ipc.proto.services.RoleManagementServiceGrpcKt
+import ai.rever.boss.ipc.proto.services.RoleNameRequest
+import ai.rever.boss.ipc.proto.services.RolePermissionRequest
+import ai.rever.boss.plugin.api.PermissionInfoData
+import ai.rever.boss.plugin.api.RoleInfoData
+import ai.rever.boss.plugin.api.RoleManagementProvider
+import ai.rever.boss.plugin.api.RoleWithPermissionsData
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.Status
+import io.grpc.StatusException
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The out-of-process RBAC surface, exercised over a real gRPC server with a real client - same style
+ * as [SecretServiceBridgeTest] (BossConsole#53).
+ *
+ * Every refusal test also asserts [FakeRoleManagementProvider] was never called: an unattributed
+ * caller enumerating or mutating roles/permissions is exactly the exposure this closes.
+ */
+class RoleManagementServiceBridgeTest {
+    private lateinit var tokenRegistry: ProcessTokenRegistry
+    private lateinit var provider: FakeRoleManagementProvider
+    private lateinit var server: Server
+    private lateinit var channel: ManagedChannel
+    private lateinit var authenticated: RoleManagementServiceGrpcKt.RoleManagementServiceCoroutineStub
+    private val extraChannels = mutableListOf<ManagedChannel>()
+
+    @BeforeTest
+    fun setUp() {
+        tokenRegistry = ProcessTokenRegistry()
+        provider = FakeRoleManagementProvider()
+        server =
+            ServerBuilder
+                .forPort(0)
+                .intercept(ProcessIdentityInterceptor(tokenRegistry))
+                .addService(RoleManagementServiceBridge(provider))
+                .build()
+                .start()
+        channel =
+            ManagedChannelBuilder
+                .forAddress("localhost", server.port)
+                .usePlaintext()
+                .intercept(ProcessTokenClientInterceptor(tokenRegistry.issue(DEFAULT_PROCESS)))
+                .build()
+        authenticated = RoleManagementServiceGrpcKt.RoleManagementServiceCoroutineStub(channel)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        channel.shutdownNow()
+        channel.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        extraChannels.forEach { it.shutdownNow() }
+        extraChannels.forEach { it.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
+        server.shutdownNow()
+        server.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    }
+
+    /** An unauthenticated stub against this test's server - no credential attached at all. */
+    private fun anonymousCaller(): RoleManagementServiceGrpcKt.RoleManagementServiceCoroutineStub {
+        val unauthenticatedChannel = ManagedChannelBuilder.forAddress("localhost", server.port).usePlaintext().build()
+        extraChannels += unauthenticatedChannel
+        return RoleManagementServiceGrpcKt.RoleManagementServiceCoroutineStub(unauthenticatedChannel)
+    }
+
+    @Test
+    fun `an authenticated caller can list roles`() =
+        runBlocking {
+            authenticated.getAllRoles(Empty.getDefaultInstance())
+            assertEquals(1, provider.getAllRolesCalls.get())
+        }
+
+    @Test
+    fun `an anonymous caller is refused and never reaches the provider`() =
+        runBlocking {
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().getAllRoles(Empty.getDefaultInstance())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
+            assertEquals(0, provider.getAllRolesCalls.get())
+        }
+
+    @Test
+    fun `getAllPermissions refuses an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> { anonymousCaller().getAllPermissions(Empty.getDefaultInstance()) }
+            assertEquals(0, provider.getAllPermissionsCalls.get())
+        }
+
+    @Test
+    fun `createRole succeeds for an authenticated caller`() =
+        runBlocking {
+            val response = authenticated.createRole(CreateRoleRequest.newBuilder().setName("editor").build())
+            assertEquals("editor", response.role.name)
+            assertEquals(1, provider.createRoleCalls.get())
+        }
+
+    @Test
+    fun `createRole refuses an anonymous caller and never mints a role`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().createRole(CreateRoleRequest.newBuilder().setName("rogue-admin").build())
+            }
+            assertEquals(0, provider.createRoleCalls.get())
+        }
+
+    @Test
+    fun `createPermission refuses an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().createPermission(CreatePermissionRequest.newBuilder().setName("secrets.read").build())
+            }
+            assertEquals(0, provider.createPermissionCalls.get())
+        }
+
+    @Test
+    fun `deleteRole and deletePermission refuse an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().deleteRole(RoleNameRequest.newBuilder().setName("admin").build())
+            }
+            assertFailsWith<StatusException> {
+                anonymousCaller().deletePermission(PermissionNameRequest.newBuilder().setName("secrets.read").build())
+            }
+            assertEquals(0, provider.deleteRoleCalls.get())
+            assertEquals(0, provider.deletePermissionCalls.get())
+        }
+
+    @Test
+    fun `assignPermissionToRole refuses an anonymous caller - no silent privilege grant`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().assignPermissionToRole(
+                    RolePermissionRequest
+                        .newBuilder()
+                        .setRoleName("admin")
+                        .setPermissionName("secrets.read")
+                        .build(),
+                )
+            }
+            assertEquals(0, provider.assignPermissionToRoleCalls.get())
+        }
+
+    @Test
+    fun `removePermissionFromRole refuses an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().removePermissionFromRole(
+                    RolePermissionRequest
+                        .newBuilder()
+                        .setRoleName("admin")
+                        .setPermissionName("secrets.read")
+                        .build(),
+                )
+            }
+            assertEquals(0, provider.removePermissionFromRoleCalls.get())
+        }
+
+    @Test
+    fun `getRolePermissions and name validation refuse an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().getRolePermissions(RoleNameRequest.newBuilder().setName("admin").build())
+            }
+            assertFailsWith<StatusException> {
+                anonymousCaller().validateRoleName(RoleNameRequest.newBuilder().setName("admin").build())
+            }
+            assertFailsWith<StatusException> {
+                anonymousCaller().validatePermissionName(
+                    PermissionNameRequest.newBuilder().setName("secrets.read").build(),
+                )
+            }
+        }
+
+    @Test
+    fun `an authenticated caller can validate names`() =
+        runBlocking {
+            val response = authenticated.validateRoleName(RoleNameRequest.newBuilder().setName("editor").build())
+            assertTrue(response.valid)
+        }
+
+    companion object {
+        private const val DEFAULT_PROCESS = "ai.rever.boss.plugin.dynamic.test-plugin"
+        private const val SHUTDOWN_TIMEOUT_MS = 5_000L
+    }
+}
+
+/** Records every call so a refusal test can assert the provider was never actually reached. */
+private class FakeRoleManagementProvider : RoleManagementProvider {
+    val getAllRolesCalls = AtomicInteger(0)
+    val getAllPermissionsCalls = AtomicInteger(0)
+    val createRoleCalls = AtomicInteger(0)
+    val createPermissionCalls = AtomicInteger(0)
+    val deleteRoleCalls = AtomicInteger(0)
+    val deletePermissionCalls = AtomicInteger(0)
+    val assignPermissionToRoleCalls = AtomicInteger(0)
+    val removePermissionFromRoleCalls = AtomicInteger(0)
+
+    override suspend fun getAllRoles(): Result<List<RoleInfoData>> {
+        getAllRolesCalls.incrementAndGet()
+        return Result.success(emptyList())
+    }
+
+    override suspend fun getAllPermissions(): Result<List<PermissionInfoData>> {
+        getAllPermissionsCalls.incrementAndGet()
+        return Result.success(emptyList())
+    }
+
+    override suspend fun createRole(
+        name: String,
+        description: String?,
+    ): Result<RoleInfoData> {
+        createRoleCalls.incrementAndGet()
+        return Result.success(
+            RoleInfoData(
+                id = "",
+                name = name,
+                description = description,
+                permissions = emptyList(),
+                createdAt = 0L,
+                isSystem = false,
+            ),
+        )
+    }
+
+    override suspend fun createPermission(
+        name: String,
+        description: String?,
+    ): Result<PermissionInfoData> {
+        createPermissionCalls.incrementAndGet()
+        return Result.success(
+            PermissionInfoData(id = "", name = name, description = description, createdAt = 0L, isSystem = false),
+        )
+    }
+
+    override suspend fun deleteRole(roleName: String): Result<Unit> {
+        deleteRoleCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+
+    override suspend fun deletePermission(permissionName: String): Result<Unit> {
+        deletePermissionCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+
+    override suspend fun assignPermissionToRole(
+        roleName: String,
+        permissionName: String,
+    ): Result<Unit> {
+        assignPermissionToRoleCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+
+    override suspend fun removePermissionFromRole(
+        roleName: String,
+        permissionName: String,
+    ): Result<Unit> {
+        removePermissionFromRoleCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+
+    override suspend fun getRolePermissions(roleName: String): Result<RoleWithPermissionsData> =
+        Result.success(RoleWithPermissionsData(roleName = roleName, permissions = emptyList()))
+
+    override fun validateRoleName(roleName: String): String? = null
+
+    override fun validatePermissionName(permissionName: String): String? = null
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/RoleManagementServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/RoleManagementServiceBridgeTest.kt
@@ -103,7 +103,9 @@ class RoleManagementServiceBridgeTest {
     @Test
     fun `getAllPermissions refuses an anonymous caller`() =
         runBlocking {
-            assertFailsWith<StatusException> { anonymousCaller().getAllPermissions(Empty.getDefaultInstance()) }
+            val failure =
+                assertFailsWith<StatusException> { anonymousCaller().getAllPermissions(Empty.getDefaultInstance()) }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.getAllPermissionsCalls.get())
         }
 
@@ -118,30 +120,42 @@ class RoleManagementServiceBridgeTest {
     @Test
     fun `createRole refuses an anonymous caller and never mints a role`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().createRole(CreateRoleRequest.newBuilder().setName("rogue-admin").build())
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().createRole(CreateRoleRequest.newBuilder().setName("rogue-admin").build())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.createRoleCalls.get())
         }
 
     @Test
     fun `createPermission refuses an anonymous caller`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().createPermission(CreatePermissionRequest.newBuilder().setName("secrets.read").build())
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().createPermission(
+                        CreatePermissionRequest.newBuilder().setName("secrets.read").build(),
+                    )
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.createPermissionCalls.get())
         }
 
     @Test
     fun `deleteRole and deletePermission refuse an anonymous caller`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().deleteRole(RoleNameRequest.newBuilder().setName("admin").build())
-            }
-            assertFailsWith<StatusException> {
-                anonymousCaller().deletePermission(PermissionNameRequest.newBuilder().setName("secrets.read").build())
-            }
+            val roleFailure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().deleteRole(RoleNameRequest.newBuilder().setName("admin").build())
+                }
+            val permissionFailure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().deletePermission(
+                        PermissionNameRequest.newBuilder().setName("secrets.read").build(),
+                    )
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, roleFailure.status.code)
+            assertEquals(Status.Code.PERMISSION_DENIED, permissionFailure.status.code)
             assertEquals(0, provider.deleteRoleCalls.get())
             assertEquals(0, provider.deletePermissionCalls.get())
         }
@@ -149,47 +163,60 @@ class RoleManagementServiceBridgeTest {
     @Test
     fun `assignPermissionToRole refuses an anonymous caller - no silent privilege grant`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().assignPermissionToRole(
-                    RolePermissionRequest
-                        .newBuilder()
-                        .setRoleName("admin")
-                        .setPermissionName("secrets.read")
-                        .build(),
-                )
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().assignPermissionToRole(
+                        RolePermissionRequest
+                            .newBuilder()
+                            .setRoleName("admin")
+                            .setPermissionName("secrets.read")
+                            .build(),
+                    )
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.assignPermissionToRoleCalls.get())
         }
 
     @Test
     fun `removePermissionFromRole refuses an anonymous caller`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().removePermissionFromRole(
-                    RolePermissionRequest
-                        .newBuilder()
-                        .setRoleName("admin")
-                        .setPermissionName("secrets.read")
-                        .build(),
-                )
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().removePermissionFromRole(
+                        RolePermissionRequest
+                            .newBuilder()
+                            .setRoleName("admin")
+                            .setPermissionName("secrets.read")
+                            .build(),
+                    )
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.removePermissionFromRoleCalls.get())
         }
 
     @Test
-    fun `getRolePermissions and name validation refuse an anonymous caller`() =
+    fun `getRolePermissions and name validation refuse an anonymous caller and never reach the provider`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().getRolePermissions(RoleNameRequest.newBuilder().setName("admin").build())
-            }
-            assertFailsWith<StatusException> {
-                anonymousCaller().validateRoleName(RoleNameRequest.newBuilder().setName("admin").build())
-            }
-            assertFailsWith<StatusException> {
-                anonymousCaller().validatePermissionName(
-                    PermissionNameRequest.newBuilder().setName("secrets.read").build(),
-                )
-            }
+            val rolePermissionsFailure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().getRolePermissions(RoleNameRequest.newBuilder().setName("admin").build())
+                }
+            val validateRoleFailure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().validateRoleName(RoleNameRequest.newBuilder().setName("admin").build())
+                }
+            val validatePermissionFailure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().validatePermissionName(
+                        PermissionNameRequest.newBuilder().setName("secrets.read").build(),
+                    )
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, rolePermissionsFailure.status.code)
+            assertEquals(Status.Code.PERMISSION_DENIED, validateRoleFailure.status.code)
+            assertEquals(Status.Code.PERMISSION_DENIED, validatePermissionFailure.status.code)
+            assertEquals(0, provider.getRolePermissionsCalls.get())
+            assertEquals(0, provider.validateRoleNameCalls.get())
+            assertEquals(0, provider.validatePermissionNameCalls.get())
         }
 
     @Test
@@ -197,6 +224,34 @@ class RoleManagementServiceBridgeTest {
         runBlocking {
             val response = authenticated.validateRoleName(RoleNameRequest.newBuilder().setName("editor").build())
             assertTrue(response.valid)
+        }
+
+    @Test
+    fun `a revoked token is refused the same as no credential at all`() =
+        runBlocking {
+            // The post-reapChildren / post-respawn case: identityFor returns null for a token
+            // the registry no longer holds, same as for an absent one - but the caller here is a
+            // live process that had a valid credential moments ago, not an anonymous one.
+            val revocableToken = tokenRegistry.issue("$DEFAULT_PROCESS.revocable")
+            val revocableChannel =
+                ManagedChannelBuilder
+                    .forAddress("localhost", server.port)
+                    .usePlaintext()
+                    .intercept(ProcessTokenClientInterceptor(revocableToken))
+                    .build()
+            extraChannels += revocableChannel
+            val revocable = RoleManagementServiceGrpcKt.RoleManagementServiceCoroutineStub(revocableChannel)
+
+            // Confirm the token actually worked before revoking it.
+            revocable.getAllRoles(Empty.getDefaultInstance())
+            assertEquals(1, provider.getAllRolesCalls.get())
+
+            tokenRegistry.revoke("$DEFAULT_PROCESS.revocable")
+
+            val failure =
+                assertFailsWith<StatusException> { revocable.getAllRoles(Empty.getDefaultInstance()) }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
+            assertEquals(1, provider.getAllRolesCalls.get(), "the revoked call must not have reached the provider")
         }
 
     companion object {
@@ -215,6 +270,9 @@ private class FakeRoleManagementProvider : RoleManagementProvider {
     val deletePermissionCalls = AtomicInteger(0)
     val assignPermissionToRoleCalls = AtomicInteger(0)
     val removePermissionFromRoleCalls = AtomicInteger(0)
+    val getRolePermissionsCalls = AtomicInteger(0)
+    val validateRoleNameCalls = AtomicInteger(0)
+    val validatePermissionNameCalls = AtomicInteger(0)
 
     override suspend fun getAllRoles(): Result<List<RoleInfoData>> {
         getAllRolesCalls.incrementAndGet()
@@ -279,10 +337,18 @@ private class FakeRoleManagementProvider : RoleManagementProvider {
         return Result.success(Unit)
     }
 
-    override suspend fun getRolePermissions(roleName: String): Result<RoleWithPermissionsData> =
-        Result.success(RoleWithPermissionsData(roleName = roleName, permissions = emptyList()))
+    override suspend fun getRolePermissions(roleName: String): Result<RoleWithPermissionsData> {
+        getRolePermissionsCalls.incrementAndGet()
+        return Result.success(RoleWithPermissionsData(roleName = roleName, permissions = emptyList()))
+    }
 
-    override fun validateRoleName(roleName: String): String? = null
+    override fun validateRoleName(roleName: String): String? {
+        validateRoleNameCalls.incrementAndGet()
+        return null
+    }
 
-    override fun validatePermissionName(permissionName: String): String? = null
+    override fun validatePermissionName(permissionName: String): String? {
+        validatePermissionNameCalls.incrementAndGet()
+        return null
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/SecretServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/SecretServiceBridgeTest.kt
@@ -10,6 +10,7 @@ import ai.rever.boss.ipc.proto.services.SecretPaginatedRequest
 import ai.rever.boss.ipc.proto.services.SecretServiceGrpcKt
 import ai.rever.boss.ipc.proto.services.ShareSecretProtoRequest
 import ai.rever.boss.ipc.proto.services.UnshareSecretProtoRequest
+import ai.rever.boss.ipc.proto.services.UpdateSecretProtoRequest
 import ai.rever.boss.plugin.api.CreateSecretRequestData
 import ai.rever.boss.plugin.api.PaginatedSecretsData
 import ai.rever.boss.plugin.api.PaginatedSecretsWithSharingData
@@ -19,10 +20,13 @@ import ai.rever.boss.plugin.api.SecretShareData
 import ai.rever.boss.plugin.api.ShareSecretRequestData
 import ai.rever.boss.plugin.api.UnshareSecretRequestData
 import ai.rever.boss.plugin.api.UpdateSecretRequestData
+import io.grpc.HandlerRegistry
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.grpc.Server
 import io.grpc.ServerBuilder
+import io.grpc.ServerMethodDefinition
+import io.grpc.ServerServiceDefinition
 import io.grpc.Status
 import io.grpc.StatusException
 import kotlinx.coroutines.runBlocking
@@ -159,6 +163,62 @@ class SecretServiceBridgeTest {
         }
 
     @Test
+    fun `updateSecret refuses an anonymous caller and never reaches the vault`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().updateSecret(
+                    UpdateSecretProtoRequest.newBuilder().setSecretId("s1").build(),
+                )
+            }
+            assertEquals(0, provider.updateSecretCalls.get())
+        }
+
+    @Test
+    fun `a bridge registered after start is still gated by the interceptor`() =
+        runBlocking {
+            // Production (KernelBootstrap.registerPluginServices) adds these bridges to an
+            // already-started BossIpcServer, i.e. into its fallback HandlerRegistry instead of
+            // the build-time registry. Pin the identity gate on that path: if interceptors ever
+            // stopped covering fallback-resolved methods, the vault would be reachable
+            // anonymously instead of refused.
+            val lateServices = SingleServiceRegistry(SecretServiceBridge(provider).bindService())
+            val lateServer =
+                ServerBuilder
+                    .forPort(0)
+                    .fallbackHandlerRegistry(lateServices)
+                    .intercept(ProcessIdentityInterceptor(tokenRegistry))
+                    .build()
+                    .start()
+
+            val lateChannel =
+                ManagedChannelBuilder.forAddress("localhost", lateServer.port).usePlaintext().build()
+            extraChannels += lateChannel
+            val lateAnonymous = SecretServiceGrpcKt.SecretServiceCoroutineStub(lateChannel)
+            val lateAuthChannel =
+                ManagedChannelBuilder
+                    .forAddress("localhost", lateServer.port)
+                    .usePlaintext()
+                    .intercept(ProcessTokenClientInterceptor(tokenRegistry.issue(DEFAULT_PROCESS)))
+                    .build()
+            extraChannels += lateAuthChannel
+            val lateAuthenticated = SecretServiceGrpcKt.SecretServiceCoroutineStub(lateAuthChannel)
+
+            val failure =
+                assertFailsWith<StatusException> {
+                    lateAnonymous.getUserSecrets(SecretPaginatedRequest.newBuilder().build())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
+            assertEquals(0, provider.getUserSecretsCalls.get())
+
+            val response = lateAuthenticated.getUserSecrets(SecretPaginatedRequest.newBuilder().build())
+            assertTrue(response.success)
+            assertEquals(1, provider.getUserSecretsCalls.get())
+
+            lateServer.shutdownNow()
+            assertTrue(lateServer.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        }
+
+    @Test
     fun `shareSecret and unshareSecret refuse an anonymous caller`() =
         runBlocking {
             assertFailsWith<StatusException> {
@@ -187,6 +247,25 @@ class SecretServiceBridgeTest {
 }
 
 /** Records every call so a refusal test can assert the vault was never actually reached. */
+
+/**
+ * A minimal stand-in for [BossIpcServer]'s late-service registry (a grpc-util
+ * MutableHandlerRegistry, which is not on the desktopTest classpath): routes every lookup to a
+ * single service, keyed by full method name exactly like MutableHandlerRegistry does. In grpc
+ * 1.84 the fallback registry is consulted as lookupMethod(fullMethodName, authority). Pins that
+ * builder-level interceptors also cover methods resolved through the fallback registry.
+ */
+private class SingleServiceRegistry(
+    private val service: ServerServiceDefinition,
+) : HandlerRegistry() {
+    override fun getServices(): List<ServerServiceDefinition> = listOf(service)
+
+    override fun lookupMethod(
+        fullMethodName: String,
+        authority: String?,
+    ): ServerMethodDefinition<*, *>? = service.getMethod(fullMethodName)
+}
+
 private class FakeSecretDataProvider : SecretDataProvider {
     val getUserSecretsCalls = AtomicInteger(0)
     val getUserSecretsWithSharingCalls = AtomicInteger(0)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/SecretServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/SecretServiceBridgeTest.kt
@@ -114,27 +114,35 @@ class SecretServiceBridgeTest {
     @Test
     fun `getUserSecretsWithSharingInfo refuses an anonymous caller`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().getUserSecretsWithSharingInfo(SecretPaginatedRequest.newBuilder().build())
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().getUserSecretsWithSharingInfo(SecretPaginatedRequest.newBuilder().build())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.getUserSecretsWithSharingCalls.get())
         }
 
     @Test
     fun `searchSecrets refuses an anonymous caller`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().searchSecrets(SearchSecretsRequest.newBuilder().setQuery("q").build())
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().searchSecrets(SearchSecretsRequest.newBuilder().setQuery("q").build())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.searchSecretsCalls.get())
         }
 
     @Test
     fun `createSecret refuses an anonymous caller and never reaches the vault`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().createSecret(CreateSecretProtoRequest.newBuilder().setWebsite("evil.example").build())
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().createSecret(
+                        CreateSecretProtoRequest.newBuilder().setWebsite("evil.example").build(),
+                    )
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.createSecretCalls.get())
         }
 
@@ -156,20 +164,24 @@ class SecretServiceBridgeTest {
     @Test
     fun `deleteSecret refuses an anonymous caller and never reaches the vault`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().deleteSecret(SecretIdRequest.newBuilder().setId("s1").build())
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().deleteSecret(SecretIdRequest.newBuilder().setId("s1").build())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.deleteSecretCalls.get())
         }
 
     @Test
     fun `updateSecret refuses an anonymous caller and never reaches the vault`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().updateSecret(
-                    UpdateSecretProtoRequest.newBuilder().setSecretId("s1").build(),
-                )
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().updateSecret(
+                        UpdateSecretProtoRequest.newBuilder().setSecretId("s1").build(),
+                    )
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.updateSecretCalls.get())
         }
 
@@ -189,44 +201,82 @@ class SecretServiceBridgeTest {
                     .intercept(ProcessIdentityInterceptor(tokenRegistry))
                     .build()
                     .start()
+            try {
+                val lateChannel =
+                    ManagedChannelBuilder.forAddress("localhost", lateServer.port).usePlaintext().build()
+                extraChannels += lateChannel
+                val lateAnonymous = SecretServiceGrpcKt.SecretServiceCoroutineStub(lateChannel)
+                // A distinct process id: `tokenRegistry.issue` replaces and invalidates whatever
+                // token DEFAULT_PROCESS already held, which would silently kill the credential
+                // `authenticated` (from setUp) is carrying for the rest of this test class.
+                val lateAuthChannel =
+                    ManagedChannelBuilder
+                        .forAddress("localhost", lateServer.port)
+                        .usePlaintext()
+                        .intercept(ProcessTokenClientInterceptor(tokenRegistry.issue("$DEFAULT_PROCESS.late")))
+                        .build()
+                extraChannels += lateAuthChannel
+                val lateAuthenticated = SecretServiceGrpcKt.SecretServiceCoroutineStub(lateAuthChannel)
 
-            val lateChannel =
-                ManagedChannelBuilder.forAddress("localhost", lateServer.port).usePlaintext().build()
-            extraChannels += lateChannel
-            val lateAnonymous = SecretServiceGrpcKt.SecretServiceCoroutineStub(lateChannel)
-            val lateAuthChannel =
+                val failure =
+                    assertFailsWith<StatusException> {
+                        lateAnonymous.getUserSecrets(SecretPaginatedRequest.newBuilder().build())
+                    }
+                assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
+                assertEquals(0, provider.getUserSecretsCalls.get())
+
+                val response = lateAuthenticated.getUserSecrets(SecretPaginatedRequest.newBuilder().build())
+                assertTrue(response.success)
+                assertEquals(1, provider.getUserSecretsCalls.get())
+            } finally {
+                lateServer.shutdownNow()
+                assertTrue(lateServer.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+            }
+        }
+
+    @Test
+    fun `a revoked token is refused the same as no credential at all`() =
+        runBlocking {
+            // The post-reapChildren / post-respawn case: identityFor returns null for a token
+            // the registry no longer holds, same as for an absent one - but the caller here is a
+            // live process that had a valid credential moments ago, not an anonymous one.
+            val revocableToken = tokenRegistry.issue("$DEFAULT_PROCESS.revocable")
+            val revocableChannel =
                 ManagedChannelBuilder
-                    .forAddress("localhost", lateServer.port)
+                    .forAddress("localhost", server.port)
                     .usePlaintext()
-                    .intercept(ProcessTokenClientInterceptor(tokenRegistry.issue(DEFAULT_PROCESS)))
+                    .intercept(ProcessTokenClientInterceptor(revocableToken))
                     .build()
-            extraChannels += lateAuthChannel
-            val lateAuthenticated = SecretServiceGrpcKt.SecretServiceCoroutineStub(lateAuthChannel)
+            extraChannels += revocableChannel
+            val revocable = SecretServiceGrpcKt.SecretServiceCoroutineStub(revocableChannel)
+
+            // Confirm the token actually worked before revoking it.
+            assertTrue(revocable.getUserSecrets(SecretPaginatedRequest.newBuilder().build()).success)
+            assertEquals(1, provider.getUserSecretsCalls.get())
+
+            tokenRegistry.revoke("$DEFAULT_PROCESS.revocable")
 
             val failure =
                 assertFailsWith<StatusException> {
-                    lateAnonymous.getUserSecrets(SecretPaginatedRequest.newBuilder().build())
+                    revocable.getUserSecrets(SecretPaginatedRequest.newBuilder().build())
                 }
             assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
-            assertEquals(0, provider.getUserSecretsCalls.get())
-
-            val response = lateAuthenticated.getUserSecrets(SecretPaginatedRequest.newBuilder().build())
-            assertTrue(response.success)
-            assertEquals(1, provider.getUserSecretsCalls.get())
-
-            lateServer.shutdownNow()
-            assertTrue(lateServer.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+            assertEquals(1, provider.getUserSecretsCalls.get(), "the revoked call must not have reached the vault")
         }
 
     @Test
     fun `shareSecret and unshareSecret refuse an anonymous caller`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().shareSecret(ShareSecretProtoRequest.newBuilder().setSecretId("s1").build())
-            }
-            assertFailsWith<StatusException> {
-                anonymousCaller().unshareSecret(UnshareSecretProtoRequest.newBuilder().setSecretId("s1").build())
-            }
+            val shareFailure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().shareSecret(ShareSecretProtoRequest.newBuilder().setSecretId("s1").build())
+                }
+            val unshareFailure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().unshareSecret(UnshareSecretProtoRequest.newBuilder().setSecretId("s1").build())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, shareFailure.status.code)
+            assertEquals(Status.Code.PERMISSION_DENIED, unshareFailure.status.code)
             assertEquals(0, provider.shareSecretCalls.get())
             assertEquals(0, provider.unshareSecretCalls.get())
         }
@@ -234,9 +284,11 @@ class SecretServiceBridgeTest {
     @Test
     fun `getSecretShares refuses an anonymous caller`() =
         runBlocking {
-            assertFailsWith<StatusException> {
-                anonymousCaller().getSecretShares(SecretIdRequest.newBuilder().setId("s1").build())
-            }
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().getSecretShares(SecretIdRequest.newBuilder().setId("s1").build())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
             assertEquals(0, provider.getSecretSharesCalls.get())
         }
 
@@ -245,8 +297,6 @@ class SecretServiceBridgeTest {
         private const val SHUTDOWN_TIMEOUT_MS = 5_000L
     }
 }
-
-/** Records every call so a refusal test can assert the vault was never actually reached. */
 
 /**
  * A minimal stand-in for [BossIpcServer]'s late-service registry (a grpc-util
@@ -266,6 +316,7 @@ private class SingleServiceRegistry(
     ): ServerMethodDefinition<*, *>? = service.getMethod(fullMethodName)
 }
 
+/** Records every call so a refusal test can assert the vault was never actually reached. */
 private class FakeSecretDataProvider : SecretDataProvider {
     val getUserSecretsCalls = AtomicInteger(0)
     val getUserSecretsWithSharingCalls = AtomicInteger(0)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/SecretServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/SecretServiceBridgeTest.kt
@@ -1,0 +1,255 @@
+package ai.rever.boss.kernel.services
+
+import ai.rever.boss.ipc.auth.ProcessIdentityInterceptor
+import ai.rever.boss.ipc.auth.ProcessTokenClientInterceptor
+import ai.rever.boss.ipc.auth.ProcessTokenRegistry
+import ai.rever.boss.ipc.proto.services.CreateSecretProtoRequest
+import ai.rever.boss.ipc.proto.services.SearchSecretsRequest
+import ai.rever.boss.ipc.proto.services.SecretIdRequest
+import ai.rever.boss.ipc.proto.services.SecretPaginatedRequest
+import ai.rever.boss.ipc.proto.services.SecretServiceGrpcKt
+import ai.rever.boss.ipc.proto.services.ShareSecretProtoRequest
+import ai.rever.boss.ipc.proto.services.UnshareSecretProtoRequest
+import ai.rever.boss.plugin.api.CreateSecretRequestData
+import ai.rever.boss.plugin.api.PaginatedSecretsData
+import ai.rever.boss.plugin.api.PaginatedSecretsWithSharingData
+import ai.rever.boss.plugin.api.SecretDataProvider
+import ai.rever.boss.plugin.api.SecretEntryData
+import ai.rever.boss.plugin.api.SecretShareData
+import ai.rever.boss.plugin.api.ShareSecretRequestData
+import ai.rever.boss.plugin.api.UnshareSecretRequestData
+import ai.rever.boss.plugin.api.UpdateSecretRequestData
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.Status
+import io.grpc.StatusException
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The out-of-process secret vault surface, exercised over a real gRPC server with a real client -
+ * the same style [PluginUIServiceBridgeTest] uses for the transport [ProcessIdentityInterceptor]
+ * secures (BossConsole#53).
+ *
+ * Every test that expects a refusal also asserts [FakeSecretDataProvider] was never called: a
+ * `PERMISSION_DENIED` that still reached the vault would defeat the point of this bridge existing.
+ */
+class SecretServiceBridgeTest {
+    private lateinit var tokenRegistry: ProcessTokenRegistry
+    private lateinit var provider: FakeSecretDataProvider
+    private lateinit var server: Server
+    private lateinit var channel: ManagedChannel
+    private lateinit var authenticated: SecretServiceGrpcKt.SecretServiceCoroutineStub
+    private val extraChannels = mutableListOf<ManagedChannel>()
+
+    @BeforeTest
+    fun setUp() {
+        tokenRegistry = ProcessTokenRegistry()
+        provider = FakeSecretDataProvider()
+        server =
+            ServerBuilder
+                .forPort(0)
+                .intercept(ProcessIdentityInterceptor(tokenRegistry))
+                .addService(SecretServiceBridge(provider))
+                .build()
+                .start()
+        channel =
+            ManagedChannelBuilder
+                .forAddress("localhost", server.port)
+                .usePlaintext()
+                .intercept(ProcessTokenClientInterceptor(tokenRegistry.issue(DEFAULT_PROCESS)))
+                .build()
+        authenticated = SecretServiceGrpcKt.SecretServiceCoroutineStub(channel)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        channel.shutdownNow()
+        channel.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        extraChannels.forEach { it.shutdownNow() }
+        extraChannels.forEach { it.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
+        server.shutdownNow()
+        server.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    }
+
+    /** An unauthenticated stub against this test's server - no credential attached at all. */
+    private fun anonymousCaller(): SecretServiceGrpcKt.SecretServiceCoroutineStub {
+        val unauthenticatedChannel = ManagedChannelBuilder.forAddress("localhost", server.port).usePlaintext().build()
+        extraChannels += unauthenticatedChannel
+        return SecretServiceGrpcKt.SecretServiceCoroutineStub(unauthenticatedChannel)
+    }
+
+    @Test
+    fun `an authenticated caller can list secrets`() =
+        runBlocking {
+            val response = authenticated.getUserSecrets(SecretPaginatedRequest.newBuilder().setLimit(10).build())
+            assertTrue(response.success)
+            assertEquals(1, provider.getUserSecretsCalls.get())
+        }
+
+    @Test
+    fun `an anonymous caller is refused and never reaches the provider`() =
+        runBlocking {
+            val failure =
+                assertFailsWith<StatusException> {
+                    anonymousCaller().getUserSecrets(SecretPaginatedRequest.newBuilder().build())
+                }
+            assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
+            assertEquals(0, provider.getUserSecretsCalls.get())
+        }
+
+    @Test
+    fun `getUserSecretsWithSharingInfo refuses an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().getUserSecretsWithSharingInfo(SecretPaginatedRequest.newBuilder().build())
+            }
+            assertEquals(0, provider.getUserSecretsWithSharingCalls.get())
+        }
+
+    @Test
+    fun `searchSecrets refuses an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().searchSecrets(SearchSecretsRequest.newBuilder().setQuery("q").build())
+            }
+            assertEquals(0, provider.searchSecretsCalls.get())
+        }
+
+    @Test
+    fun `createSecret refuses an anonymous caller and never reaches the vault`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().createSecret(CreateSecretProtoRequest.newBuilder().setWebsite("evil.example").build())
+            }
+            assertEquals(0, provider.createSecretCalls.get())
+        }
+
+    @Test
+    fun `createSecret succeeds for an authenticated caller`() =
+        runBlocking {
+            val result =
+                authenticated.createSecret(
+                    CreateSecretProtoRequest
+                        .newBuilder()
+                        .setWebsite("example.com")
+                        .setUsername("me")
+                        .build(),
+                )
+            assertTrue(result.success)
+            assertEquals(1, provider.createSecretCalls.get())
+        }
+
+    @Test
+    fun `deleteSecret refuses an anonymous caller and never reaches the vault`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().deleteSecret(SecretIdRequest.newBuilder().setId("s1").build())
+            }
+            assertEquals(0, provider.deleteSecretCalls.get())
+        }
+
+    @Test
+    fun `shareSecret and unshareSecret refuse an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().shareSecret(ShareSecretProtoRequest.newBuilder().setSecretId("s1").build())
+            }
+            assertFailsWith<StatusException> {
+                anonymousCaller().unshareSecret(UnshareSecretProtoRequest.newBuilder().setSecretId("s1").build())
+            }
+            assertEquals(0, provider.shareSecretCalls.get())
+            assertEquals(0, provider.unshareSecretCalls.get())
+        }
+
+    @Test
+    fun `getSecretShares refuses an anonymous caller`() =
+        runBlocking {
+            assertFailsWith<StatusException> {
+                anonymousCaller().getSecretShares(SecretIdRequest.newBuilder().setId("s1").build())
+            }
+            assertEquals(0, provider.getSecretSharesCalls.get())
+        }
+
+    companion object {
+        private const val DEFAULT_PROCESS = "ai.rever.boss.plugin.dynamic.test-plugin"
+        private const val SHUTDOWN_TIMEOUT_MS = 5_000L
+    }
+}
+
+/** Records every call so a refusal test can assert the vault was never actually reached. */
+private class FakeSecretDataProvider : SecretDataProvider {
+    val getUserSecretsCalls = AtomicInteger(0)
+    val getUserSecretsWithSharingCalls = AtomicInteger(0)
+    val searchSecretsCalls = AtomicInteger(0)
+    val createSecretCalls = AtomicInteger(0)
+    val updateSecretCalls = AtomicInteger(0)
+    val deleteSecretCalls = AtomicInteger(0)
+    val getSecretSharesCalls = AtomicInteger(0)
+    val shareSecretCalls = AtomicInteger(0)
+    val unshareSecretCalls = AtomicInteger(0)
+
+    override suspend fun getUserSecrets(
+        limit: Int,
+        offset: Int,
+    ): Result<PaginatedSecretsData> {
+        getUserSecretsCalls.incrementAndGet()
+        return Result.success(PaginatedSecretsData(data = emptyList(), hasMore = false))
+    }
+
+    override suspend fun getUserSecretsWithSharingInfo(
+        limit: Int,
+        offset: Int,
+    ): Result<PaginatedSecretsWithSharingData> {
+        getUserSecretsWithSharingCalls.incrementAndGet()
+        return Result.success(PaginatedSecretsWithSharingData(data = emptyList(), hasMore = false))
+    }
+
+    override suspend fun searchSecrets(
+        query: String,
+        limit: Int,
+        offset: Int,
+    ): Result<PaginatedSecretsData> {
+        searchSecretsCalls.incrementAndGet()
+        return Result.success(PaginatedSecretsData(data = emptyList(), hasMore = false))
+    }
+
+    override suspend fun createSecret(request: CreateSecretRequestData): Result<Unit> {
+        createSecretCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+
+    override suspend fun updateSecret(request: UpdateSecretRequestData): Result<Unit> {
+        updateSecretCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+
+    override suspend fun deleteSecret(id: String): Result<Unit> {
+        deleteSecretCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+
+    override suspend fun getSecretShares(secretId: String): Result<List<SecretShareData>> {
+        getSecretSharesCalls.incrementAndGet()
+        return Result.success(emptyList())
+    }
+
+    override suspend fun shareSecret(request: ShareSecretRequestData): Result<Unit> {
+        shareSecretCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+
+    override suspend fun unshareSecret(request: UnshareSecretRequestData): Result<Unit> {
+        unshareSecretCalls.incrementAndGet()
+        return Result.success(Unit)
+    }
+}

--- a/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/BossIpcServer.kt
+++ b/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/BossIpcServer.kt
@@ -31,9 +31,15 @@ class BossIpcServer(
     /**
      * When present, every call is run through a [ProcessIdentityInterceptor] backed by this registry,
      * so a service on this server can read a verified caller identity from the gRPC [io.grpc.Context]
-     * instead of trusting a request field (BossConsole#53). Null (the default) installs no interceptor
-     * and leaves every service's behaviour exactly as it was — most `BossIpcServer` instances (every
-     * child process's own `processServer`, every test server) have no use for one.
+     * instead of trusting a request field (BossConsole#53). Null (the default) installs no interceptor,
+     * which is a no-op for a service that never checks identity - most `BossIpcServer` instances (every
+     * child process's own `processServer`, every test server) have no use for one. It stops being a
+     * no-op for a server hosting a service that fails closed on a missing identity (currently
+     * [ai.rever.boss.kernel.services.SecretServiceBridge] and
+     * [ai.rever.boss.kernel.services.RoleManagementServiceBridge]): with no registry, every call to
+     * that service is refused, not merely unauthenticated as before - a silent total outage rather
+     * than the pre-BossConsole#53 status quo. Any kernel server hosting one of those bridges must
+     * be constructed with a real registry.
      */
     private val tokenRegistry: ProcessTokenRegistry? = null,
 ) {

--- a/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/auth/ProcessIdentityInterceptor.kt
+++ b/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/auth/ProcessIdentityInterceptor.kt
@@ -14,12 +14,14 @@ import io.grpc.ServerInterceptor
  * Reads the [PROCESS_TOKEN_METADATA_KEY] header, resolves it through [registry], and — when it names
  * a real, currently-issued credential — publishes the owning process id under [AUTHENTICATED_PROCESS_ID]
  * for the rest of the call to read via [Context]. A missing or unrecognised token leaves that key unset
- * rather than failing the call outright: most of the kernel's IPC surface (fourteen other service
+ * rather than failing the call outright: most of the kernel's IPC surface (twelve other service
  * bridges as of writing, none of them authenticated today) does not check identity at all, and
  * rejecting here would be authentication for services that never asked for it — the same reason a
  * missing/invalid token must not weaken or change behaviour for those. Whether the *absence* of an
- * identity is acceptable is each service's own call; [ai.rever.boss.kernel.services.PluginUIServiceBridge]
- * is the one that currently makes it.
+ * identity is acceptable is each service's own call; [ai.rever.boss.kernel.services.PluginUIServiceBridge],
+ * [ai.rever.boss.kernel.services.SecretServiceBridge] and
+ * [ai.rever.boss.kernel.services.RoleManagementServiceBridge] are the three that currently make it -
+ * BossConsole#53's own follow-up tracks closing the rest.
  */
 class ProcessIdentityInterceptor(
     private val registry: ProcessTokenRegistry,

--- a/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/auth/ProcessIdentityInterceptor.kt
+++ b/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/auth/ProcessIdentityInterceptor.kt
@@ -14,7 +14,7 @@ import io.grpc.ServerInterceptor
  * Reads the [PROCESS_TOKEN_METADATA_KEY] header, resolves it through [registry], and — when it names
  * a real, currently-issued credential — publishes the owning process id under [AUTHENTICATED_PROCESS_ID]
  * for the rest of the call to read via [Context]. A missing or unrecognised token leaves that key unset
- * rather than failing the call outright: most of the kernel's IPC surface (twelve other service
+ * rather than failing the call outright: most of the kernel's IPC surface (thirteen other service
  * bridges as of writing, none of them authenticated today) does not check identity at all, and
  * rejecting here would be authentication for services that never asked for it — the same reason a
  * missing/invalid token must not weaken or change behaviour for those. Whether the *absence* of an


### PR DESCRIPTION
## Summary

BossConsole#53 built a full caller-identity verification system for the kernel's out-of-process IPC transport  -  `ProcessIdentityInterceptor` (a `ServerInterceptor`) plus `ProcessTokenRegistry` (mints a per-process credential at spawn, never trusts a request body). It's wired into `BossIpcServer` in production and `PluginUIServiceBridge` uses it correctly, with real per-surface ownership checks in `RemoteUiSurfaceRegistry`.

But `ProcessIdentityInterceptor`'s own KDoc says it plainly: *"fourteen other service bridges as of writing, none of them authenticated today."* The interceptor establishes identity on every call; it's each service's own choice whether to check it, and only one of fifteen bridges makes that choice.

This PR closes that gap for the two bridges where it matters most:

- **`SecretServiceBridge`**  -  the entire out-of-process password vault surface: list, search, create, update, delete, share, unshare.
- **`RoleManagementServiceBridge`**  -  RBAC: list/create/delete roles and permissions, grant/revoke a permission on a role.

Before this, any out-of-process plugin that could reach the kernel's local IPC socket had unrestricted, unattributed access to both. Not a network-remote threat (the socket is user-scoped), but a real gap against a rogue or compromised plugin process  -  exactly the class of concern #53 raised, on a more sensitive surface than the UI transport it originally fixed.

## What changed

Both bridges now call an `authenticatedCallerOrRefuse(rpc)` helper (mirroring `PluginUIServiceBridge`'s own) at the top of every RPC method  -  **reads included, not only mutations**, since an unattributed read of the secret list is exactly the exposure this closes. A call with no verified `AUTHENTICATED_PROCESS_ID` in its gRPC `Context` is refused with `PERMISSION_DENIED` before it ever reaches the underlying `SecretDataProvider` / `RoleManagementProvider`. Every mutating call additionally logs the verified caller identity (`LogCategory.AUTH`), so a compromised plugin's vault/RBAC activity is attributable after the fact rather than just blocked.

**No behavior change for any real plugin.** Every process spawned through `ai.rever.boss.process.ProcessSpawner` (the only spawn path in production) already receives a `BOSS_PROCESS_TOKEN` env var, and `ChildProcessBootstrap` already attaches `ProcessTokenClientInterceptor` to its kernel channel whenever that token is present. The only callers with no credential are processes started outside that path  -  tests, and exactly the kind of caller this closes the door on.

## Test plan

New `SecretServiceBridgeTest` (9 tests) and `RoleManagementServiceBridgeTest` (10 tests), both exercised over a **real gRPC server and real client**  -  same harness `PluginUIServiceBridgeTest` already established (`ProcessIdentityInterceptor` + `ProcessTokenRegistry` on a real `ServerBuilder`, `ProcessTokenClientInterceptor` on a real `ManagedChannel`, an `anonymousCaller()` with no credential at all).

Every refusal test asserts two things: the RPC fails with `PERMISSION_DENIED`, **and** the underlying provider's call counter stayed at zero  -  the assertion that actually matters, since a refusal that still reached the vault would defeat the point.

- `./gradlew :composeApp:compileKotlinDesktop :composeApp:compileTestKotlinDesktop`  -  clean
- `./gradlew :composeApp:desktopTest --tests "ai.rever.boss.kernel.services.*"`  -  all green, including the pre-existing `PluginUIServiceBridgeTest` suite (no regression)
- `./gradlew :boss-ipc:test`  -  clean
- `./gradlew ktlintCheck detekt`  -  clean

## Deliberately out of scope

The other twelve unauthenticated bridges (`ActiveTabsServiceBridge`, `ContextMenuServiceBridge`, `DirectoryPickerServiceBridge`, `DownloadServiceBridge`, `GitServiceBridge`, `LogServiceBridge`, `NotificationServiceBridge`, `PanelEventServiceBridge`, `PerformanceServiceBridge`, `ProjectDataServiceBridge`, `RunConfigServiceBridge`, `SplitViewServiceBridge`, `SupabaseServiceBridge`) are untouched. Their worst case is stale/crossed UI or workspace state rather than credential/permission exposure, and extending the pattern to all of them is a much larger, more mechanical follow-up better done as its own PR (or several) rather than bundled here.


### Duplicate submission provenance

This PR is the surviving implementation for #598, also authored by Antriksh (@Antriksh1984). Both submissions gate the same nine Secret Service RPCs before provider access using the same verified identity and PERMISSION_DENIED result. #505 additionally retains attributed mutation logging, RBAC protection, individual refusal tests, token-revocation coverage and late-service registration coverage. #598 was reviewed against #505 at `7bf4f6e0db504495cfebf6e76ba552933d2cce0c`; it supplies no additional production behavior. Its positive workflow test exercises existing provider mapping rather than a distinct fix. Contributor credit belongs to Antriksh for both original submissions; prior reviewer repairs remain separately attributed above. No code from another contributor is being dropped.


Final source-level runtime check: at runtime main `7ac0607ee7884b04a4b225bbdc3cf732c83cb30f`, PluginProcessMain passes connection.kernelClient.channel into RemotePluginContext, whose SecretDataProviderProxy and RoleManagementProviderProxy reuse it. This resolves the review's channel-wiring question without claiming packaged-runtime validation. Head `7bf4f6e0d` remains unchanged with all nine CI checks green and prior focused tests/quality checks passing. User authorized a serialized squash merge into dev only.
