### PR TITLE
fix(passkey): lock completed_authentications down to service_role (#528)

### DIFF
--- a/supabase/migrations/20260911000000_revoke_anon_completed_authentications.sql
+++ b/supabase/migrations/20260911000000_revoke_anon_completed_authentications.sql
@@ -1,0 +1,68 @@
+-- ============================================================================
+-- BOSS Database Schema: Lock down completed_authentications to service_role
+-- ============================================================================
+-- File: 20260911000000_revoke_anon_completed_authentications.sql
+-- Description:
+--   Removes the anon (and authenticated) access to completed_authentications.
+--   That table stores freshly minted access_token + refresh_token for the
+--   cross-device (QR) login flow, and its original policies were guarded only
+--   by `session_id IS NOT NULL` - a per-row filter that is TRUE for every real
+--   row, so it never checked that the caller actually knows a session_id.
+--
+--   Combined with `GRANT ALL ... TO anon` and the fact that the anon key is
+--   public (shipped in the desktop app; the repo is public), any client with
+--   the anon apikey could hit PostgREST directly and:
+--     - Token harvest -> account takeover:
+--         GET /rest/v1/completed_authentications?select=*
+--         returns every in-flight login's access_token / refresh_token.
+--     - DoS: DELETE /rest/v1/completed_authentications wipes all in-flight
+--         logins.
+--     - Session fixation: anon INSERT lets an attacker pre-seed a victim's
+--         session_id with the attacker's tokens.
+--
+--   This is dead code as far as the real flow is concerned. The desktop no
+--   longer touches this table directly - it polls the Edge Function
+--   (GET /passkey/auth/status/{sessionId}, service role) and writes through the
+--   Edge Function too (auth.ts checkAuthStatus / storeCompletedAuthentication).
+--   So dropping the anon/authenticated policies and revoking their grants
+--   removes the exposure without touching the only real path, service_role,
+--   which bypasses RLS.
+--
+-- Dependencies:
+--   - 20251023000013_rls_policies.sql (created the policies dropped here)
+--   - 20251023000014_grants.sql       (created the grants revoked here)
+--
+-- Test: supabase/tests/completed_authentications_lockdown_test.sql
+-- ============================================================================
+
+
+-- ----------------------------------------------------------------------------
+-- 1. Drop the anon policies (the leaking path)
+-- ----------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Anon can insert completed authentications" ON "public"."completed_authentications";
+DROP POLICY IF EXISTS "Anon can select by session_id"             ON "public"."completed_authentications";
+DROP POLICY IF EXISTS "Anon can delete by session_id"             ON "public"."completed_authentications";
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Drop the authenticated policies
+-- ----------------------------------------------------------------------------
+-- The grant below removes every authenticated privilege on this table, so these
+-- policies can never fire again. Dropping them keeps the RLS surface honest: a
+-- policy for a role that holds no table privilege is misleading dead code. Every
+-- real mutation and read of this table goes through the service_role Edge
+-- Function, never a logged-in client.
+DROP POLICY IF EXISTS "Authenticated users can insert own results" ON "public"."completed_authentications";
+DROP POLICY IF EXISTS "Authenticated users can select own results" ON "public"."completed_authentications";
+DROP POLICY IF EXISTS "Authenticated users can delete own results" ON "public"."completed_authentications";
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Revoke the table grants from anon and authenticated
+-- ----------------------------------------------------------------------------
+-- Supabase's default privileges GRANT ALL ON TABLES to anon and authenticated
+-- for schema public, and 20251023000014_grants.sql granted them explicitly too,
+-- so RLS alone is not enough - the privilege has to go as well. service_role is
+-- deliberately left untouched: it is the only real path and it bypasses RLS.
+REVOKE ALL ON TABLE "public"."completed_authentications" FROM "anon";
+REVOKE ALL ON TABLE "public"."completed_authentications" FROM "authenticated";

--- a/supabase/tests/completed_authentications_lockdown_test.sql
+++ b/supabase/tests/completed_authentications_lockdown_test.sql
@@ -1,0 +1,78 @@
+-- pgTAP tests for the completed_authentications lockdown
+-- (migration 20260911000000_revoke_anon_completed_authentications.sql).
+--
+-- completed_authentications stores freshly minted access_token + refresh_token
+-- for the cross-device (QR) login flow. Its original anon policies were guarded
+-- only by `session_id IS NOT NULL`, which is TRUE for every real row, so with
+-- the public anon apikey plus `GRANT ALL ... TO anon` any client could read
+-- every in-flight login's tokens, delete them all, or pre-seed a victim's
+-- session. The migration drops the anon and authenticated policies and revokes
+-- their grants, leaving service_role (the Edge Function path) as the only way
+-- in. RLS alone would not be enough here: the table privilege has to go too, so
+-- both halves are asserted.
+
+begin;
+select plan(6);
+
+-- ---------------------------------------------------------------------------
+-- Table grants: anon and authenticated hold nothing, service_role keeps all.
+-- ---------------------------------------------------------------------------
+select ok(
+    NOT has_table_privilege('anon', 'public.completed_authentications', 'SELECT')
+    AND NOT has_table_privilege('anon', 'public.completed_authentications', 'INSERT')
+    AND NOT has_table_privilege('anon', 'public.completed_authentications', 'UPDATE')
+    AND NOT has_table_privilege('anon', 'public.completed_authentications', 'DELETE'),
+    'anon holds no privilege on completed_authentications - the public apikey can no longer reach the tokens'
+);
+
+select ok(
+    NOT has_table_privilege('authenticated', 'public.completed_authentications', 'SELECT')
+    AND NOT has_table_privilege('authenticated', 'public.completed_authentications', 'INSERT')
+    AND NOT has_table_privilege('authenticated', 'public.completed_authentications', 'UPDATE')
+    AND NOT has_table_privilege('authenticated', 'public.completed_authentications', 'DELETE'),
+    'authenticated holds no privilege on completed_authentications either'
+);
+
+select ok(
+    has_table_privilege('service_role', 'public.completed_authentications', 'SELECT')
+    AND has_table_privilege('service_role', 'public.completed_authentications', 'INSERT')
+    AND has_table_privilege('service_role', 'public.completed_authentications', 'UPDATE')
+    AND has_table_privilege('service_role', 'public.completed_authentications', 'DELETE'),
+    'service_role keeps full access - the Edge Function path is unaffected'
+);
+
+-- ---------------------------------------------------------------------------
+-- Policies: no anon or authenticated policy survives; the service_role one does.
+-- A leftover policy for a role that holds no privilege would be misleading dead
+-- code, and a leftover anon policy would be the exact hole this migration closes
+-- if a grant were ever re-added by accident.
+-- ---------------------------------------------------------------------------
+select is(
+    (select count(*)::int from pg_policies
+      where schemaname = 'public'
+        and tablename = 'completed_authentications'
+        and 'anon' = any(roles)),
+    0,
+    'no anon policy remains on completed_authentications'
+);
+
+select is(
+    (select count(*)::int from pg_policies
+      where schemaname = 'public'
+        and tablename = 'completed_authentications'
+        and 'authenticated' = any(roles)),
+    0,
+    'no authenticated policy remains on completed_authentications'
+);
+
+select is(
+    (select count(*)::int from pg_policies
+      where schemaname = 'public'
+        and tablename = 'completed_authentications'
+        and 'service_role' = any(roles)),
+    1,
+    'the service_role policy is left intact'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Fixes #528.

`completed_authentications` holds freshly minted `access_token` + `refresh_token` for the cross-device (QR) login flow. Its **anon** policies were guarded only by `session_id IS NOT NULL` - TRUE for every real row, so effectively `USING(true)`. With the public anon key (shipped in the desktop app), that allowed:

- **Token harvest -> account takeover** via `GET /rest/v1/completed_authentications?select=*`
- **DoS** via `DELETE /rest/v1/completed_authentications`
- **Session fixation** via anon `INSERT`

The desktop no longer touches this table directly - it polls the Edge Function (`GET /passkey/auth/status/{sessionId}`, service role) and writes through it too (`auth.ts`, client built with `SUPABASE_SERVICE_ROLE_KEY`), so the anon and authenticated policies and grants are dead code.

## Changes

- **`supabase/migrations/20260911000000_revoke_anon_completed_authentications.sql`** - drops the 3 anon and 3 authenticated policies, and `REVOKE ALL` from `anon` and `authenticated`. `service_role` (which bypasses RLS) is left untouched.
- **`supabase/tests/completed_authentications_lockdown_test.sql`** - pgTAP test asserting anon/authenticated hold no privilege and no policy, while service_role keeps full access and its policy.

## Testing

Ran the migration and the committed pgTAP test against a real PostgreSQL 16.15 instance with pgTAP 1.3.3, reproducing the true pre-fix state (real `anon`/`authenticated`/`service_role` roles, the original table DDL, the 7 policies + `GRANT ALL`):

- After the migration: **6/6 pgTAP assertions pass**.
- Negative control on the pre-fix state: the anon/authenticated assertions **fail** as expected, confirming the test detects the vulnerability rather than passing vacuously.
