### PR TITLE
test(config): isolate Chromium flags test from local environment variables

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -163,6 +163,16 @@ object ChromiumFlagsSettingsManager {
             field = value
             lastPersisted = null
         }
+
+    // `internal var` purely so tests can stub the environment - a JVM cannot set its own
+    // environment variables, and one exported BOSS_* variable would otherwise leak into every
+    // test that reads envOverride. Production never reassigns this; the default System::getenv
+    // is what runs in the field.
+    //
+    // Declared before `bootSettings = loadSync()` on purpose: object initialisers run in
+    // declaration order, so any initialiser below that reached envOverride would have read a
+    // not-yet-assigned envReader and died at object init before a logger could say why.
+    internal var envReader: (String) -> String? = System::getenv
     private val json =
         Json {
             prettyPrint = true
@@ -252,12 +262,11 @@ object ChromiumFlagsSettingsManager {
      * The environment's value for [key], or null. Used by the Settings UI to say a row
      * is overridden instead of letting it look broken. Reads the environment ONLY: a
      * system property here would report this object's own publication back to it.
+     *
+     * Blank reads as UNSET. `FOO= boss` exports an empty string, which is non-null, so a bare
+     * getenv let an empty variable claim ownership of a key and silently suppress the user's
+     * setting - reported in the UI as an override with no value to show.
      */
-    // Blank reads as UNSET. `FOO= boss` exports an empty string, which is non-null, so a bare
-    // getenv let an empty variable claim ownership of a key and silently suppress the user's
-    // setting - reported in the UI as an override with no value to show.
-    internal var envReader: (String) -> String? = System::getenv
-
     fun envOverride(key: String): String? = envReader(key)?.takeIf { it.isNotBlank() }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -256,7 +256,9 @@ object ChromiumFlagsSettingsManager {
     // Blank reads as UNSET. `FOO= boss` exports an empty string, which is non-null, so a bare
     // getenv let an empty variable claim ownership of a key and silently suppress the user's
     // setting - reported in the UI as an override with no value to show.
-    fun envOverride(key: String): String? = System.getenv(key)?.takeIf { it.isNotBlank() }
+    internal var envReader: (String) -> String? = System::getenv
+
+    fun envOverride(key: String): String? = envReader(key)?.takeIf { it.isNotBlank() }
 
     /**
      * What [key] would resolve to on the next launch given [settings] — **env first,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -170,8 +170,9 @@ object ChromiumFlagsSettingsManager {
     // is what runs in the field.
     //
     // Declared before `bootSettings = loadSync()` on purpose: object initialisers run in
-    // declaration order, so any initialiser below that reached envOverride would have read a
-    // not-yet-assigned envReader and died at object init before a logger could say why.
+    // declaration order, so an initialiser above this line that reached envOverride would
+    // read a not-yet-assigned envReader and die at object init before a logger could say why.
+    // In the old layout this var sat below bootSettings, so the very first load ran first.
     internal var envReader: (String) -> String? = System::getenv
     private val json =
         Json {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
@@ -362,26 +362,42 @@ class ChromiumFlagsSettingsTest {
 
     @Test
     fun `previewValue puts the environment ahead of the setting`() {
-        // The precedence the whole screen rests on, and the rule the command-line preview has to
-        // reproduce or it reports a next launch that will not happen.
-        val settings = ChromiumFlagsSettings(renderingMode = "OFF_SCREEN")
-        // No env var is set for this key in a test JVM, so the setting shows through.
-        assertEquals(
-            "OFF_SCREEN",
-            ChromiumFlagsSettingsManager.previewValue(settings, ChromiumFlagKeys.RENDERING_MODE),
-        )
-        // A key with no setting and no env resolves to nothing rather than to a guess.
-        assertNull(ChromiumFlagsSettingsManager.previewValue(ChromiumFlagsSettings(), ChromiumFlagKeys.RENDERING_MODE))
-        // And it never consults system properties, which hold THIS process's published boot
-        // values — reading them would make the preview echo the running session back at the user
-        // instead of showing what they just chose.
-        System.setProperty(ChromiumFlagKeys.SKIKO_RENDER_API, "METAL")
+        val originalReader = ChromiumFlagsSettingsManager.envReader
         try {
-            assertNull(
-                ChromiumFlagsSettingsManager.previewValue(ChromiumFlagsSettings(), ChromiumFlagKeys.SKIKO_RENDER_API),
+            // Isolate from local environment pollution (e.g. BOSS_RENDERING_MODE="OFF_SCREEN")
+            ChromiumFlagsSettingsManager.envReader = { null }
+
+            // The precedence the whole screen rests on, and the rule the command-line preview has to
+            // reproduce or it reports a next launch that will not happen.
+            val settings = ChromiumFlagsSettings(renderingMode = "OFF_SCREEN")
+            // No env var is set for this key in a test JVM, so the setting shows through.
+            assertEquals(
+                "OFF_SCREEN",
+                ChromiumFlagsSettingsManager.previewValue(settings, ChromiumFlagKeys.RENDERING_MODE),
             )
+            // A key with no setting and no env resolves to nothing rather than to a guess.
+            assertNull(
+                ChromiumFlagsSettingsManager.previewValue(
+                    ChromiumFlagsSettings(),
+                    ChromiumFlagKeys.RENDERING_MODE,
+                ),
+            )
+            // And it never consults system properties, which hold THIS process's published boot
+            // values — reading them would make the preview echo the running session back at the user
+            // instead of showing what they just chose.
+            System.setProperty(ChromiumFlagKeys.SKIKO_RENDER_API, "METAL")
+            try {
+                assertNull(
+                    ChromiumFlagsSettingsManager.previewValue(
+                        ChromiumFlagsSettings(),
+                        ChromiumFlagKeys.SKIKO_RENDER_API,
+                    ),
+                )
+            } finally {
+                System.clearProperty(ChromiumFlagKeys.SKIKO_RENDER_API)
+            }
         } finally {
-            System.clearProperty(ChromiumFlagKeys.SKIKO_RENDER_API)
+            ChromiumFlagsSettingsManager.envReader = originalReader
         }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
@@ -296,9 +296,10 @@ class ChromiumFlagsSettingsTest {
 
     @Test
     fun `envOverride reads the environment only, never system properties`() {
-        // Renamed to what it actually pins. It cannot test blank - a JVM cannot set its own
-        // environment variables - and the previous name promised coverage that now genuinely
-        // lives in ConfigLoaderTest, where the pure resolver takes envValue as a parameter.
+        // Renamed to what it actually pins. The blank rule is no longer untestable - the
+        // envReader seam makes it so, and the previewValue test below pins it - and the
+        // environment-outranks-everything ordering lives in ConfigLoaderTest, where the pure
+        // resolver takes envValue as a parameter.
         // What IS worth pinning here: envOverride must not fall back to a system property, since
         // those hold this process's own published boot settings and reading them would make the
         // UI report the app's own setting as an environment override.
@@ -364,18 +365,40 @@ class ChromiumFlagsSettingsTest {
     fun `previewValue puts the environment ahead of the setting`() {
         val originalReader = ChromiumFlagsSettingsManager.envReader
         try {
-            // Isolate from local environment pollution (e.g. BOSS_RENDERING_MODE="OFF_SCREEN")
+            // The stubbed reader answers null, so the setting shows through instead of whatever
+            // BOSS_* variables happen to be exported on the machine running the test.
             ChromiumFlagsSettingsManager.envReader = { null }
 
             // The precedence the whole screen rests on, and the rule the command-line preview has to
             // reproduce or it reports a next launch that will not happen.
             val settings = ChromiumFlagsSettings(renderingMode = "OFF_SCREEN")
-            // No env var is set for this key in a test JVM, so the setting shows through.
             assertEquals(
                 "OFF_SCREEN",
                 ChromiumFlagsSettingsManager.previewValue(settings, ChromiumFlagKeys.RENDERING_MODE),
             )
+            // The case the name promises: with an exported variable the environment outranks the
+            // setting, exactly as the next launch resolves it. Without the seam a JVM could not
+            // test this half at all.
+            ChromiumFlagsSettingsManager.envReader = { "HARDWARE_ACCELERATED" }
+            assertEquals(
+                "HARDWARE_ACCELERATED",
+                ChromiumFlagsSettingsManager.previewValue(settings, ChromiumFlagKeys.RENDERING_MODE),
+                "an exported variable must outrank the setting, as the next launch will",
+            )
+            // Blank reads as UNSET (envOverride's isNotBlank guard): a `FOO=`-style export must
+            // not claim the key, so the setting shows through again.
+            ChromiumFlagsSettingsManager.envReader = { "   " }
+            assertEquals(
+                "OFF_SCREEN",
+                ChromiumFlagsSettingsManager.previewValue(settings, ChromiumFlagKeys.RENDERING_MODE),
+                "a blank variable must not suppress the setting",
+            )
+            assertNull(
+                ChromiumFlagsSettingsManager.envOverride(ChromiumFlagKeys.RENDERING_MODE),
+                "a blank value must read as unset, not as an empty override",
+            )
             // A key with no setting and no env resolves to nothing rather than to a guess.
+            ChromiumFlagsSettingsManager.envReader = { null }
             assertNull(
                 ChromiumFlagsSettingsManager.previewValue(
                     ChromiumFlagsSettings(),

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
@@ -304,13 +304,18 @@ class ChromiumFlagsSettingsTest {
         // those hold this process's own published boot settings and reading them would make the
         // UI report the app's own setting as an environment override.
         System.setProperty("BOSS_TEST_UNUSED_KEY", "ignored")
+        val originalReader = ChromiumFlagsSettingsManager.envReader
         try {
+            // Hermetic: the assertion must hold even on a machine that exports the exact key
+            // name, for the same reason this PR exists - by construction, not by convention.
+            ChromiumFlagsSettingsManager.envReader = { null }
             assertNull(
                 ChromiumFlagsSettingsManager.envOverride("BOSS_TEST_UNUSED_KEY"),
                 "a system property must not be reported as an environment override",
             )
         } finally {
             System.clearProperty("BOSS_TEST_UNUSED_KEY")
+            ChromiumFlagsSettingsManager.envReader = originalReader
         }
     }
 


### PR DESCRIPTION
This PR fixes a flaky test (`ChromiumFlagsSettingsTest`) that was failing due to local environment variable pollution. I injected an `envReader` to mock the environment during the test run to isolate it from the host machine.

---
**Review sweep 2026-09-11 (config-matching):** retargeted to `dev` and rebased (`c6bce0ded` -> `cfa913eae`) because `main` advanced past `dev` with conflicting changes after this branch was cut. Original authorship preserved.


**Review sweep follow-up (config-matching, after Claude review):** commit `6bcd83c73` addresses the Claude review of `cfa913eae`. The `envReader` seam is now declared beside the `settingsFile` seam (the KDoc reattaches to `envOverride`, and the seam is initialised before `bootSettings = loadSync()`, closing the object-init ordering trap), and the `previewValue` test now pins the two halves the seam unlocks but could not previously test: an exported variable outranking the setting, and the blank-reads-as-UNSET guard. Two comments that the seam made stale were reworded. Test-only plus the seam relocation; no behaviour change.

**Second Claude review (head `6bcd83c73`):** "Confirmed: all three items from the `cfa913e` review are addressed, and nothing blocking remains" (5632804261). Both optional items implemented in commit `85a025c85`: the init-order comment read inverted (an initialiser *above* the seam is the hazard - which is exactly what the old layout had - and the comment now says so), and `envOverride reads the environment only, never system properties` now stubs the reader to null for its own assertions, so it is hermetic by construction rather than by the `BOSS_TEST_UNUSED_KEY` naming convention. Current head `85a025c85`; local `ChromiumFlagsSettingsTest` 15/15.


Merge review: Original environment-isolation seam and flaky-test diagnosis by @pundhiranshul; prior review-agent initialization and regression-test repairs are recorded separately above.
