### PR TITLE
fix(repository): a cancelled store call is not a network failure

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoadGateRecovery.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoadGateRecovery.kt
@@ -361,8 +361,10 @@ private suspend fun publishedVersion(
     // Timing out reads as "could not be asked", which is already a state with sensible copy.
     val lookup =
         withTimeoutOrNull(STORE_LOOKUP_TIMEOUT_MS) {
-            // Both failure shapes: `getPlugin` returns `Result.failure` rather than throwing,
-            // so runCatching alone would report success with a null inside it.
+            // Both failure shapes, flattened: `getPlugin` returns `Result.failure` for store
+            // errors (and the bundled repository rethrows a caller's cancellation, which this
+            // runCatching catches) - and the `PluginRepository` interface permits either shape -
+            // so runCatching alone would report success with a null inside.
             runCatching { store.getPlugin(pluginId) }.getOrElse { Result.failure(it) }
         }
     // Null covers two different outcomes, and each gets its own line so the log distinguishes

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginStoreVersionBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginStoreVersionBridge.kt
@@ -49,10 +49,14 @@ actual object PluginStoreVersionBridge {
                 )
         // Both failure shapes, flattened. This used to be `runCatching { … }` around the call with
         // `result.getOrNull()?.getOrNull()` inside, which looked like it distinguished a broken lookup
-        // from an unpublished plugin and did not: `RemotePluginRepository.getPlugin` RETURNS
-        // `Result.failure` instead of throwing, so the inner `getOrNull()` swallowed the error, the
-        // outer `isFailure` was always false, and every failure fell through to NotPublished. A single
-        // undecodable dependency entry in a store row was reported to the user as "not published".
+        // from an unpublished plugin and did not: `getPlugin` returns `Result.failure` instead of
+        // throwing, so the inner `getOrNull()` swallowed the error, the outer `isFailure` was always
+        // false, and every failure fell through to NotPublished. A single undecodable dependency
+        // entry in a store row was reported to the user as "not published". The flatten covers both
+        // arrival shapes because the `PluginRepository` interface permits either: the bundled
+        // `RemotePluginRepository` rethrows a caller's cancellation while returning
+        // `Result.failure` for a genuine store error, and a third-party implementation may fold
+        // the cancellation into the returned `Result.failure` too.
         val lookup = runCatching { store.getPlugin(pluginId) }.getOrElse { Result.failure(it) }
         // The repository logs the detail; this only needs a line short enough to render.
         lookup.exceptionOrNull()?.let { failure ->

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -65,8 +65,10 @@ class StoreMissingDependencyInstaller(
      *
      * Cancellation is not a failure and is not swallowed: it propagates, thrown or returned, before
      * the log line, so dismissing the dialog mid-lookup does not record a store problem that did not
-     * happen. `RemotePluginRepository.getPlugin` folds a caller's cancellation into `Result.failure`,
-     * which is why the returned shape has to be handled too.
+     * happen. Both arrival shapes are handled: the bundled `RemotePluginRepository` rethrows a
+     * caller's cancellation, but the [PluginRepository] interface permits either shape - a
+     * third-party implementation may still fold it into `Result.failure` - so the returned shape
+     * is checked as well.
      */
     override suspend fun displayNameFor(pluginId: String): String? {
         val lookup = runCatching { repository()?.getPlugin(pluginId) }.getOrElse { Result.failure(it) }

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
@@ -216,7 +216,7 @@ class RemotePluginRepository(
                 )
 
                 plugins
-            }.onFailure { e ->
+            }.onStoreFailure { e ->
                 logger.error(LogCategory.NETWORK, "Failed to list remote plugins", error = e)
             }
         }
@@ -252,7 +252,7 @@ class RemotePluginRepository(
                     page = response.page,
                     pageSize = response.pageSize,
                 )
-            }.onFailure { e ->
+            }.onStoreFailure { e ->
                 logger.error(LogCategory.NETWORK, "Failed to search remote plugins", error = e)
             }
         }
@@ -266,7 +266,7 @@ class RemotePluginRepository(
 
                 val response = PluginStoreClient.getPlugin(pluginId)
                 response?.toPluginInfo()
-            }.onFailure { e ->
+            }.onStoreFailure { e ->
                 logger.error(LogCategory.NETWORK, "Failed to get remote plugin", mapOf("pluginId" to pluginId), e)
             }
         }
