### PR TITLE
Address final project announcement review from #344

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1092,6 +1092,9 @@ the whole `TabTypeId`, whose equality includes `pluginId` and `defaultOrder`.
 - [Role Creation](docs/ROLE_CREATION_GUIDE.md) - Creating and managing roles
 - [Windows Deep Link](docs/WINDOWS_DEEP_LINK_SETUP.md) - Windows protocol handler setup
 - [Release Rebuild](docs/RELEASE_REBUILD_GUIDE.md) - Re-running release builds
+
+
+
 ### Governed MCP invocation (#371)
 
 The host policy applies to registry invocation; it does not isolate installed JVM

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -832,7 +832,7 @@ class DefaultPlugin(
 
     // Phase 4: Application event bus for state change events
     override val applicationEventBus: ApplicationEventBus by lazy {
-        createApplicationEventBus(pluginScope)
+        createApplicationEventBus()
     }
 
     // Phase 4: Plugin storage factory for persistent data

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/ApplicationEventBusFactory.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/ApplicationEventBusFactory.kt
@@ -8,7 +8,8 @@ import kotlinx.coroutines.CoroutineScope
  * Factory function to create platform-specific ApplicationEventBus.
  * Desktop implementation provides a singleton event bus.
  *
- * @param scope CoroutineScope for event processing
+ * @param scope retained for source-set factory compatibility; the desktop singleton currently
+ * uses no coroutine scope
  * @return ApplicationEventBus implementation
  */
 expect fun createApplicationEventBus(scope: CoroutineScope): ApplicationEventBus

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/ApplicationEventBusFactory.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/ApplicationEventBusFactory.kt
@@ -2,17 +2,14 @@ package ai.rever.boss.components.plugin.providers
 
 import ai.rever.boss.plugin.api.ApplicationEvent
 import ai.rever.boss.plugin.api.ApplicationEventBus
-import kotlinx.coroutines.CoroutineScope
 
 /**
  * Factory function to create platform-specific ApplicationEventBus.
  * Desktop implementation provides a singleton event bus.
  *
- * @param scope retained for source-set factory compatibility; the desktop singleton currently
- * uses no coroutine scope
  * @return ApplicationEventBus implementation
  */
-expect fun createApplicationEventBus(scope: CoroutineScope): ApplicationEventBus
+expect fun createApplicationEventBus(): ApplicationEventBus
 
 /**
  * Publish a host/system [ApplicationEvent] onto the shared application event bus so plugins

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/ProjectDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/ProjectDataProviderImpl.kt
@@ -38,8 +38,8 @@ class ProjectDataProviderImpl(
     // Cancelling on window close would leave that gRPC stream open and simply never changing:
     // a silent freeze for every out-of-process plugin, which is worse than the leak. Closing it
     // properly means the bridge reading ProjectState directly instead of a per-window provider,
-    // which is its own change - see the PR discussion. logDataProvider and gitDataProvider are
-    // registered in the same group and want the same look.
+    // which BossConsole#520 tracks. logDataProvider and gitDataProvider are registered in the
+    // same group and want the same look.
     private val scope = CoroutineScope(dispatcher + SupervisorJob())
 
     // Map ProjectState's recentProjects to plugin's ProjectData type

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/ProjectChangeAnnouncer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/ProjectChangeAnnouncer.kt
@@ -29,15 +29,18 @@ internal class ProjectChangeAnnouncer(
     private val windowId: String,
 ) : ProjectSelectionCallback {
     /**
-     * Every production selection is main-confined. The one former exception was the KERNEL-mode
-     * gRPC bridge; `ProjectDataServiceBridge.selectProject` now hops to Main before it calls the
-     * provider. Keeping that confinement at the boundary means publishing here needs no monitor,
-     * so third-party code resumed inline by `tryEmit` never runs while holding a host lock.
+     * Every host-initiated selection is main-confined. The one former host exception was the
+     * KERNEL-mode gRPC bridge; `ProjectDataServiceBridge.selectProject` now hops to Main before it
+     * calls the provider. The plugin-facing `ProjectDataProviderImpl.selectProject` is different:
+     * in-process plugin code may call it from any thread. `@Volatile` makes those writes visible to
+     * the host thread, but deliberately does not make the read-check-write sequence atomic. A
+     * monitor would run third-party code resumed inline by `tryEmit` while holding a host lock.
      *
      * [previousPath] advances before the publish. A subscriber that re-enters `selectProject`
      * inline with the same path therefore takes the early return; a different path produces a
      * correctly chained second event.
      */
+    @Volatile
     private var previousPath: String = ""
 
     override fun onProjectSelected(project: Project) {
@@ -49,6 +52,7 @@ internal class ProjectChangeAnnouncer(
         // that as a "reload the project" nudge no longer receives one. (Checked: the only
         // consumers in boss_plugins are the two fluck-agent panels, and both assign
         // `_bossProject.value` and re-sweep, which is idempotent on a repeat.)
+        // BossConsole#520 tracks the release note for that observable change.
         if (path == from) return
         previousPath = path
         publishSystemEvent(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/ProjectChangeAnnouncer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/ProjectChangeAnnouncer.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.window
 
 import ai.rever.boss.components.plugin.providers.publishSystemEvent
 import ai.rever.boss.plugin.api.ProjectChangeEvent
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Announces every project selection in one window onto the application event bus.
@@ -32,20 +33,20 @@ internal class ProjectChangeAnnouncer(
      * Every host-initiated selection is main-confined. The one former host exception was the
      * KERNEL-mode gRPC bridge; `ProjectDataServiceBridge.selectProject` now hops to Main before it
      * calls the provider. The plugin-facing `ProjectDataProviderImpl.selectProject` is different:
-     * in-process plugin code may call it from any thread. `@Volatile` makes those writes visible to
-     * the host thread, but deliberately does not make the read-check-write sequence atomic. A
-     * monitor would run third-party code resumed inline by `tryEmit` while holding a host lock.
+     * in-process plugin code may call it from any thread. [AtomicReference.getAndSet] keeps the
+     * previous-path chain atomic without a monitor, so third-party code resumed by publication
+     * never runs while holding a host lock. Concurrent callers can still publish their already
+     * coherent events out of order; serialising publication would reintroduce that lock.
      *
      * [previousPath] advances before the publish. A subscriber that re-enters `selectProject`
      * inline with the same path therefore takes the early return; a different path produces a
      * correctly chained second event.
      */
-    @Volatile
-    private var previousPath: String = ""
+    private val previousPath = AtomicReference("")
 
     override fun onProjectSelected(project: Project) {
         val path = project.path
-        val from = previousPath
+        val from = previousPath.getAndSet(path)
         // Re-selecting the same project is not a change. The old publish site did fire for
         // it - selectProject rewrites lastOpened on every call, so the state emits a fresh
         // Project each time - with previousProjectPath == projectPath. A plugin that used
@@ -54,7 +55,6 @@ internal class ProjectChangeAnnouncer(
         // `_bossProject.value` and re-sweep, which is idempotent on a repeat.)
         // BossConsole#520 tracks the release note for that observable change.
         if (path == from) return
-        previousPath = path
         publishSystemEvent(
             ProjectChangeEvent(
                 projectPath = path,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/ApplicationEventBusFactory.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/ApplicationEventBusFactory.kt
@@ -15,7 +15,6 @@ import ai.rever.boss.plugin.api.TerminalSessionEvent
 import ai.rever.boss.plugin.api.WindowFocusEvent
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -29,8 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * so the host and every in-process plugin share a single bus regardless of which classloader
  * first creates it.
  */
-@Suppress("UNUSED_PARAMETER")
-actual fun createApplicationEventBus(scope: CoroutineScope): ApplicationEventBus {
+actual fun createApplicationEventBus(): ApplicationEventBus {
     ApplicationEventBusRegistry.bus?.let { return it }
     return ApplicationEventBusImpl.getInstance()
 }
@@ -115,20 +113,19 @@ class ApplicationEventBusImpl private constructor() : ApplicationEventBus {
                 // publisher to capture events (ProjectChangeAnnouncementTest,
                 // BrowserAnalyticsEmissionTest, BossTabsComponentMoveTest). Testing only `bus`
                 // would let this method silently take that publisher away from them.
-                if (ApplicationEventBusRegistry.bus == null && ApplicationEventBusRegistry.systemPublisher != null) {
-                    if (missingBusRegistryWarned.compareAndSet(false, true)) {
-                        systemEventLogger.warn(
-                            LogCategory.SYSTEM,
-                            "ApplicationEventBusRegistry has a systemPublisher but no bus; " +
-                                "plugin subscribers are disconnected",
-                        )
+                if (ApplicationEventBusRegistry.bus == null) {
+                    if (ApplicationEventBusRegistry.systemPublisher != null) {
+                        if (missingBusRegistryWarned.compareAndSet(false, true)) {
+                            systemEventLogger.warn(
+                                LogCategory.SYSTEM,
+                                "ApplicationEventBusRegistry has a systemPublisher but no bus; " +
+                                    "plugin subscribers are disconnected (expected in publisher-capturing tests)",
+                            )
+                        }
+                    } else {
+                        ApplicationEventBusRegistry.bus = bus
+                        ApplicationEventBusRegistry.systemPublisher = { event -> bus.publishInternal(event) }
                     }
-                } else if (
-                    ApplicationEventBusRegistry.bus == null &&
-                    ApplicationEventBusRegistry.systemPublisher == null
-                ) {
-                    ApplicationEventBusRegistry.bus = bus
-                    ApplicationEventBusRegistry.systemPublisher = { event -> bus.publishInternal(event) }
                 }
                 bus
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/ApplicationEventBusFactory.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/ApplicationEventBusFactory.kt
@@ -16,8 +16,6 @@ import ai.rever.boss.plugin.api.WindowFocusEvent
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -31,19 +29,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * so the host and every in-process plugin share a single bus regardless of which classloader
  * first creates it.
  */
+@Suppress("UNUSED_PARAMETER")
 actual fun createApplicationEventBus(scope: CoroutineScope): ApplicationEventBus {
     ApplicationEventBusRegistry.bus?.let { return it }
-    return ApplicationEventBusImpl.getInstance(scope)
+    return ApplicationEventBusImpl.getInstance()
 }
-
-/**
- * Scope handed to a bus created by [publishSystemEvent] rather than by a plugin touching
- * `PluginContext.applicationEventBus`. Nothing in [ApplicationEventBusImpl] launches on it today;
- * it exists because the constructor takes one, and it is a supervisor so that a future child
- * failing cannot take the process-wide bus with it. Lazy so it is built only if that fallback is
- * ever taken, which on most runs it is not.
- */
-private val systemEventBusScope by lazy { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
 
 actual fun publishSystemEvent(event: ApplicationEvent) {
     // Route through the shared registry rather than this classloader's own singleton, so host
@@ -76,7 +66,7 @@ actual fun publishSystemEvent(event: ApplicationEvent) {
     // TabEvent, and with replay = 0 nothing recoverable afterwards. Whether a plugin has been
     // curious is not a sensible thing for the host's events to depend on. getInstance registers
     // the publisher, so this branch is taken at most once.
-    ApplicationEventBusImpl.getInstance(systemEventBusScope).publishInternal(event)
+    ApplicationEventBusImpl.getInstance().publishInternal(event)
 }
 
 private val systemEventLogger = BossLogger.forComponent("ApplicationEventBus")
@@ -84,31 +74,33 @@ private val systemEventLogger = BossLogger.forComponent("ApplicationEventBus")
 /** One warning, not one per event: the drop is permanent, so repeating it only buries the log. */
 private val partialRegistryWarned = AtomicBoolean(false)
 
+/** One warning, not one per factory call: the split bus stays disconnected until repaired. */
+private val missingBusRegistryWarned = AtomicBoolean(false)
+
 /**
  * Desktop implementation of ApplicationEventBus.
  *
  * This is a singleton that manages application-wide event distribution.
  * All events are broadcast to all subscribers via SharedFlow.
  */
-class ApplicationEventBusImpl private constructor(
-    private val scope: CoroutineScope,
-) : ApplicationEventBus {
+class ApplicationEventBusImpl private constructor() : ApplicationEventBus {
     companion object {
         // Not @Volatile: every read and write is inside the synchronized block below. The
         // lock-free fast path is gone deliberately - both callers (createApplicationEventBus,
         // publishSystemEvent) check the registry first, so this is not on a hot path.
         private var instance: ApplicationEventBusImpl? = null
 
-        fun getInstance(scope: CoroutineScope): ApplicationEventBusImpl =
+        fun getInstance(): ApplicationEventBusImpl =
             synchronized(this) {
-                val bus = instance ?: ApplicationEventBusImpl(scope).also { instance = it }
+                val bus = instance ?: ApplicationEventBusImpl().also { instance = it }
                 // Publish to the process-global registry so the host's publishSystemEvent and
                 // in-process plugins share this exact instance regardless of classloader.
                 //
                 // Checked on every call rather than only at creation: when BOTH registry fields
                 // are empty, an instance that already exists would otherwise leave host events
                 // going nowhere forever. A half-populated registry is deliberately left alone;
-                // publishSystemEvent refuses its bus-without-publisher form and warns once.
+                // publishSystemEvent refuses its bus-without-publisher form and warns once;
+                // getInstance warns for the publisher-without-bus mirror below.
                 // Inside the lock, because it is a read-modify-write of two process-global
                 // statics; the lock is uncontended after the first call.
                 //
@@ -123,7 +115,18 @@ class ApplicationEventBusImpl private constructor(
                 // publisher to capture events (ProjectChangeAnnouncementTest,
                 // BrowserAnalyticsEmissionTest, BossTabsComponentMoveTest). Testing only `bus`
                 // would let this method silently take that publisher away from them.
-                if (ApplicationEventBusRegistry.bus == null && ApplicationEventBusRegistry.systemPublisher == null) {
+                if (ApplicationEventBusRegistry.bus == null && ApplicationEventBusRegistry.systemPublisher != null) {
+                    if (missingBusRegistryWarned.compareAndSet(false, true)) {
+                        systemEventLogger.warn(
+                            LogCategory.SYSTEM,
+                            "ApplicationEventBusRegistry has a systemPublisher but no bus; " +
+                                "plugin subscribers are disconnected",
+                        )
+                    }
+                } else if (
+                    ApplicationEventBusRegistry.bus == null &&
+                    ApplicationEventBusRegistry.systemPublisher == null
+                ) {
                     ApplicationEventBusRegistry.bus = bus
                     ApplicationEventBusRegistry.systemPublisher = { event -> bus.publishInternal(event) }
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/ProjectDataServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/ProjectDataServiceBridge.kt
@@ -10,6 +10,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 
+/**
+ * KERNEL bridge for project data. [uiDispatcher] must be a live UI dispatcher because project
+ * selection mutates window state; callers must not block that dispatcher while waiting for this
+ * RPC, or the dispatcher hop in [selectProject] will deadlock.
+ */
 class ProjectDataServiceBridge(
     private val provider: ProjectDataProvider,
     private val uiDispatcher: CoroutineDispatcher = Dispatchers.Main,
@@ -52,7 +57,7 @@ class ProjectDataServiceBridge(
 
     override suspend fun selectProject(request: ProjectProto): Empty {
         // The provider mutates per-window UI state and synchronously announces that change.
-        // Confining the only non-UI entry point here keeps the state and its previous-path event
+        // Confining the only non-UI host entry point here keeps the state and its previous-path event
         // chain ordered without making third-party event handlers run under a host lock.
         withContext(uiDispatcher) {
             provider.selectProject(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/ProjectDataServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/ProjectDataServiceBridgeTest.kt
@@ -52,7 +52,11 @@ class ProjectDataServiceBridgeTest {
 
     private class RecordingProjectDataProvider : ProjectDataProvider {
         override val recentProjects: StateFlow<List<ProjectData>> = MutableStateFlow(emptyList())
+
+        @Volatile
         var selectedProject: ProjectData? = null
+
+        @Volatile
         var selectionThread: String? = null
 
         override fun updateRecentProjects(project: ProjectData) = Unit

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ProjectChangeAnnouncementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ProjectChangeAnnouncementTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.window
 
 import ai.rever.boss.components.plugin.panels.left_top.ProjectState
 import ai.rever.boss.components.plugin.providers.ProjectDataProviderImpl
+import ai.rever.boss.components.plugin.providers.createApplicationEventBus
 import ai.rever.boss.components.plugin.providers.publishSystemEvent
 import ai.rever.boss.components.window_panel.SplitViewState
 import ai.rever.boss.components.workspaces.LayoutWorkspace
@@ -14,10 +15,12 @@ import ai.rever.boss.plugin.api.ProjectChangeEvent
 import ai.rever.boss.plugin.api.ProjectData
 import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.runBlocking
+import java.lang.reflect.Modifier
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -99,6 +102,14 @@ class ProjectChangeAnnouncementTest {
             listOf("" to "/tmp/boss-pca-first", "/tmp/boss-pca-first" to "/tmp/boss-pca-second"),
             changes().map { it.previousProjectPath to it.projectPath },
         )
+    }
+
+    /** Plugin-facing selection is arbitrary-threaded, so the path chain must be visible to Main. */
+    @Test
+    fun `the previous path field is volatile`() {
+        val field = ProjectChangeAnnouncer::class.java.getDeclaredField("previousPath")
+
+        assertTrue(Modifier.isVolatile(field.modifiers), "plugin-thread selections would be invisible to Main")
     }
 
     /**
@@ -347,7 +358,8 @@ class ProjectChangeAnnouncementTest {
      * To be precise about what is fixed: no registered publisher means nobody holds the bus,
      * which means it has no subscribers, so the event that triggers this branch still reaches
      * no one. What changes is that it is the last one to - the host stops being permanently
-     * silent while it waits for a plugin to be curious.
+     * silent while it waits for a plugin to be curious. The singleton this test leaves behind is
+     * stateless apart from its event flow; it no longer captures the first caller's scope.
      */
     @Test
     fun `a system event published with no bus leaves one behind, so the next one has somewhere to go`() {
@@ -397,6 +409,39 @@ class ProjectChangeAnnouncementTest {
                 "the half-registry should be refused, not completed by whatever getInstance builds",
             )
             assertSame(StubBus, ApplicationEventBusRegistry.bus, "and the existing bus left alone")
+        } finally {
+            ApplicationEventBusRegistry.bus = previousBus
+            ApplicationEventBusRegistry.systemPublisher = outerPublisher
+        }
+    }
+
+    /**
+     * The mirror half-registry is just as broken: host events use the installed publisher while
+     * plugins would subscribe to this classloader's disconnected singleton. The factory warns
+     * once and preserves the foreign registration rather than silently claiming it repaired the
+     * invariant. The warning itself is process-global and therefore not order-independently
+     * assertable; this pins the state that fires it and its non-destructive behavior.
+     */
+    @Test
+    fun `the bus factory preserves a publisher-only half-registry and leaves it visibly incomplete`() {
+        val previousBus: ApplicationEventBus? = ApplicationEventBusRegistry.bus
+        val outerPublisher = ApplicationEventBusRegistry.systemPublisher
+        val publisher: (ApplicationEvent) -> Unit = { captured += it }
+        ApplicationEventBusRegistry.bus = null
+        ApplicationEventBusRegistry.systemPublisher = publisher
+        try {
+            val localBus = createApplicationEventBus(CoroutineScope(Dispatchers.Unconfined))
+
+            assertNotNull(localBus, "the factory still returns its classloader-local singleton")
+            assertNull(
+                ApplicationEventBusRegistry.bus,
+                "the factory must not pair a foreign publisher with its own bus",
+            )
+            assertSame(
+                publisher,
+                ApplicationEventBusRegistry.systemPublisher,
+                "the foreign publisher must be left alone",
+            )
         } finally {
             ApplicationEventBusRegistry.bus = previousBus
             ApplicationEventBusRegistry.systemPublisher = outerPublisher

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ProjectChangeAnnouncementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/ProjectChangeAnnouncementTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.window
 
 import ai.rever.boss.components.plugin.panels.left_top.ProjectState
+import ai.rever.boss.components.plugin.providers.ApplicationEventBusImpl
 import ai.rever.boss.components.plugin.providers.ProjectDataProviderImpl
 import ai.rever.boss.components.plugin.providers.createApplicationEventBus
 import ai.rever.boss.components.plugin.providers.publishSystemEvent
@@ -15,12 +16,12 @@ import ai.rever.boss.plugin.api.ProjectChangeEvent
 import ai.rever.boss.plugin.api.ProjectData
 import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.runBlocking
 import java.lang.reflect.Modifier
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -104,12 +105,20 @@ class ProjectChangeAnnouncementTest {
         )
     }
 
-    /** Plugin-facing selection is arbitrary-threaded, so the path chain must be visible to Main. */
+    /** Plugin-facing selection is arbitrary-threaded, so the path chain must update atomically. */
     @Test
-    fun `the previous path field is volatile`() {
+    fun `the previous path field is atomic`() {
         val field = ProjectChangeAnnouncer::class.java.getDeclaredField("previousPath")
 
-        assertTrue(Modifier.isVolatile(field.modifiers), "plugin-thread selections would be invisible to Main")
+        assertEquals(AtomicReference::class.java, field.type, "plugin-thread selections would race the path chain")
+    }
+
+    /** The callback itself is also read from arbitrary plugin threads and must be visible there. */
+    @Test
+    fun `the project selection callback field is volatile`() {
+        val field = WindowProjectState::class.java.getDeclaredField("projectSelectionCallback")
+
+        assertTrue(Modifier.isVolatile(field.modifiers), "a plugin thread could miss the callback and drop the event")
     }
 
     /**
@@ -430,9 +439,13 @@ class ProjectChangeAnnouncementTest {
         ApplicationEventBusRegistry.bus = null
         ApplicationEventBusRegistry.systemPublisher = publisher
         try {
-            val localBus = createApplicationEventBus(CoroutineScope(Dispatchers.Unconfined))
+            val localBus = createApplicationEventBus()
 
-            assertNotNull(localBus, "the factory still returns its classloader-local singleton")
+            assertSame(
+                ApplicationEventBusImpl.getInstance(),
+                localBus,
+                "the factory still returns its classloader-local singleton",
+            )
             assertNull(
                 ApplicationEventBusRegistry.bus,
                 "the factory must not pair a foreign publisher with its own bus",

--- a/plugin-platform/plugin-window/src/commonMain/kotlin/ai/rever/boss/plugin/window/WindowProjectState.kt
+++ b/plugin-platform/plugin-window/src/commonMain/kotlin/ai/rever/boss/plugin/window/WindowProjectState.kt
@@ -34,7 +34,10 @@ class WindowProjectState(
         )
     val selectedProject: StateFlow<Project> = _selectedProject.asStateFlow()
 
-    // Callback for project selection (e.g., to update recent projects)
+    // selectProject is exposed to in-process plugins and may run on an arbitrary thread. Without
+    // visibility here, that thread could observe the pre-registration null and drop the callback;
+    // a ProjectChangeEvent on the replay-free application bus cannot be recovered later.
+    @Volatile
     private var projectSelectionCallback: ProjectSelectionCallback? = null
 
     /**


### PR DESCRIPTION
## Summary

PR #344 was merged at `c5b01ec2` while its final review round was being implemented and validated. This follow-up contains the complete final review response:

- make `ProjectChangeAnnouncer` use an atomic previous-path handoff for arbitrary-threaded plugin calls;
- make `WindowProjectState.projectSelectionCallback` visible to arbitrary plugin threads with `@Volatile`;
- warn once for the `systemPublisher != null && bus == null` half-registry state without overwriting the foreign registration;
- remove the unused scope from the event bus singleton and factory API;
- document the KERNEL bridge UI-dispatcher and reentrancy requirements;
- mark the bridge test's cross-thread result fields `@Volatile`;
- strengthen the event bus registry test and add structural concurrency regression tests;
- restore unrelated `AGENTS.md` whitespace from #344;
- link the deferred API, lifecycle, and release-note work to #520.

## Tests

- `./gradlew clean :composeApp:desktopTest detekt ktlintCheck`
- 4312 desktop tests across 444 classes: 0 failures, 0 errors, 1 skipped
- focused announcement and bridge tests passed with `--rerun-tasks`
- mutation check: replacing the atomic path field and removing callback `@Volatile` makes both named structural tests fail; production code restored afterward
- final diff, imports, newline, KDoc, and added-prose checks clean

Closes every finding and note from the final review on #344 and the first review on this follow-up. The deliberately deferred product/API work is tracked in #520.
