### PR TITLE
fix: keep focus mode rail actions stable

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -281,8 +281,10 @@ internal fun BossAppScaffold(
     // clearing is not on screen however the preference reads. See asDrawn.
     val drawn = appearance.asDrawn(focusModeSettings)
 
-    // Whether the hover-revealed bar is up, reported by SplitViewPanel. It decides where the
-    // host's actions render while the bar is collapsed - see the placement below.
+    // Whether the hover-revealed bar is up, reported by SplitViewPanel. The placement decision
+    // deliberately ignores it (the rail keeps its actions while the drawer is open - see
+    // verticalBarHost), but the value and its reporting chain are kept as a documented hedge
+    // for a future decision that does need the drawer's state.
     var drawerVisible by remember { mutableStateOf(false) }
 
     // Whether the bar in the layout is the RAIL, reported by SplitViewPanel once it has measured.
@@ -316,8 +318,10 @@ internal fun BossAppScaffold(
         )
 
     // Whether the collapsed tab-bar rail has enough height for its quick actions.
-    // Keep the measured answer while a hover drawer temporarily owns the actions. The rail
-    // stays composed behind that drawer and will not report again unless its fit changes.
+    // Keep the measured answer while the drawer is open: the rail stays composed behind that
+    // drawer and will not report again unless its fit changes. Consequence of the rail no
+    // longer handing its actions to the drawer: with the fit false and the bar collapsed, the
+    // actions now fall through to PANEL_FOOTER/FLOATING instead of the drawer's roomy foot.
     var railActionsFit by remember { mutableStateOf(true) }
 
     // Gated, so the measurement costs nothing in the configuration that will never use it. With

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
@@ -338,6 +338,13 @@ internal enum class VerticalBarHost {
  *
  * Pure and named because it is the one input to [focusQuickActionsPlacement] that is not a
  * standing preference, and because the scaffold that reads it is at detekt's complexity ceiling.
+ *
+ * [drawerVisible] is deliberately NOT an input: the rail keeps its actions while the drawer is
+ * open, so the answer must not move with the drawer. The parameter is kept as a documented
+ * hedge for a future decision that does need the drawer's state, rather than deleted and
+ * re-plumbed later - and it is stated here because the reporting chain behind it (Scaffold
+ * state, SplitView's LaunchedEffect) is still live, and recomposes the scaffold on every
+ * drawer open/close.
  */
 internal fun verticalBarHost(
     tabBarOnLeft: Boolean,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
@@ -332,10 +332,9 @@ internal enum class VerticalBarHost {
  * What the vertical tab bar can host right now.
  *
  * Three states, not two, and an enum rather than a pair of booleans because two of the three are
- * the same bar: an EXPANDED left bar has a foot under its split map, a COLLAPSED one is a rail
- * whose bottom is the only room it has, and a collapsed bar whose hover drawer is OPEN has a foot
- * again for as long as the drawer is up, because the drawer is a full bar. Carried as two flags
- * these would admit "a foot AND a rail", which is not a window that exists.
+ * the same bar: an EXPANDED left bar has a foot under its split map, while a COLLAPSED one keeps
+ * its host actions in the rail even when its hover drawer is open. The drawer sits beside that
+ * rail, so moving actions into its foot would relocate targets already under the pointer.
  *
  * Pure and named because it is the one input to [focusQuickActionsPlacement] that is not a
  * standing preference, and because the scaffold that reads it is at detekt's complexity ceiling.
@@ -343,10 +342,10 @@ internal enum class VerticalBarHost {
 internal fun verticalBarHost(
     tabBarOnLeft: Boolean,
     barCollapsed: Boolean,
-    drawerVisible: Boolean,
+    @Suppress("UnusedParameter") drawerVisible: Boolean,
 ): VerticalBarHost =
     when {
         !tabBarOnLeft -> VerticalBarHost.NONE
-        !barCollapsed || drawerVisible -> VerticalBarHost.FOOT
+        !barCollapsed -> VerticalBarHost.FOOT
         else -> VerticalBarHost.RAIL
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/VerticalTabBarDrawer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/VerticalTabBarDrawer.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
 
 /**
- * The full vertical tab bar shown as a temporary drawer over a panel whose bar is down to its
+ * The full vertical tab bar shown as a temporary drawer beside a panel whose bar is down to its
  * rail.
  *
  * **Why this is not just a Box with an offset.** Under HARDWARE_ACCELERATED JxBrowser - the
@@ -55,6 +56,7 @@ fun BoxScope.VerticalTabBarDrawer(
     hoverSource: MutableInteractionSource,
     hoverEnabled: Boolean,
     width: Dp,
+    railWidth: Dp,
     panelRegion: IntRect?,
     onDismissOutside: (() -> Unit)?,
     content: @Composable () -> Unit,
@@ -72,13 +74,14 @@ fun BoxScope.VerticalTabBarDrawer(
 
     val region = panelRegion ?: return
     val heavyweight = overlayCornerIsHeavyweight()
+    val drawerRegion = region.besideLeadingRail(railWidth)
 
     if (heavyweight) {
         OverlayCorner(
             alignment = Alignment.TopStart,
             // First-frame size only; later measurements use the parent region.
-            initialSize = DpSize(width, region.height.dp),
-            regionInWindow = region,
+            initialSize = DpSize(width, drawerRegion.height.dp),
+            regionInWindow = drawerRegion,
         ) {
             Box(modifier = Modifier.hoverable(hoverSource, enabled = hoverEnabled)) { content() }
         }
@@ -89,13 +92,23 @@ fun BoxScope.VerticalTabBarDrawer(
         // animating a native window's bounds per frame is a different and much worse trade.
         AnimatedVisibility(
             visible = true,
-            modifier = Modifier.align(Alignment.CenterStart).fillMaxHeight(),
+            modifier =
+                Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = railWidth)
+                    .fillMaxHeight(),
             enter = slideInHorizontally(initialOffsetX = { -it }),
             exit = slideOutHorizontally(targetOffsetX = { -it }),
         ) {
             Box(modifier = Modifier.hoverable(hoverSource, enabled = hoverEnabled)) { content() }
         }
     }
+}
+
+/** The drawer's usable overlay region after preserving the in-flow collapsed rail. */
+internal fun IntRect.besideLeadingRail(railWidth: Dp): IntRect {
+    val railEnd = (left + railWidth.value.roundToInt()).coerceAtMost(right)
+    return copy(left = railEnd)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/VerticalTabBarDrawer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/VerticalTabBarDrawer.kt
@@ -46,9 +46,11 @@ import kotlin.math.roundToInt
  *   reveal decision needs it alongside the rail's.
  * @param panelRegion this panel's rectangle in dp relative to the window's content pane. Null
  *   means not yet measured, and nothing is drawn - see [overlayRegionInWindow].
- * @param onDismissOutside installs a click-catcher over the rest of the panel that invokes this.
- *   Non-null only for a drawer opened by the chevron; a hover-revealed one must NOT swallow the
- *   click that focuses the content behind it, since the pointer leaving is what closes it.
+ * @param onDismissOutside installs a click-catcher over the part of the panel the drawer does not
+ *   cover - the retained rail is excluded, because pressing the sidebar is not an outside click -
+ *   that invokes this. Non-null only for a drawer opened by the chevron; a hover-revealed one
+ *   must NOT swallow the click that focuses the content behind it, since the pointer leaving is
+ *   what closes it.
  */
 @Composable
 fun BoxScope.VerticalTabBarDrawer(
@@ -62,11 +64,19 @@ fun BoxScope.VerticalTabBarDrawer(
     content: @Composable () -> Unit,
 ) {
     if (onDismissOutside != null && visible) {
+        // The retained rail stays interactive under the drawer: SplitView composes it before
+        // this catcher, so an unpadded fillMaxSize sits on top of it - pressing a retained
+        // quick action would dismiss the drawer instead of firing, and the rail would get no
+        // hover at all, so its labels never appear. The rail is part of the sidebar, and
+        // pressing the sidebar is not an "outside" click.
         Box(
             modifier =
-                Modifier.fillMaxSize().pointerInput(Unit) {
-                    detectTapGestures(onPress = { onDismissOutside() })
-                },
+                Modifier
+                    .fillMaxSize()
+                    .padding(start = railWidth)
+                    .pointerInput(Unit) {
+                        detectTapGestures(onPress = { onDismissOutside() })
+                    },
         )
     }
 
@@ -105,7 +115,18 @@ fun BoxScope.VerticalTabBarDrawer(
     }
 }
 
-/** The drawer's usable overlay region after preserving the in-flow collapsed rail. */
+/**
+ * The drawer's usable overlay region after preserving the in-flow collapsed rail.
+ *
+ * In dp, like its receiver: [overlayRegionInWindow] has already divided the pixel bounds by
+ * density, so [railWidth] is added dp-plus-dp and HiDPI is handled by that invariant rather
+ * than by any arithmetic here. Do not reintroduce a density multiply.
+ *
+ * A panel narrower than the rail coerces to a zero-width region; `resolveRegion` then answers
+ * with its documented inset fallback (the drawer lands at the content pane corner rather than
+ * beside the rail). That "wrong but visible" choice is inherited, not handled here, and only
+ * bites for a panel narrower than the rail itself.
+ */
 internal fun IntRect.besideLeadingRail(railWidth: Dp): IntRect {
     val railEnd = (left + railWidth.value.roundToInt()).coerceAtMost(right)
     return copy(left = railEnd)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/WindowVerticalTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/WindowVerticalTabBar.kt
@@ -212,16 +212,9 @@ fun WindowVerticalTabBar(
      * The same app-level chrome for when this bar is down to its RAIL, at the very foot of it.
      *
      * A second slot rather than [belowMap] handed to both branches, which is what this was, and
-     * the reason is that the two are on screen at once. `SplitViewPanel` composes the in-flow rail
-     * and the hover drawer together - the drawer is an overlay over the rail, not a replacement
-     * for it - and the drawer being open makes the LIVE placement `TAB_BAR_FOOTER`. One shared
-     * slot therefore drew the full bar's wrapping row twice: once in the drawer's foot, and once
-     * behind it at the bottom of a 36dp rail, where four 32dp buttons wrap to four lines of
-     * squeezed icons. Hidden while the drawer covers it, and visible for the frame after it is
-     * dismissed - `drawerVisible` is reported through a `LaunchedEffect`, so the uncovered rail
-     * draws the wrong layout for one frame before the placement catches up.
-     *
-     * With two slots each branch is handed only its own layout, so there is nothing to get wrong.
+     * the reason is that the two are on screen at once. The drawer sits beside the in-flow rail,
+     * which remains the host-action owner while collapsed. Its full-bar foot therefore receives an
+     * empty host-action slot in that state, preventing duplicate targets.
      */
     belowTabs: @Composable () -> Unit = {},
 ) {
@@ -349,6 +342,7 @@ fun BoxScope.WindowRevealedTabBarDrawer(
         hoverSource = reveal.drawerHover,
         hoverEnabled = bar.hoverExpand,
         width = bar.width,
+        railWidth = tabBarRailWidth,
         panelRegion = contentRegion,
         onDismissOutside = reveal.dismissOutside,
     ) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/SwingTooltip.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/SwingTooltip.kt
@@ -65,6 +65,10 @@ object SwingTooltip {
                         // A JWindow is non-focusable by default; make it explicit so it can never
                         // steal focus from the browser when it appears.
                         focusableWindowState = false
+                        // The hover drawer is an always-on-top native window too. Keeping this
+                        // tooltip in that layer and raising it after show prevents a retained rail
+                        // action's label from being covered by its sibling drawer.
+                        isAlwaysOnTop = true
                         contentPane.add(fresh)
                         pack() // size to the label
                     }
@@ -96,6 +100,7 @@ object SwingTooltip {
                 w.setLocation(x, y)
             }
             w.isVisible = true
+            w.toFront()
             window = w
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/SwingTooltip.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/SwingTooltip.kt
@@ -21,6 +21,11 @@ import java.awt.Color as AwtColor
  *  - It's positioned from [MouseInfo] (exact screen coordinates), avoiding window/inset/DPI
  *    coordinate conversion — a tooltip near the cursor is the conventional placement anyway.
  *
+ * Always-on-top is a consequence of that JWindow layer, not a feature: the label sits above
+ * EVERY application, not just BOSS, until hover exit hides it (a Cmd/Alt-Tab away with a label
+ * up can leave it lingering over the other app), and toFront() on a non-focusable window is a
+ * best-effort hint under some X11 window managers.
+ *
  * Only used when [OverlayConfig.useHeavyweightPopups] is true (HARDWARE mode); otherwise callers
  * keep using the normal Compose tooltip, so this cannot affect the OFF_SCREEN default.
  */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
@@ -35,10 +35,12 @@ import kotlin.test.assertNull
  *
  * The first test exists because that second failure SHIPPED in this change's first draft: one slot
  * was handed to both the collapsed rail and the hover drawer on the reasoning that "a rail is
- * TAB_BAR_RAIL and a full bar is TAB_BAR_FOOTER, never both". `SplitViewPanel` composes the rail
- * and the drawer TOGETHER - the drawer is an overlay over the rail, not a replacement - so with
- * the drawer up the rail drew the full bar's wrapping row at 36dp wide, four lines of squeezed
- * icons, visible for the frame after dismissal.
+ * TAB_BAR_RAIL and a full bar is TAB_BAR_FOOTER, never both". Back then the drawer was an overlay
+ * over the rail, and with the drawer up the rail drew the full bar's wrapping row at 36dp wide -
+ * four lines of squeezed icons, visible for the frame after dismissal. The drawer now reveals
+ * BESIDE the rail, and the invariant the test pins is the conclusion of that fix: `SplitViewPanel`
+ * still composes rail and drawer together, but the rail keeps its one slot in every drawer state
+ * and the drawer never takes it.
  */
 class HostActionsWiringTest {
     @get:Rule

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
@@ -61,7 +61,7 @@ class HostActionsWiringTest {
     )
 
     @Test
-    fun `the hover drawer moves the actions out of the rail, never doubles them`() {
+    fun `the hover drawer keeps the actions in the rail without doubling them`() {
         val drawerVisible = mutableStateOf(false)
         rule.setContent {
             val placement = placementFor(drawerVisible = drawerVisible.value)
@@ -83,11 +83,11 @@ class HostActionsWiringTest {
 
         drawerVisible.value = true
         rule.waitForIdle()
-        assertOnly(VERTICAL_BAR_HOST_ACTIONS_TAG, "the drawer is a full bar, so its foot takes them")
+        assertOnly(VERTICAL_BAR_RAIL_ACTIONS_TAG, "the drawer opens beside the rail, which keeps the actions")
 
         drawerVisible.value = false
         rule.waitForIdle()
-        assertOnly(VERTICAL_BAR_RAIL_ACTIONS_TAG, "and dismissing it hands them back to the rail")
+        assertOnly(VERTICAL_BAR_RAIL_ACTIONS_TAG, "and dismissing it leaves them there")
     }
 
     /** Exactly one of the two bar layouts on screen, and it is [expected]. */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
@@ -98,10 +98,10 @@ class QuickActionsFooterPlacementTest {
             placement(rightStripHidden = true, verticalBar = collapsedOnLeft),
         )
 
-        // The drawer is the third state: a collapsed bar with it open HAS a foot again.
+        // A collapsed rail remains the action host while its sibling drawer is open.
         val drawerOpen = verticalBarHost(tabBarOnLeft = true, barCollapsed = true, drawerVisible = true)
         assertEquals(
-            FocusQuickActionsPlacement.TAB_BAR_FOOTER,
+            FocusQuickActionsPlacement.TAB_BAR_RAIL,
             placement(rightStripHidden = true, verticalBar = drawerOpen),
         )
     }
@@ -227,9 +227,8 @@ class QuickActionsFooterPlacementTest {
 /**
  * Pins the three states of "what can the vertical bar host".
  *
- * Two of them look the same from the settings alone - a collapsed bar with the drawer open and one
- * with it shut differ only in a transient flag - and getting it wrong is silent either way: the
- * actions render twice, or nowhere.
+ * A collapsed rail remains the host whether or not its sibling drawer is visible. Getting that
+ * wrong is silent: actions render twice, nowhere, or at a moved target.
  */
 class VerticalBarHostTest {
     @Test
@@ -250,10 +249,9 @@ class VerticalBarHostTest {
     }
 
     @Test
-    fun `a collapsed bar with the drawer open has a foot again`() {
-        // The drawer is a full bar, split map and all, for as long as it is up.
+    fun `a collapsed bar remains a rail while its drawer is open`() {
         assertEquals(
-            VerticalBarHost.FOOT,
+            VerticalBarHost.RAIL,
             verticalBarHost(tabBarOnLeft = true, barCollapsed = true, drawerVisible = true),
         )
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/VerticalTabBarDrawerCatcherTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/VerticalTabBarDrawerCatcherTest.kt
@@ -1,12 +1,15 @@
 package ai.rever.boss.app
 
 import ai.rever.boss.components.window_panel.components.main_window_panels.VerticalTabBarDrawer
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -23,12 +26,17 @@ import kotlin.test.assertEquals
  *
  * SplitView composes the rail (WindowBarRow) BEFORE the drawer, so the drawer's dismissal
  * catcher - a fillMaxSize Box - sits on top of the rail. Pressing a retained quick action must
- * fire the action, not dismiss the drawer, and the rail must keep its hover (its Swing labels
- * are driven by it). Pressing the part of the panel the drawer does not cover still dismisses.
+ * fire the action, not dismiss the drawer. The rail must also keep its hover (its Swing labels
+ * are driven by it); the hit-region exclusion that keeps the rail pressable is the same one,
+ * but hover itself is not asserted here. Pressing the part of the panel the drawer does not
+ * cover still dismisses.
  *
- * The test composes the lightweight drawer path: in a test `OverlayConfig.heavyweightCorner` is
- * never set, so `overlayCornerIsHeavyweight()` is false and the drawer is ordinary layout, where
- * the catcher's hit region is what is under test.
+ * The catcher is composed before the heavyweight/lightweight split, so its hit region is under
+ * test in both rendering modes; only the panel-region press below additionally depends on the
+ * lightweight layout, which is the path composed in a test (`OverlayConfig.heavyweightCorner`
+ * is never set there, so `overlayCornerIsHeavyweight()` is false). Presses inside the drawer's
+ * press-transparent content also dismiss by fall-through to the catcher; that pre-existing
+ * behaviour is deliberately not pinned here.
  */
 class VerticalTabBarDrawerCatcherTest {
     @get:Rule
@@ -37,15 +45,19 @@ class VerticalTabBarDrawerCatcherTest {
     @Test
     fun `the retained rail stays interactive under the chevron drawer's click-catcher`() {
         var dismissals = 0
+        var railClicks = 0
         rule.setContent {
             Box(modifier = Modifier.size(PANEL_SIZE)) {
                 // Composed first, exactly as SplitView composes WindowBarRow before RevealedBar.
+                // Clickable with its own counter so the test pins that the rail action FIRES,
+                // not only that nothing dismissed.
                 Box(
                     modifier =
                         Modifier
                             .width(RAIL_WIDTH)
                             .fillMaxHeight()
-                            .testTag(RAIL_TAG),
+                            .testTag(RAIL_TAG)
+                            .clickable { railClicks++ },
                 )
                 VerticalTabBarDrawer(
                     visible = true,
@@ -53,29 +65,47 @@ class VerticalTabBarDrawerCatcherTest {
                     hoverEnabled = false,
                     width = PANEL_SIZE,
                     railWidth = RAIL_WIDTH,
+                    // Exists only to satisfy the parameter's null guard; its dimensions are
+                    // irrelevant on this path (and deliberately not PANEL_SIZE).
                     panelRegion = IntRect(0, 0, 300, 400),
                     onDismissOutside = { dismissals++ },
                 ) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .size(DRAWER_WIDTH, DRAWER_HEIGHT)
-                                .testTag(DRAWER_TAG),
-                    )
+                    Box(modifier = Modifier.size(DRAWER_WIDTH, DRAWER_HEIGHT))
                 }
+                // Fills the panel area to the right of the drawer - x in
+                // [RAIL_WIDTH + DRAWER_WIDTH, PANEL_SIZE]: inside the catcher's hit region,
+                // outside the drawer's content.
+                Box(
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterStart)
+                            .padding(start = RAIL_WIDTH + DRAWER_WIDTH)
+                            .width(PANEL_SIZE - RAIL_WIDTH - DRAWER_WIDTH)
+                            .fillMaxHeight()
+                            .testTag(PANEL_RIGHT_TAG),
+                )
             }
         }
         rule.waitForIdle()
 
         rule.onNodeWithTag(RAIL_TAG).performClick()
         assertEquals(
+            1,
+            railClicks,
+            "pressing the retained rail must fire the rail's own action",
+        )
+        assertEquals(
             0,
             dismissals,
             "pressing the retained rail must not count as an outside click",
         )
 
-        rule.onNodeWithTag(DRAWER_TAG).performClick()
-        assertEquals(1, dismissals, "pressing the rest of the panel still dismisses the drawer")
+        rule.onNodeWithTag(PANEL_RIGHT_TAG).performClick()
+        assertEquals(
+            1,
+            dismissals,
+            "pressing the part of the panel the drawer does not cover still dismisses the drawer",
+        )
     }
 
     private companion object {
@@ -84,6 +114,6 @@ class VerticalTabBarDrawerCatcherTest {
         val DRAWER_WIDTH = 100.dp
         val DRAWER_HEIGHT = 200.dp
         const val RAIL_TAG = "retained-rail"
-        const val DRAWER_TAG = "drawer-content"
+        const val PANEL_RIGHT_TAG = "panel-right-of-drawer"
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/VerticalTabBarDrawerCatcherTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/VerticalTabBarDrawerCatcherTest.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -31,12 +31,13 @@ import kotlin.test.assertEquals
  * but hover itself is not asserted here. Pressing the part of the panel the drawer does not
  * cover still dismisses.
  *
- * The catcher is composed before the heavyweight/lightweight split, so its hit region is under
- * test in both rendering modes; only the panel-region press below additionally depends on the
- * lightweight layout, which is the path composed in a test (`OverlayConfig.heavyweightCorner`
- * is never set there, so `overlayCornerIsHeavyweight()` is false). Presses inside the drawer's
- * press-transparent content also dismiss by fall-through to the catcher; that pre-existing
- * behaviour is deliberately not pinned here.
+ * The catcher is mode-independent code, so what this test pins holds in both rendering modes;
+ * the panel-region press additionally depends on the lightweight layout, which is the path
+ * composed in a test (`OverlayConfig.heavyweightCorner` is never set there, so
+ * `overlayCornerIsHeavyweight()` is false) - and under HARDWARE the catcher can be occluded by
+ * the browser's native surface entirely (see the chevron comment in `WindowVerticalTabBar`).
+ * In this test the drawer's stub content has no pointer input, so presses inside it fall
+ * through to the catcher; that pre-existing behaviour is deliberately not pinned here.
  */
 class VerticalTabBarDrawerCatcherTest {
     @get:Rule
@@ -65,8 +66,8 @@ class VerticalTabBarDrawerCatcherTest {
                     hoverEnabled = false,
                     width = PANEL_SIZE,
                     railWidth = RAIL_WIDTH,
-                    // Exists only to satisfy the parameter's null guard; its dimensions are
-                    // irrelevant on this path (and deliberately not PANEL_SIZE).
+                    // Exists only to satisfy the parameter's null guard; nothing on this
+                    // path reads its dimensions.
                     panelRegion = IntRect(0, 0, 300, 400),
                     onDismissOutside = { dismissals++ },
                 ) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/VerticalTabBarDrawerCatcherTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/VerticalTabBarDrawerCatcherTest.kt
@@ -1,0 +1,89 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.window_panel.components.main_window_panels.VerticalTabBarDrawer
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * The chevron drawer's click-catcher must leave the retained rail interactive.
+ *
+ * SplitView composes the rail (WindowBarRow) BEFORE the drawer, so the drawer's dismissal
+ * catcher - a fillMaxSize Box - sits on top of the rail. Pressing a retained quick action must
+ * fire the action, not dismiss the drawer, and the rail must keep its hover (its Swing labels
+ * are driven by it). Pressing the part of the panel the drawer does not cover still dismisses.
+ *
+ * The test composes the lightweight drawer path: in a test `OverlayConfig.heavyweightCorner` is
+ * never set, so `overlayCornerIsHeavyweight()` is false and the drawer is ordinary layout, where
+ * the catcher's hit region is what is under test.
+ */
+class VerticalTabBarDrawerCatcherTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun `the retained rail stays interactive under the chevron drawer's click-catcher`() {
+        var dismissals = 0
+        rule.setContent {
+            Box(modifier = Modifier.size(PANEL_SIZE)) {
+                // Composed first, exactly as SplitView composes WindowBarRow before RevealedBar.
+                Box(
+                    modifier =
+                        Modifier
+                            .width(RAIL_WIDTH)
+                            .fillMaxHeight()
+                            .testTag(RAIL_TAG),
+                )
+                VerticalTabBarDrawer(
+                    visible = true,
+                    hoverSource = remember { MutableInteractionSource() },
+                    hoverEnabled = false,
+                    width = PANEL_SIZE,
+                    railWidth = RAIL_WIDTH,
+                    panelRegion = IntRect(0, 0, 300, 400),
+                    onDismissOutside = { dismissals++ },
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(DRAWER_WIDTH, DRAWER_HEIGHT)
+                                .testTag(DRAWER_TAG),
+                    )
+                }
+            }
+        }
+        rule.waitForIdle()
+
+        rule.onNodeWithTag(RAIL_TAG).performClick()
+        assertEquals(
+            0,
+            dismissals,
+            "pressing the retained rail must not count as an outside click",
+        )
+
+        rule.onNodeWithTag(DRAWER_TAG).performClick()
+        assertEquals(1, dismissals, "pressing the rest of the panel still dismisses the drawer")
+    }
+
+    private companion object {
+        val RAIL_WIDTH = 36.dp
+        val PANEL_SIZE = 220.dp
+        val DRAWER_WIDTH = 100.dp
+        val DRAWER_HEIGHT = 200.dp
+        const val RAIL_TAG = "retained-rail"
+        const val DRAWER_TAG = "drawer-content"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabBarSidebarRevealTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabBarSidebarRevealTest.kt
@@ -82,4 +82,16 @@ class TabBarSidebarRevealTest {
             panel.besideLeadingRail(36.dp),
         )
     }
+
+    @Test
+    fun `a panel narrower than the rail coerces to a zero-width region`() {
+        // left + railWidth passes right, so the drawer gets nothing beside the rail; the
+        // zero-width answer is what resolveRegion's documented inset fallback then acts on.
+        // Pin the coercion direction so that inheritance stays a deliberate choice.
+        val panel = IntRect(left = 40, top = 12, right = 50, bottom = 612)
+        val region = panel.besideLeadingRail(36.dp)
+
+        assertEquals(50, region.left)
+        assertEquals(region.left, region.right, "the drawer region is zero-width, not negative")
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabBarSidebarRevealTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabBarSidebarRevealTest.kt
@@ -2,8 +2,12 @@ package ai.rever.boss.components.window_panel
 
 import ai.rever.boss.components.window_panel.components.main_window_panels.SIDEBAR_REVEAL_CLOSE_DELAY_MS
 import ai.rever.boss.components.window_panel.components.main_window_panels.SIDEBAR_REVEAL_OPEN_DELAY_MS
+import ai.rever.boss.components.window_panel.components.main_window_panels.besideLeadingRail
 import ai.rever.boss.components.window_panel.components.main_window_panels.hoverRevealTarget
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -30,9 +34,8 @@ class TabBarSidebarRevealTest {
 
     @Test
     fun `pointer on the drawer keeps it revealed`() {
-        // The handoff: the drawer slides OVER the rail, so hover moves between two different
-        // nodes - and under HARDWARE between two different windows. Without this vote the drawer
-        // closes the instant it finishes opening.
+        // The drawer sits beside the rail, but they remain separate nodes and under HARDWARE
+        // separate windows. Without this vote the drawer closes during that handoff.
         assertTrue(reveal(pointerOnRail = false, pointerOnDrawer = true))
     }
 
@@ -68,5 +71,15 @@ class TabBarSidebarRevealTest {
         // Load-bearing rather than cosmetic: the close grace has to cover the rail-to-drawer
         // handoff, which itself takes the open delay. Equal or shorter and the drawer flickers.
         assertTrue(SIDEBAR_REVEAL_CLOSE_DELAY_MS > SIDEBAR_REVEAL_OPEN_DELAY_MS)
+    }
+
+    @Test
+    fun `the drawer region begins after the retained rail`() {
+        val panel = IntRect(left = 40, top = 12, right = 520, bottom = 612)
+
+        assertEquals(
+            IntRect(left = 76, top = 12, right = 520, bottom = 612),
+            panel.besideLeadingRail(36.dp),
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fixes Issue #411, where host quick actions moved from the collapsed left rail into the Focus Mode drawer footer as the drawer opened.

Quick actions now remain in their original rail position while the drawer reveals beside them. This keeps targets stationary under the pointer, making hover and click interactions predictable. Heavyweight hover labels also remain visible above the native drawer.

## User Experience Improvement

- Quick-action buttons no longer shift while users approach or interact with them.
- The collapsed rail remains available while the drawer is open.
- Hover labels stay readable in hardware-accelerated/native rendering mode.
- Existing fallback behavior is preserved when the rail lacks sufficient height.

## Changes

- Keep collapsed vertical-bar ownership in `RAIL` state regardless of drawer visibility.
- Offset the revealed drawer beside the retained rail in both Compose and native-overlay paths.
- Raise heavyweight Swing tooltips above the native drawer.
- Update focused ownership, placement, and geometry regression coverage.

## Files Changed

### Production

- `VerticalBarWindowControls.kt`
- `VerticalTabBarDrawer.kt`
- `WindowVerticalTabBar.kt`
- `SwingTooltip.kt`

### Tests

- `HostActionsWiringTest.kt`
- `QuickActionsFooterPlacementTest.kt`
- `TabBarSidebarRevealTest.kt`

## Validation

### Automated

- Focused desktop ownership and placement tests
- Quick-action rail layout tests
- Drawer/reveal regression tests
- `:composeApp:compileKotlinDesktop`
- `detekt`
- `git diff --check`

### Manual

- Confirmed quick actions remain stationary as the drawer opens and closes.
- Confirmed the retained rail action remains clickable.
- Confirmed hover labels stay visible above the native drawer.
---

## Consolidation note (review, 2026-09-11)

PR #534 by **Rohan Gaikwad (@rohangaikwad4)** implemented the same "Permanent Activity Bar" fix for #411 in parallel. It was reviewed diff-by-diff against this PR: same `verticalBarHost` placement change, same four test updates, and the same 40dp offset beside the rail in both rendering paths (its `besideRail()`/`BossChrome.dimens.stripWidth` equals this PR's `tabBarRailWidth`, which is `stripWidth` itself). This PR additionally keeps the width density-aware, unit-tests the region math, and raises the heavyweight Swing tooltip above the native drawer (the companion occlusion half of #411). #534 was closed as fully covered, with credit and the coverage explanation in its thread. Rohan's "Permanent Activity Bar" framing and Fitts's Law rationale are reflected in the KDocs here.

Prepared for `dev`: single commit rebased onto current `dev`, authorship intact.

## Round 2 — Claude review response (2026-09-11)

- **Blocking fix:** the chevron drawer's dismissal catcher no longer sits on top of the retained rail — it now pads `start = railWidth`, so retained rail quick actions (and their hover/labels) stay interactive under a chevron-opened drawer. New `VerticalTabBarDrawerCatcherTest` composes the rail and the catcher in `SplitView`'s order and pins both directions.
- `verticalBarHost`'s `drawerVisible` parameter is documented in its KDoc as a deliberate, non-input hedge (the reporting chain stays, for a reason). The two stale `BossAppScaffold` comments are rewritten, and the `railActionsFit == false` fall-through to `PANEL_FOOTER`/`FLOATING` on short windows is recorded.
- `besideLeadingRail` KDoc states the dp invariant (the receiver is already density-divided) and the degenerate zero-width case, which inherits `resolveRegion`'s documented inset fallback; `TabBarSidebarRevealTest` pins the coercion.
- `SwingTooltip` class KDoc records the always-on-top consequence; `HostActionsWiringTest` KDoc updated (the drawer reveals beside the rail, not over it).

## Round 3 — delta review response (2026-09-11)

Claude delta review at `7562e90c6` approved the production code and the blocking catcher fix, and asked that the regression test check what its messages claim. Applied in `16bdcf00d`: the rail `Box` is clickable with its own counter (`railClicks == 1` — the action fires, not just "nothing dismissed"), and a third tagged `Box` fills the panel area right of the drawer whose press must dismiss. The follow-up delta on that test (`9e939539c`) is closed: ktlint import-order fix plus two KDoc precision corrections (mode-independence/HARDWARE occlusion caveat; in-drawer fall-through scoped to the test's stub content). Final head: `9e939539c`. The Compose UI test cannot execute in the review sandbox (executor SIGABRT, proven on unmodified dev); it runs under the build CI now that `build.yml` triggers on `dev`.