@@ -302,7 +302,7 @@ class RemotePluginRepository(
                         verified = response.verified,
                     )
                 }
-            }.onFailure { e ->
+            }.onStoreFailure { e ->
                 logger.error(LogCategory.NETWORK, "Failed to get plugin versions", mapOf("pluginId" to pluginId), e)
             }
         }
@@ -457,17 +457,30 @@ class RemotePluginRepository(
                     // pluginId alone — pre-existing), don't yank its flow out.
                     downloadProgress.remove(pluginId, progressFlow)
                 }
-            }.onFailure { e ->
-                // A cancellation is not a download failure, and it must not arrive as
-                // one: `runCatching` catches Throwable, so a cancelled download used to
-                // come back as Result.failure and every caller above reported it as a
-                // fault - and stopped propagating, so nobody's cancellation handler ran.
-                if (e is CancellationException) throw e
+            }.onStoreFailure { e ->
                 logger.error(LogCategory.NETWORK, "Failed to download plugin", mapOf("pluginId" to pluginId), e)
             }
         }
 
     override fun getDownloadProgress(pluginId: String): Flow<Float>? = downloadProgress[pluginId]?.asStateFlow()
+
+    /**
+     * `onFailure` for a store call, with one rule the file used to state only on [downloadPlugin]:
+     * a caller's cancellation is not a network failure and must not arrive as one.
+     *
+     * `runCatching` catches Throwable, so a cancelled request used to come back as `Result.failure`
+     * with a `CancellationException` inside, [handler] logged it at ERROR as a fault that never
+     * happened, and the caller saw a failed lookup rather than its own cancellation. Dismissing the
+     * dependency dialog while the store was slow produced one such ERROR per in-flight lookup; with
+     * a host log file those lines now survive the process, so a reader would go hunting a store
+     * outage that did not occur. Rethrowing here lets the cancellation reach the caller's own
+     * handler, which is what `withContext` would have done had nothing caught it.
+     */
+    private inline fun <T> Result<T>.onStoreFailure(handler: (Throwable) -> Unit): Result<T> =
+        onFailure { e ->
+            if (e is CancellationException) throw e
+            handler(e)
+        }
 
     override suspend fun refresh(): Result<Unit> = listPlugins().map { }
 
@@ -500,7 +513,7 @@ class RemotePluginRepository(
                         "rating" to rating,
                     ),
                 )
-            }.onFailure { e ->
+            }.onStoreFailure { e ->
                 logger.error(LogCategory.NETWORK, "Failed to rate plugin", mapOf("pluginId" to pluginId), e)
             }
         }

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
@@ -464,24 +464,6 @@ class RemotePluginRepository(
 
     override fun getDownloadProgress(pluginId: String): Flow<Float>? = downloadProgress[pluginId]?.asStateFlow()
 
-    /**
-     * `onFailure` for a store call, with one rule the file used to state only on [downloadPlugin]:
-     * a caller's cancellation is not a network failure and must not arrive as one.
-     *
-     * `runCatching` catches Throwable, so a cancelled request used to come back as `Result.failure`
-     * with a `CancellationException` inside, [handler] logged it at ERROR as a fault that never
-     * happened, and the caller saw a failed lookup rather than its own cancellation. Dismissing the
-     * dependency dialog while the store was slow produced one such ERROR per in-flight lookup; with
-     * a host log file those lines now survive the process, so a reader would go hunting a store
-     * outage that did not occur. Rethrowing here lets the cancellation reach the caller's own
-     * handler, which is what `withContext` would have done had nothing caught it.
-     */
-    private inline fun <T> Result<T>.onStoreFailure(handler: (Throwable) -> Unit): Result<T> =
-        onFailure { e ->
-            if (e is CancellationException) throw e
-            handler(e)
-        }
-
     override suspend fun refresh(): Result<Unit> = listPlugins().map { }
 
     /**
@@ -536,5 +518,23 @@ class RemotePluginRepository(
             "tab" -> ai.rever.boss.plugin.api.PluginType.TAB
             "hybrid", "mixed" -> ai.rever.boss.plugin.api.PluginType.MIXED
             else -> ai.rever.boss.plugin.api.PluginType.PANEL
+        }
+
+    /**
+     * `onFailure` for a store call, with one rule the file used to state only on [downloadPlugin]:
+     * a caller's cancellation is not a network failure and must not arrive as one.
+     *
+     * `runCatching` catches Throwable, so a cancelled request used to come back as `Result.failure`
+     * with a `CancellationException` inside, [handler] logged it at ERROR as a fault that never
+     * happened, and the caller saw a failed lookup rather than its own cancellation. Dismissing the
+     * dependency dialog while the store was slow produced one such ERROR per in-flight lookup; with
+     * a host log file those lines now survive the process, so a reader would go hunting a store
+     * outage that did not occur. Rethrowing here lets the cancellation reach the caller's own
+     * handler, which is what `withContext` would have done had nothing caught it.
+     */
+    private inline fun <T> Result<T>.onStoreFailure(handler: (Throwable) -> Unit): Result<T> =
+        onFailure { e ->
+            if (e is CancellationException) throw e
+            handler(e)
         }
 }

