### PR TITLE
Stop FileIcons keeping a second copy of the icon extension list

### DIFF
--- a/plugin-platform/plugin-icons/detekt-baseline.xml
+++ b/plugin-platform/plugin-icons/detekt-baseline.xml
@@ -5,12 +5,12 @@
     <ID>CyclomaticComplexMethod:FileIcons.kt$FileIcons$fun forFile(fileName: String): FileIconInfo</ID>
     <ID>CyclomaticComplexMethod:FileIcons.kt$FileIcons$private fun forSpecialFileName(fileName: String): FileIconInfo?</ID>
     <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forDatabase(database: String): Pair&lt;ImageVector, Color&gt;</ID>
-    <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forExtension(extension: String): Pair&lt;ImageVector, Color&gt;</ID>
+    <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forExtensionOrNull(extension: String): Pair&lt;ImageVector, Color&gt;?</ID>
     <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forFramework(framework: String): Pair&lt;ImageVector, Color&gt;</ID>
     <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forLanguage(language: String): Pair&lt;ImageVector, Color&gt;</ID>
     <ID>LongMethod:FileIcons.kt$FileIcons$fun forFile(fileName: String): FileIconInfo</ID>
     <ID>LongMethod:FileIcons.kt$FileIcons$private fun forSpecialFileName(fileName: String): FileIconInfo?</ID>
-    <ID>LongMethod:LanguageIcons.kt$LanguageIcons$fun forExtension(extension: String): Pair&lt;ImageVector, Color&gt;</ID>
+    <ID>LongMethod:LanguageIcons.kt$LanguageIcons$fun forExtensionOrNull(extension: String): Pair&lt;ImageVector, Color&gt;?</ID>
     <ID>LongMethod:LanguageIcons.kt$LanguageIcons$fun forFramework(framework: String): Pair&lt;ImageVector, Color&gt;</ID>
     <ID>MaxLineLength:FileIcons.kt$FileIcons$"png", "jpg", "jpeg", "gif", "bmp", "ico", "icns", "webp", "avif", "tiff", "tif" -&gt; FileIconInfo(image, Colors.image)</ID>
     <ID>WildcardImport:FileIcons.kt$import androidx.compose.material.icons.outlined.*</ID>

--- a/plugin-platform/plugin-icons/detekt-baseline.xml
+++ b/plugin-platform/plugin-icons/detekt-baseline.xml
@@ -12,7 +12,6 @@
     <ID>LongMethod:FileIcons.kt$FileIcons$private fun forSpecialFileName(fileName: String): FileIconInfo?</ID>
     <ID>LongMethod:LanguageIcons.kt$LanguageIcons$fun forExtensionOrNull(extension: String): Pair&lt;ImageVector, Color&gt;?</ID>
     <ID>LongMethod:LanguageIcons.kt$LanguageIcons$fun forFramework(framework: String): Pair&lt;ImageVector, Color&gt;</ID>
-    <ID>MaxLineLength:FileIcons.kt$FileIcons$"png", "jpg", "jpeg", "gif", "bmp", "ico", "icns", "webp", "avif", "tiff", "tif" -&gt; FileIconInfo(image, Colors.image)</ID>
     <ID>WildcardImport:FileIcons.kt$import androidx.compose.material.icons.outlined.*</ID>
     <ID>WildcardImport:LanguageIcons.kt$import compose.icons.simpleicons.*</ID>
   </CurrentIssues>