--- a/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepositoryCancellationTest.kt
+++ b/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepositoryCancellationTest.kt
@@ -1,0 +1,125 @@
+package ai.rever.boss.plugin.repository.remote
+
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import ai.rever.boss.plugin.logging.LogLevel
+import ai.rever.boss.plugin.repository.PluginSearchFilter
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.net.InetSocketAddress
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * A caller's cancellation of a store call must not be recorded as a network failure.
+ *
+ * `runCatching` catches Throwable, so a cancelled request used to come back as `Result.failure`
+ * carrying a `CancellationException`, and the repository logged it at ERROR under NETWORK as a fault
+ * that never happened. Dismissing the dependency dialog while the store was slow produced one such
+ * line per in-flight lookup. [RemotePluginRepository.downloadPlugin] had the fix; the other five
+ * store calls did not.
+ *
+ * Tested against a real local server that receives the request and then holds it, so the
+ * cancellation lands inside the ktor call the way it does in production, not in a fake. The
+ * observable is the log, because the caller's own `await` throws on a cancelled job either way.
+ * A positive control proves the assertion can see an ERROR when there is one.
+ *
+ * `ratePlugin` gets the same rule but is not driven here: it refuses without an access token before
+ * any request is sent, so a held server would never see it.
+ */
+class RemotePluginRepositoryCancellationTest {
+    private lateinit var server: HttpServer
+    private lateinit var received: CountDownLatch
+    private lateinit var release: CountDownLatch
+    private var status = 200
+
+    @BeforeTest
+    fun setup() {
+        received = CountDownLatch(1)
+        release = CountDownLatch(1)
+        status = 200
+        server =
+            HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+                // One context for every store path: signal that the request arrived, then hold it
+                // until the test lets go, so the cancellation is guaranteed to land mid-request.
+                createContext("/") { exchange ->
+                    received.countDown()
+                    release.await(10, TimeUnit.SECONDS)
+                    val body = "{}".toByteArray()
+                    exchange.sendResponseHeaders(status, body.size.toLong())
+                    exchange.responseBody.use { it.write(body) }
+                }
+                start()
+            }
+        PluginStoreConfig.initialize("http://127.0.0.1:${server.address.port}/functions/v1", "test-anon-key")
+        BossLogger.clearLogs()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        release.countDown()
+        server.stop(0)
+        PluginStoreConfig.clear()
+    }
+
+    private fun networkErrors(message: String) =
+        BossLogger
+            .getRecentLogs(category = LogCategory.NETWORK, minLevel = LogLevel.ERROR)
+            .filter { it.message == message }
+
+    /** Starts [call], waits until the server holds it, cancels, and asserts nothing was logged as [message]. */
+    private fun assertCancellationIsNotLogged(
+        message: String,
+        call: suspend (RemotePluginRepository) -> Unit,
+    ) = runBlocking {
+        val repository = RemotePluginRepository()
+        // Off runBlocking's own thread: the latch wait below is a blocking Java call, and a child
+        // launched on the same single-threaded loop would never start before it.
+        val job = launch(Dispatchers.IO) { call(repository) }
+
+        assertTrue(received.await(10, TimeUnit.SECONDS), "the store never received the request")
+        job.cancelAndJoin()
+        release.countDown()
+
+        val spurious = networkErrors(message)
+        assertTrue(spurious.isEmpty(), "a cancellation was logged as a network failure: $spurious")
+    }
+
+    @Test
+    fun `cancelling getPlugin is not logged as a failure`() =
+        assertCancellationIsNotLogged("Failed to get remote plugin") { it.getPlugin("some.plugin") }
+
+    @Test
+    fun `cancelling getPluginVersions is not logged as a failure`() =
+        assertCancellationIsNotLogged("Failed to get plugin versions") { it.getPluginVersions("some.plugin") }
+
+    @Test
+    fun `cancelling listPlugins is not logged as a failure`() =
+        assertCancellationIsNotLogged("Failed to list remote plugins") { it.listPlugins() }
+
+    @Test
+    fun `cancelling searchPlugins is not logged as a failure`() =
+        assertCancellationIsNotLogged("Failed to search remote plugins") {
+            it.searchPlugins(PluginSearchFilter(query = "x"))
+        }
+
+    @Test
+    fun `a real failure is still logged`() =
+        runBlocking {
+            // Positive control: the assertions above are only meaningful if this one sees the line.
+            status = 500
+            release.countDown()
+
+            val result = RemotePluginRepository().getPlugin("some.plugin")
+
+            assertTrue(result.isFailure, "a 500 must still be a failure")
+            assertTrue(networkErrors("Failed to get remote plugin").isNotEmpty(), "a real failure must still be logged")
+        }
+}

--- a/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepositoryCancellationTest.kt
+++ b/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepositoryCancellationTest.kt
@@ -5,6 +5,8 @@ import ai.rever.boss.plugin.logging.LogCategory
 import ai.rever.boss.plugin.logging.LogLevel
 import ai.rever.boss.plugin.repository.PluginSearchFilter
 import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
@@ -18,21 +20,28 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 /**
- * A caller's cancellation of a store call must not be recorded as a network failure.
+ * A caller's cancellation of a store call must not be recorded as a network failure, and it
+ * must not be swallowed into a returned `Result.failure`.
  *
  * `runCatching` catches Throwable, so a cancelled request used to come back as `Result.failure`
- * carrying a `CancellationException`, and the repository logged it at ERROR under NETWORK as a fault
- * that never happened. Dismissing the dependency dialog while the store was slow produced one such
- * line per in-flight lookup. [RemotePluginRepository.downloadPlugin] had the fix; the other five
- * store calls did not.
+ * carrying a `CancellationException`, and the repository logged it at ERROR under NETWORK as a
+ * fault that never happened. Dismissing the dependency dialog while the store was slow produced
+ * one such line per in-flight lookup, and the caller saw a failed store where there was only its
+ * own cancellation. [RemotePluginRepository.downloadPlugin] had the rule; the other five store
+ * calls did not.
  *
- * Tested against a real local server that receives the request and then holds it, so the
- * cancellation lands inside the ktor call the way it does in production, not in a fake. The
- * observable is the log, because the caller's own `await` throws on a cancelled job either way.
- * A positive control proves the assertion can see an ERROR when there is one.
+ * Every store call is tested both ways, against a real local server that receives the request
+ * and then holds it, so the cancellation lands inside the ktor call the way it does in
+ * production, not in a fake:
  *
- * `ratePlugin` gets the same rule but is not driven here: it refuses without an access token before
- * any request is sent, so a held server would never see it.
+ * 1. Log absence - the ERROR line for a store failure must not appear. A positive control
+ *    proves the assertion can see an ERROR when there is one.
+ * 2. Propagation - the repository method must throw the caller's [CancellationException] out,
+ *    not return a failed [Result]. The log assertion cannot see this half: a swallowed
+ *    cancellation and a correctly propagated one are both "no ERROR line".
+ *
+ * `ratePlugin` is the only store call that refuses before a request is sent - it requires an
+ * access token - so its two tests install a structurally valid one first; see those tests.
  */
 class RemotePluginRepositoryCancellationTest {
     private lateinit var server: HttpServer
@@ -45,6 +54,10 @@ class RemotePluginRepositoryCancellationTest {
         received = CountDownLatch(1)
         release = CountDownLatch(1)
         status = 200
+        // No executor is passed, so the JDK dispatches handlers on its own single thread. The
+        // latch design depends on that thread: the handler runs off the test's threads (the test
+        // blocks on `received`, the handler on `release`), and with exactly one request per test
+        // nothing can queue behind the held one.
         server =
             HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
                 // One context for every store path: signal that the request arrived, then hold it
@@ -92,6 +105,56 @@ class RemotePluginRepositoryCancellationTest {
         assertTrue(spurious.isEmpty(), "a cancellation was logged as a network failure: $spurious")
     }
 
+    /**
+     * Asserts that cancelling [call] propagates the caller's [CancellationException] out of the
+     * repository method, rather than the method swallowing it and returning a `Result.failure`
+     * that reads as a store fault.
+     *
+     * The deferred records whichever half actually happened: the call returning normally (the
+     * cancellation was swallowed into the returned value) or it throwing. Both branches complete
+     * before the job ends, so after [cancelAndJoin] the deferred is always complete.
+     */
+    private fun assertCancellationPropagates(call: suspend (RemotePluginRepository) -> Any?) {
+        runBlocking {
+            val repository = RemotePluginRepository()
+            val thrown = CompletableDeferred<Throwable>()
+            val job =
+                launch(Dispatchers.IO) {
+                    // runCatching, the same idiom the production methods use: success means the
+                    // cancellation was swallowed into the returned value, failure means it propagated.
+                    val result = runCatching { call(repository) }
+                    thrown.complete(
+                        if (result.isSuccess) {
+                            IllegalStateException(
+                                "the store call returned normally instead of propagating the cancellation",
+                            )
+                        } else {
+                            result.exceptionOrNull()!!
+                        },
+                    )
+                }
+
+            assertTrue(received.await(10, TimeUnit.SECONDS), "the store never received the request")
+            job.cancelAndJoin()
+            release.countDown()
+
+            val error = thrown.await()
+            assertTrue(error is CancellationException, "cancellation did not propagate out of the store call: $error")
+        }
+    }
+
+    private fun installAccessToken() {
+        // ratePlugin is the only store call that refuses before a request is sent (it requires
+        // an access token), so without one the held server would never see it. "a.b.c" is a
+        // three-part token with no admin claim: structurally valid for the client's token check
+        // and for decodeIsAdmin, and enough to get the request on the wire.
+        PluginStoreConfig.initialize(
+            "http://127.0.0.1:${server.address.port}/functions/v1",
+            "test-anon-key",
+            accessToken = "a.b.c",
+        )
+    }
+
     @Test
     fun `cancelling getPlugin is not logged as a failure`() =
         assertCancellationIsNotLogged("Failed to get remote plugin") { it.getPlugin("some.plugin") }
@@ -109,6 +172,38 @@ class RemotePluginRepositoryCancellationTest {
         assertCancellationIsNotLogged("Failed to search remote plugins") {
             it.searchPlugins(PluginSearchFilter(query = "x"))
         }
+
+    @Test
+    fun `cancelling ratePlugin is not logged as a failure`() {
+        installAccessToken()
+        assertCancellationIsNotLogged("Failed to rate plugin") { it.ratePlugin("some.plugin", 5) }
+    }
+
+    @Test
+    fun `a cancelled getPlugin propagates the caller's cancellation`() {
+        assertCancellationPropagates { it.getPlugin("some.plugin") }
+    }
+
+    @Test
+    fun `a cancelled getPluginVersions propagates the caller's cancellation`() {
+        assertCancellationPropagates { it.getPluginVersions("some.plugin") }
+    }
+
+    @Test
+    fun `a cancelled listPlugins propagates the caller's cancellation`() {
+        assertCancellationPropagates { it.listPlugins() }
+    }
+
+    @Test
+    fun `a cancelled searchPlugins propagates the caller's cancellation`() {
+        assertCancellationPropagates { it.searchPlugins(PluginSearchFilter(query = "x")) }
+    }
+
+    @Test
+    fun `a cancelled ratePlugin propagates the caller's cancellation`() {
+        installAccessToken()
+        assertCancellationPropagates { it.ratePlugin("some.plugin", 5) }
+    }
 
     @Test
     fun `a real failure is still logged`() =


### PR DESCRIPTION
## Description

`RemotePluginRepository` wraps every store call in `runCatching`, which catches `Throwable`, so a caller's cancellation came back as `Result.failure(CancellationException)` and was logged at ERROR under NETWORK as a fault that never happened. `downloadPlugin` fixed this for itself with a comment saying exactly why; the other five store calls (`listPlugins`, `searchPlugins`, `getPlugin`, `getPluginVersions`, `ratePlugin`) never got the rule.

Where it shows: dismissing the dependency dialog while the store is slow produced one such ERROR per in-flight lookup. The reviews of #429 and #483 both recorded this as pre-existing and outside those PRs; with #526 those lines now land on disk, so a reader would go looking for a store outage that did not occur.

## What changed

One private helper, `Result<T>.onStoreFailure(handler)`, that rethrows `CancellationException` and otherwise runs the handler. All six store calls use it, including `downloadPlugin`, whose inline check and comment moved onto the helper's KDoc so the rule is stated once and cannot be applied to five sites and forgotten on the sixth again. No log message, category, or metadata changed; a real failure logs exactly as before.

Behaviour for a real failure is unchanged. Behaviour for a cancellation: the exception now propagates out of `withContext`, which is what would have happened had nothing caught it. Callers that already rethrow cancellation (`displayNameFor`, `planFor`) now see the `CancellationException` directly rather than a failed `Result` wrapping one; callers without an explicit guard flatten it back the same way they flatten any thrown error, so they degrade exactly as before. That is the whole caller-visible change. The durable win is the spurious ERROR lines no longer being written, and with #526 those lines now persist, which is what made them worth removing.

## Not changed, same bug family (deliberately out of scope)

The same fold-then-swallow pattern survives at these call sites. None of them writes a network ERROR on a cancellation anymore once the repository rethrows (that is the win this PR removes); each is named here so this PR is not read as covering them:

- `StoreMissingDependencyInstaller.installFromStore` - flattens a thrown cancellation and logs `Store lookup failed for a missing dependency` at ERROR under SYSTEM.
- `PluginStoreVersionBridge.lookup` - flattens it into an `Unavailable` result ("could not reach the store").
- `PluginRepositoryManager.getPlugin` - funnels a thrown cancellation into `PluginLookupException`.
- `PluginStoreClient.checkHealth` - `catch (_: Exception)` swallows it as `false`.

Each needs the same one-line rule when it is next touched.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests

## Version Impact
- [x] Patch version

## Testing

- `RemotePluginRepositoryCancellationTest` (11). Behavioural, not source-regex: a real local `HttpServer` receives the request and holds it, the test cancels the calling job mid-request.
  - Log absence (5, one per store call): `BossLogger.getRecentLogs(NETWORK, ERROR)` carries no entry for that call. `ratePlugin` is driven too - it is the only store call that refuses before a request is sent, so its test installs a structurally valid access token first (`a.b.c`, a three-part token with no admin claim: enough to get the request on the wire, nothing more).
  - Propagation (5, one per store call): a `CompletableDeferred` records whether the method threw or returned normally; the assertion demands a `CancellationException` out of the method. The log assertion alone cannot see this half: a swallowed cancellation is also "no ERROR line".
  - Positive control (1): a 500 from the same server must still produce a failed `Result` and the ERROR line, and must have reached the server, so the negative assertions cannot pass vacuously.
  - The ten negative tests fail against the previous code and pass with the fix (the log tests were verified by the author before the rebase; the propagation tests fail by construction there, since a swallowed cancellation returns normally, which the assertion rejects).
- The rest of `plugin-repository` green; `ktlintCheck` and `detekt` clean; `:plugin-platform:plugin-api-core:desktopTest` (`ApiPackageDivergenceTest`) green, since `ai.rever.boss.plugin.repository` may be api-duplicated and I did not want to learn that from CI a second time; `:composeApp:compileKotlinDesktop` green.
- Manual: not exercised in the app; a fork build has no store credentials, so the repository is never constructed with a live store here. The test is the closest thing to the production path available on a fork.

## Related
- #429 and #483, whose reviews named this as pre-existing and outside scope
- #526, which makes these ERROR lines persistent, and therefore worth being true

## Review Focus Areas
- [x] Logic and Algorithm: that rethrowing from inside `onFailure` reaches the caller as a cancellation, and that no non-cancellation path changed

## Pre-merge Checklist
- [x] Rebased on latest dev (b39c756f2)
- [x] One fix commit (plus review follow-ups), builds and passes on its own
- [x] No em-dashes in added prose