--- a/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/FileIcons.kt
+++ b/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/FileIcons.kt
@@ -97,184 +97,104 @@ object FileIcons {
 
         // Handle by extension
         return when (extension) {
-            // Code files - delegate to LanguageIcons
-            "kt", "kts" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "java" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "scala", "sc" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "py", "pyw", "pyx", "pxd", "pxi" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "js", "mjs", "cjs" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "ts", "mts", "cts" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "jsx", "tsx" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "go" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "rs" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "rb", "erb", "rake" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "swift" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "m", "mm" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Objective-C
-            "c", "h" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "cpp", "cc", "cxx", "hpp", "hxx", "hh" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "cs" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "fs", "fsx", "fsi" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // F#
-            "php" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "lua" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "pl", "pm" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "r", "rmd" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "dart" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "ex", "exs" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "erl", "hrl" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Erlang
-            "clj", "cljs", "cljc", "edn" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "jl" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "ml", "mli" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "zig" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "hs", "lhs" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "nim", "nims" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Nim
-            "cr" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Crystal
-            "f", "f90", "f95", "f03", "f08", "for" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Fortran
-            "cob", "cbl" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // COBOL
-            "asm", "s" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Assembly
-            "sol" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Solidity
-            "v" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // V
-            "d" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // D
-            "groovy", "gvy", "gy", "gsh" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Groovy
-            "res", "resi" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // ReScript
-            "rkt" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Racket
-
-            // Web files - delegate to LanguageIcons
-            "html", "htm", "xhtml" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "css", "scss", "sass", "less" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "vue" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "svelte" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
             // Shell scripts - delegate to LanguageIcons
-            "sh", "bash", "zsh" -> LanguageIcons.forExtension(extension).toFileIconInfo()
 
-            "ps1", "psm1", "psd1" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "bat", "cmd" -> FileIconInfo(LanguageIcons.powershell, LanguageIcons.Colors.powershell)
-
-            // Windows batch/cmd
-
-            // Data/Config files - delegate to LanguageIcons for supported types
-            "json" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "yaml", "yml" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "toml" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            "md", "markdown" -> LanguageIcons.forExtension(extension).toFileIconInfo()
+            "bat", "cmd" -> {
+                FileIconInfo(LanguageIcons.powershell, LanguageIcons.Colors.powershell)
+            }
 
             // Config files - use config icon
-            "xml" -> FileIconInfo(config, Colors.xml)
+            "xml" -> {
+                FileIconInfo(config, Colors.xml)
+            }
 
-            "plist" -> FileIconInfo(LanguageIcons.ios, LanguageIcons.Colors.ios)
+            "plist" -> {
+                FileIconInfo(LanguageIcons.ios, LanguageIcons.Colors.ios)
+            }
 
             // Apple property list
-            "gradle" -> FileIconInfo(LanguageIcons.gradle, LanguageIcons.Colors.gradle)
+            "gradle" -> {
+                FileIconInfo(LanguageIcons.gradle, LanguageIcons.Colors.gradle)
+            }
 
-            "properties", "ini", "cfg", "conf" -> FileIconInfo(config, Colors.config)
+            "properties", "ini", "cfg", "conf" -> {
+                FileIconInfo(config, Colors.config)
+            }
 
-            "env" -> FileIconInfo(lock, Colors.lock)
-
-            // Environment files often contain secrets
+            "env" -> {
+                FileIconInfo(lock, Colors.lock)
+            }
 
             // Documentation
-            "txt", "log", "text" -> FileIconInfo(document, Colors.document)
+            "txt", "log", "text" -> {
+                FileIconInfo(document, Colors.document)
+            }
 
-            "doc", "docx", "odt" -> FileIconInfo(document, Colors.document)
+            "doc", "docx", "odt" -> {
+                FileIconInfo(document, Colors.document)
+            }
 
-            "pdf" -> FileIconInfo(pdf, Colors.pdf)
+            "pdf" -> {
+                FileIconInfo(pdf, Colors.pdf)
+            }
 
-            "rtf" -> FileIconInfo(document, Colors.document)
+            "rtf" -> {
+                FileIconInfo(document, Colors.document)
+            }
 
             // Images
-            "png", "jpg", "jpeg", "gif", "bmp", "ico", "icns", "webp", "avif", "tiff", "tif" -> FileIconInfo(image, Colors.image)
+            "png", "jpg", "jpeg", "gif", "bmp", "ico", "icns", "webp", "avif", "tiff", "tif" -> {
+                FileIconInfo(image, Colors.image)
+            }
 
-            "svg" -> FileIconInfo(image, Colors.image)
+            "svg" -> {
+                FileIconInfo(image, Colors.image)
+            }
 
-            "psd", "ai", "sketch", "fig", "xd" -> FileIconInfo(image, Colors.image)
+            "psd", "ai", "sketch", "fig", "xd" -> {
+                FileIconInfo(image, Colors.image)
+            }
 
             // Audio
-            "mp3", "wav", "flac", "ogg", "aac", "m4a", "wma" -> FileIconInfo(audio, Colors.audio)
+            "mp3", "wav", "flac", "ogg", "aac", "m4a", "wma" -> {
+                FileIconInfo(audio, Colors.audio)
+            }
 
             // Video
-            "mp4", "mkv", "avi", "mov", "wmv", "webm", "m4v" -> FileIconInfo(video, Colors.video)
+            "mp4", "mkv", "avi", "mov", "wmv", "webm", "m4v" -> {
+                FileIconInfo(video, Colors.video)
+            }
 
             // Archives
-            "zip", "tar", "gz", "rar", "7z", "bz2", "xz" -> FileIconInfo(archive, Colors.archive)
+            "zip", "tar", "gz", "rar", "7z", "bz2", "xz" -> {
+                FileIconInfo(archive, Colors.archive)
+            }
 
-            "jar", "war", "ear" -> FileIconInfo(archive, LanguageIcons.Colors.java)
+            "jar", "war", "ear" -> {
+                FileIconInfo(archive, LanguageIcons.Colors.java)
+            }
 
             // Databases
-            "sql" -> LanguageIcons.forExtension(extension).toFileIconInfo()
 
-            "db", "sqlite", "sqlite3" -> FileIconInfo(database, LanguageIcons.Colors.sqlite)
+            "db", "sqlite", "sqlite3" -> {
+                FileIconInfo(database, LanguageIcons.Colors.sqlite)
+            }
 
             // Fonts
-            "ttf", "otf", "woff", "woff2", "eot" -> FileIconInfo(font, Colors.font)
-
-            // Git
-            "gitignore", "gitattributes", "gitmodules" -> LanguageIcons.forExtension(extension).toFileIconInfo()
-
-            // Docker
-            "dockerfile" -> LanguageIcons.forExtension(extension).toFileIconInfo()
+            "ttf", "otf", "woff", "woff2", "eot" -> {
+                FileIconInfo(font, Colors.font)
+            }
 
             // Default
-            else -> FileIconInfo(file, Colors.unknown)
+            // Anything else: ask LanguageIcons directly rather than keeping a second
+            // copy of its extension list here. The branches above stay ahead of this
+            // because they deliberately override it (a .xml is a config file, a .bat
+            // is PowerShell-coloured, a .env is a lock icon), and a jar/war/ear is an
+            // archive rather than Java source.
+            else -> {
+                LanguageIcons.forExtensionOrNull(extension)?.toFileIconInfo()
+                    ?: FileIconInfo(file, Colors.unknown)
+            }
         }
     }
 

--- a/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/FileIcons.kt
+++ b/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/FileIcons.kt
@@ -97,7 +97,7 @@ object FileIcons {
 
         // Handle by extension
         return when (extension) {
-            // Shell scripts - delegate to LanguageIcons
+            // Windows batch - PowerShell icon, deliberately not the language mapping
 
             "bat", "cmd" -> {
                 FileIconInfo(LanguageIcons.powershell, LanguageIcons.Colors.powershell)
@@ -175,7 +175,6 @@ object FileIcons {
             }
 
             // Databases
-
             "db", "sqlite", "sqlite3" -> {
                 FileIconInfo(database, LanguageIcons.Colors.sqlite)
             }

--- a/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/FileIcons.kt
+++ b/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/FileIcons.kt
@@ -98,7 +98,6 @@ object FileIcons {
         // Handle by extension
         return when (extension) {
             // Windows batch - PowerShell icon, deliberately not the language mapping
-
             "bat", "cmd" -> {
                 FileIconInfo(LanguageIcons.powershell, LanguageIcons.Colors.powershell)
             }
@@ -108,13 +107,9 @@ object FileIcons {
                 FileIconInfo(config, Colors.xml)
             }
 
+            // Apple property list
             "plist" -> {
                 FileIconInfo(LanguageIcons.ios, LanguageIcons.Colors.ios)
-            }
-
-            // Apple property list
-            "gradle" -> {
-                FileIconInfo(LanguageIcons.gradle, LanguageIcons.Colors.gradle)
             }
 
             "properties", "ini", "cfg", "conf" -> {

--- a/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/LanguageIcons.kt
+++ b/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/LanguageIcons.kt
@@ -554,7 +554,33 @@ object LanguageIcons {
      * @param extension File extension without the dot (e.g., "kt", "py", "js")
      * @return Pair of ImageVector icon and Color
      */
-    fun forExtension(extension: String): Pair<ImageVector, Color> =
+
+    /**
+     * Icon and colour for a file extension, or the generic unknown pair.
+     *
+     * Kept for callers that want a total function. Anything that needs to know
+     * whether the extension was actually recognised should use
+     * [forExtensionOrNull] rather than comparing against [unknown], which a real
+     * mapping could legitimately return.
+     */
+    fun forExtension(extension: String): Pair<ImageVector, Color> {
+        // Block body deliberately: as an expression body ktlintFormat joins this
+        // onto one line, which then trips detekt's 120-character limit.
+        return forExtensionOrNull(extension) ?: (unknown to Colors.unknown)
+    }
+
+    /**
+     * Icon and colour for a file extension, or null when this is not an
+     * extension we have an icon for.
+     *
+     * The nullable form exists so callers stop keeping their own copy of the
+     * extension list. [FileIcons] used to gate this call behind a `when` that
+     * re-listed the same extensions purely to decide whether to call it, which
+     * is one of the duplicated language tables BossConsole#75 is about, and it
+     * had already drifted: eleven extensions this function has icons for were
+     * missing from that gate and fell through to the generic file icon.
+     */
+    fun forExtensionOrNull(extension: String): Pair<ImageVector, Color>? =
         when (extension.lowercase()) {
             // Kotlin
             "kt", "kts" -> kotlin to Colors.kotlin
@@ -736,7 +762,7 @@ object LanguageIcons {
 
             "prettierrc", "prettierignore" -> prettier to Colors.prettier
 
-            else -> unknown to Colors.unknown
+            else -> null
         }
 
     /**

--- a/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/LanguageIcons.kt
+++ b/plugin-platform/plugin-icons/src/commonMain/kotlin/ai/rever/boss/plugin/icons/LanguageIcons.kt
@@ -550,12 +550,6 @@ object LanguageIcons {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /**
-     * Get icon and color for a file extension.
-     * @param extension File extension without the dot (e.g., "kt", "py", "js")
-     * @return Pair of ImageVector icon and Color
-     */
-
-    /**
      * Icon and colour for a file extension, or the generic unknown pair.
      *
      * Kept for callers that want a total function. Anything that needs to know

--- a/plugin-platform/plugin-icons/src/desktopTest/kotlin/ai/rever/boss/plugin/icons/FileIconsLanguageDelegationTest.kt
+++ b/plugin-platform/plugin-icons/src/desktopTest/kotlin/ai/rever/boss/plugin/icons/FileIconsLanguageDelegationTest.kt
@@ -1,0 +1,106 @@
+package ai.rever.boss.plugin.icons
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Pins the behaviour of routing unmatched extensions straight to
+ * [LanguageIcons.forExtensionOrNull], which replaced a `when` in [FileIcons] whose
+ * 52 branches were byte-identical calls to `LanguageIcons.forExtension`.
+ *
+ * That `when` was a second copy of the extension list living in the adjacent file,
+ * one of the duplicated language tables BossConsole#75 is about. It had already
+ * drifted: eleven extensions LanguageIcons has icons for were missing from it and
+ * fell through to the generic file icon, and nothing reported that.
+ *
+ * The two properties worth holding onto are that no extension LOST an icon (the
+ * old list was a strict subset) and that the explicit branches still win, because
+ * several of them deliberately disagree with the language mapping.
+ */
+class FileIconsLanguageDelegationTest {
+    private val genericFile = FileIcons.forFile("a.does-not-exist-anywhere")
+
+    @Test
+    fun `an unknown extension still falls back to the generic file icon`() {
+        // The delegation must not turn "no icon for this" into something arbitrary.
+        assertEquals(FileIcons.forFile("notes.zzzzz").icon, genericFile.icon)
+        assertEquals(FileIcons.forFile("notes.zzzzz").color, genericFile.color)
+    }
+
+    @Test
+    fun `extensions the old gate listed still resolve to their language icon`() {
+        // A spread across the branches that were removed: JVM, scripting, systems,
+        // web, and the ones whose extension differs from the language name.
+        for (name in listOf("A.kt", "a.py", "a.ts", "a.rs", "a.go", "a.rb", "a.swift", "a.dart", "a.vue", "a.hs")) {
+            val icon = FileIcons.forFile(name)
+            assertNotEquals(genericFile.icon, icon.icon, "$name lost its icon")
+        }
+    }
+
+    @Test
+    fun `the eleven extensions the old gate had drifted past now resolve too`() {
+        // These are the drift. LanguageIcons has had icons for them all along; the
+        // hand-maintained gate in FileIcons never listed them, so they rendered as
+        // a blank document while the icon existed one file away.
+        val drifted =
+            listOf(
+                "a.astro",
+                "a.eslintignore",
+                "a.eslintrc",
+                "a.gql",
+                "a.graphql",
+                "a.pom",
+                "a.prettierignore",
+                "a.prettierrc",
+                "a.prisma",
+                "a.proto",
+                "a.styl",
+            )
+        for (name in drifted) {
+            assertNotEquals(genericFile.icon, FileIcons.forFile(name).icon, "$name still falls through")
+        }
+    }
+
+    @Test
+    fun `explicit branches still override the language mapping`() {
+        // The reason the remaining `when` has to stay ahead of the delegation.
+        // Each of these is an extension LanguageIcons also knows, where FileIcons
+        // deliberately answers something else.
+        assertEquals(LanguageIcons.powershell, FileIcons.forFile("run.bat").icon)
+        assertEquals(LanguageIcons.powershell, FileIcons.forFile("run.cmd").icon)
+        assertEquals(LanguageIcons.gradle, FileIcons.forFile("build.gradle").icon)
+        assertEquals(LanguageIcons.ios, FileIcons.forFile("Info.plist").icon)
+
+        // xml, properties, ini and cfg are config documents here, not markup/source.
+        // Deliberately not pom.xml: forSpecialFileName claims that one by name
+        // before any of this runs, which is the ordering the last case pins.
+        val xml = FileIcons.forFile("data.xml")
+        assertEquals(xml.icon, FileIcons.forFile("app.properties").icon)
+        assertEquals(xml.icon, FileIcons.forFile("settings.ini").icon)
+    }
+
+    @Test
+    fun `a jar is an archive rather than Java source`() {
+        // Same override reasoning, and the one most likely to be "simplified" away
+        // because the colour is Java's while the icon is not.
+        val jar = FileIcons.forFile("app.jar")
+        assertEquals(FileIcons.forFile("app.zip").icon, jar.icon)
+        assertEquals(LanguageIcons.Colors.java, jar.color)
+    }
+
+    @Test
+    fun `special file names still win over both`() {
+        // forSpecialFileName runs before the extension logic and must stay there.
+        assertEquals(LanguageIcons.docker, FileIcons.forFile("Dockerfile").icon)
+        assertEquals(LanguageIcons.npm, FileIcons.forFile("package.json").icon)
+    }
+
+    @Test
+    fun `forExtension stays total for callers that want a fallback`() {
+        // The nullable variant is additive; the original contract is unchanged.
+        assertEquals(LanguageIcons.unknown, LanguageIcons.forExtension("zzzzz").first)
+        assertEquals(null, LanguageIcons.forExtensionOrNull("zzzzz"))
+        assertEquals(LanguageIcons.forExtensionOrNull("kt"), LanguageIcons.forExtension("kt"))
+    }
+}

--- a/plugin-platform/plugin-icons/src/desktopTest/kotlin/ai/rever/boss/plugin/icons/FileIconsLanguageDelegationTest.kt
+++ b/plugin-platform/plugin-icons/src/desktopTest/kotlin/ai/rever/boss/plugin/icons/FileIconsLanguageDelegationTest.kt
@@ -16,7 +16,8 @@ import kotlin.test.assertNotEquals
  *
  * The two properties worth holding onto are that no extension LOST an icon (the
  * old list was a strict subset) and that the explicit branches still win, because
- * several of them deliberately disagree with the language mapping.
+ * one of them (xml) deliberately disagrees with the language mapping and the rest
+ * carry icons the language table does not have.
  */
 class FileIconsLanguageDelegationTest {
     private val genericFile = FileIcons.forFile("a.does-not-exist-anywhere")
@@ -64,12 +65,12 @@ class FileIconsLanguageDelegationTest {
 
     @Test
     fun `explicit branches still override the language mapping`() {
-        // The reason the remaining `when` has to stay ahead of the delegation.
-        // Each of these is an extension LanguageIcons also knows, where FileIcons
-        // deliberately answers something else.
+        // The reason the remaining `when` has to stay ahead of the delegation. xml is the one
+        // branch that deliberately disagrees with the language mapping (a .xml is a config
+        // document, not a Maven project); bat/cmd and plist carry icons the language table does
+        // not have, and they would fall to the generic file icon if their branches were dropped.
         assertEquals(LanguageIcons.powershell, FileIcons.forFile("run.bat").icon)
         assertEquals(LanguageIcons.powershell, FileIcons.forFile("run.cmd").icon)
-        assertEquals(LanguageIcons.gradle, FileIcons.forFile("build.gradle").icon)
         assertEquals(LanguageIcons.ios, FileIcons.forFile("Info.plist").icon)
 
         // xml, properties, ini and cfg are config documents here, not markup/source.
@@ -78,6 +79,19 @@ class FileIconsLanguageDelegationTest {
         val xml = FileIcons.forFile("data.xml")
         assertEquals(xml.icon, FileIcons.forFile("app.properties").icon)
         assertEquals(xml.icon, FileIcons.forFile("settings.ini").icon)
+        // And the disagreement is real: the same contents under a .pom extension get the
+        // Maven icon through the language table, so the xml branch is load-bearing.
+        assertNotEquals(xml.icon, FileIcons.forFile("data.pom").icon)
+    }
+
+    @Test
+    fun `gradle files keep their icon through the language table`() {
+        // The old gate's explicit "gradle" branch was value-identical to LanguageIcons' own
+        // mapping, so it was the duplication this PR removes rather than an override.
+        // build.gradle is still claimed by forSpecialFileName by name; libs.gradle reaches the
+        // icon through the forExtensionOrNull delegation, which is what pins the hand-off.
+        assertEquals(LanguageIcons.gradle, FileIcons.forFile("build.gradle").icon)
+        assertEquals(LanguageIcons.gradle, FileIcons.forFile("libs.gradle").icon)
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #75, on the part #358 did not reach.

#358 consolidated the host and out-of-process language-ID tables into `LanguageIds`, which is the bulk of that issue. It did not touch the icon layer, and `FileIcons` still references `LanguageIds` zero times.

## What was duplicated

`FileIcons.forFile` gated `LanguageIcons.forExtension` behind a `when` whose **52 branches were byte-identical**:

```kotlin
"kt", "kts" -> LanguageIcons.forExtension(extension).toFileIconInfo()
"java" -> LanguageIcons.forExtension(extension).toFileIconInfo()
"py", "pyw", "pyx", "pxd", "pxi" -> LanguageIcons.forExtension(extension).toFileIconInfo()
```

The branches carry no behaviour, only a vocabulary, and that vocabulary is already declared in `LanguageIcons`' own `when` in the adjacent file. Exactly the shape #75 is about: a table you have to edit when a language is added, in a place the next author may not know about.

## It had already drifted

Which is the failure mode the issue predicts. Measured before changing anything:

- the gate routed **108** extensions, and `LanguageIcons` knows all 108, so **nothing loses an icon**
- `LanguageIcons` knows **11** the gate never listed: `astro`, `eslintignore`, `eslintrc`, `gql`, `graphql`, `pom`, `prettierignore`, `prettierrc`, `prisma`, `proto`, `styl`

Those eleven fell through to the generic file icon while a proper icon existed one file away, and nothing reported it. The gate was a strict subset, so removing it is additive rather than a behaviour swap.

## The change

`forExtensionOrNull` is the nullable variant, so a caller can ask whether an extension is recognised instead of comparing against `unknown`, which a real mapping could legitimately return. `forExtension` keeps its total contract and delegates to it.

The **19 explicit branches stay ahead of the delegation**, because they deliberately disagree with the language mapping: a `.xml` is a config document, `.bat`/`.cmd` take PowerShell's colour, `.env` is a lock, and `jar`/`war`/`ear` are archives carrying Java's colour rather than Java source. `forSpecialFileName` still runs first, which is why `pom.xml` is Maven rather than XML.

Net: 212 lines changed in `FileIcons`, 150 of them deletions.

## Tests

`FileIconsLanguageDelegationTest` pins each property that could regress: the fallback for a genuinely unknown extension, a spread of the previously gated extensions, each of the eleven that had drifted, every override that must keep winning, the jar case (the one most likely to be "simplified" away, since its colour is Java's while its icon is not), and that `forExtension` is still total.

One of those tests caught my own error while writing it: I had used `pom.xml` as the XML example, and it failed because `forSpecialFileName` claims that name first. The test now says so explicitly rather than quietly using a different file.

## Verification

- `:plugin-platform:plugin-icons:desktopTest` : **47 tests, 0 failures**
- module `ktlintCheck` and `detekt` clean
- the two existing detekt baseline entries were **rekeyed** to the renamed function, not widened. They are the pre-existing `LongMethod` and `CyclomaticComplexMethod` findings on the big `when`, which the rename unkeyed.
- `LanguageIcons.forExtension` has no callers outside this module, so the signature is unchanged for everyone else

I could not compile `:composeApp` locally to double-check downstream: it fails offline on an uncached `io.grpc:grpc-util` in `:boss-ipc`, unrelated to this change. Hosted CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Review sweep 2026-09-11 (config-matching):** rebased onto current dev (`a1c298ef6` -> `d345af841`, authorship preserved). A second commit `bbaad9938` is a maintainer comment-only cleanup (two stale section comments left by the branch removal); it is excluded from the original contribution.


**Review sweep follow-up (config-matching, after Claude review):** commit `72060f1aa` addresses the Claude review of `bbaad9938`. The explicit `"gradle"` branch was value-identical to `LanguageIcons`' own mapping (`LanguageIcons.kt:742`), i.e. it was the duplication this PR removes rather than an override, so it is dropped: non-special gradle files (e.g. `libs.gradle`) now reach the icon through the `forExtensionOrNull` delegation, which the test pins with a name `forSpecialFileName` does not claim. The old `build.gradle` assertion was actually exercising `forSpecialFileName` (it claims that name first), and the xml-vs-maven disagreement is now pinned directly (`data.xml` vs `data.pom`). Also fixed: the `// Apple property list` comment had drifted onto the wrong branch, a stray blank line at the Windows batch comment, an orphaned KDoc left by the `forExtension` rename, and one stale detekt-baseline entry (the long `png` line is a block body now). One precision note on the description above: only `xml` *disagrees* with the language mapping; the other explicit branches keep FileIcons-specific icons the language table does not carry.


Merge review: Original icon-delegation refactor and tests by @arjun28115; review-agent corrections are recorded separately above. Latest Claude review confirms all substantive findings resolved. Its remaining terminology nit is non-blocking: the explicit branches override the generic fallback as well as the sole conflicting language mapping (xml); no lookup or icon regression is present. The test KDoc accurately distinguishes these cases.
