### PR TITLE
Add authenticated BOSS AI edge provider with model allowances

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,9 +394,13 @@ jobs:
   database-tests:
     name: 🧪 Database (pgTAP)
     runs-on: ubuntu-latest
-    needs: version-check
+    needs: [version-check, boss-ai-tests]
+    if: always() && needs.version-check.result == 'success'
 
     steps:
+      - name: Require BOSS AI contract checks
+        run: test "${{ needs.boss-ai-tests.result }}" = "success"
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v7
 
@@ -417,13 +421,17 @@ jobs:
       - name: 🧪 Run pgTAP RBAC tests
         run: supabase test db
 
+      - name: Verify BOSS AI admission across PostgreSQL sessions
+        timeout-minutes: 2
+        run: python3 scripts/test/test-boss-ai-concurrency.py
+
       - name: 🧹 Stop Supabase
         if: always()
         run: supabase stop --no-backup || true
 
   build-summary:
     if: always()
-    needs: [version-check, build-test, code-quality, compatibility-test, database-tests]
+    needs: [version-check, build-test, code-quality, compatibility-test, database-tests, boss-ai-tests]
     runs-on: ubuntu-latest
 
     steps:
@@ -443,14 +451,16 @@ jobs:
           echo "- **Code Quality**: ${{ needs.code-quality.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Compatibility Test**: ${{ needs.compatibility-test.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Database (pgTAP)**: ${{ needs.database-tests.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **BOSS AI contracts**: ${{ needs.boss-ai-tests.result }}" >> $GITHUB_STEP_SUMMARY
 
           # Overall status
-          if [[ "${{ needs.build-test.result }}" == "success" && "${{ needs.code-quality.result }}" == "success" && "${{ needs.compatibility-test.result }}" == "success" && "${{ needs.database-tests.result }}" == "success" ]]; then
+          if [[ "${{ needs.build-test.result }}" == "success" && "${{ needs.code-quality.result }}" == "success" && "${{ needs.compatibility-test.result }}" == "success" && "${{ needs.database-tests.result }}" == "success" && "${{ needs.boss-ai-tests.result }}" == "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "🎉 **Overall Status**: ✅ SUCCESS" >> $GITHUB_STEP_SUMMARY
           else
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "❌ **Overall Status**: FAILED" >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
 
 # Temporarily disabled for debugging

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,6 +380,17 @@ jobs:
           
           echo "✅ Auto-update integration test passed"
 
+  boss-ai-tests:
+    name: BOSS AI contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - run: deno task check && deno task test
+        working-directory: supabase/functions/boss-ai
+
   database-tests:
     name: 🧪 Database (pgTAP)
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,7 +395,7 @@ jobs:
     name: 🧪 Database (pgTAP)
     runs-on: ubuntu-latest
     needs: [version-check, boss-ai-tests]
-    if: always() && needs.version-check.result == 'success'
+    if: ${{ !cancelled() && needs.version-check.result == 'success' }}
 
     steps:
       - name: Require BOSS AI contract checks
@@ -430,7 +430,7 @@ jobs:
         run: supabase stop --no-backup || true
 
   build-summary:
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [version-check, build-test, code-quality, compatibility-test, database-tests, boss-ai-tests]
     runs-on: ubuntu-latest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,6 +415,17 @@ taking `first().replacementDisplayName` told the user their panel moved somewher
 
 ## Configuration
 
+### Shared managed AI providers
+
+`supabase/functions/boss-ai` serves multiple configured models through one
+authenticated endpoint. Configuration and accounting tables are service-role-only;
+every inference rechecks live per-model permissions and atomically reserves usage.
+The host's `boss-ai` broker is a fixed trust boundary, not a provider preset.
+Provider discovery is owned by Secret Manager's shared vault definitions.
+See `supabase/functions/boss-ai/README.md` for deployment and accounting semantics.
+Do not put upstream credentials in the shared definition or accept caller-selected
+broker URLs. Plugin bundling is intentionally separate.
+
 Create `local.properties`:
 ```properties
 jxbrowser.license.key=<your-license-key>

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/llm/CredentialBrokers.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/llm/CredentialBrokers.kt
@@ -50,6 +50,7 @@ internal data class CredentialBroker(
  * each carrying its own copy of the URL.
  */
 internal object CredentialBrokers {
+    const val BOSS_AI: String = "boss-ai"
     const val RISA_GLM: String = "risa-glm"
 
     private const val RISA_TOKEN_URL = "https://llm.risa.inc/auth/token"
@@ -60,6 +61,12 @@ internal object CredentialBrokers {
 
     fun all(): List<CredentialBroker> =
         listOf(
+            CredentialBroker(
+                id = BOSS_AI,
+                displayName = "BOSS AI",
+                tokenUrl = "https://api.risaboss.com/functions/v1/boss-ai/auth/token",
+                scopedTo = "https://api.risaboss.com/functions/v1/boss-ai/v1",
+            ),
             CredentialBroker(
                 id = RISA_GLM,
                 displayName = "RISA Codex GLM",

--- a/scripts/test/test-boss-ai-concurrency.py
+++ b/scripts/test/test-boss-ai-concurrency.py
@@ -1,0 +1,71 @@
+"""Two independent PostgreSQL sessions against CI's disposable local Supabase DB.
+
+The first transaction remains open until pg_stat_activity proves the second is
+waiting on the advisory lock. No timing sleep is used as evidence of serialization.
+"""
+import json
+import subprocess
+import time
+
+PSQL = ["docker", "exec", "-i", "supabase_db_boss-main", "psql", "-XqAt",
+        "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1"]
+USER = "bc000000-0000-4000-8000-000000000001"
+FIRST = "bd000000-0000-4000-8000-000000000001"
+SECOND = "bd000000-0000-4000-8000-000000000002"
+
+
+def query(sql):
+    return subprocess.check_output(PSQL + ["-c", sql], text=True, timeout=15).strip()
+
+
+first = second = None
+try:
+    query(f"""
+      INSERT INTO auth.users(id,email) VALUES('{USER}','boss-ai-concurrency@pgtap.test');
+      INSERT INTO public.boss_ai_connections VALUES
+        ('concurrency-test','https://example.com/v1','BOSS_AI_TEST','openai_chat',true);
+      INSERT INTO public.boss_ai_models
+        (id,display_name,connection_id,upstream_model,context_length,max_output_tokens,published)
+        VALUES('concurrency-test','Test','concurrency-test','private',1024,128,true);
+      INSERT INTO public.boss_ai_allowances VALUES('concurrency-test','ai.use',1024,1024,1024,2);
+    """)
+    first = subprocess.Popen(PSQL, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, text=True, bufsize=1)
+    first.stdin.write(f"BEGIN; SET LOCAL statement_timeout='10s';\n"
+                      f"SELECT public.boss_ai_reserve('{USER}','concurrency-test','{FIRST}');\n")
+    first.stdin.flush()
+    # readline is bounded by the server's statement timeout and the CI step timeout.
+    admitted = json.loads(first.stdout.readline())
+    assert "model" in admitted, admitted
+    second = subprocess.Popen(PSQL + ["-c",
+        f"SET statement_timeout='10s'; SELECT public.boss_ai_reserve('{USER}','concurrency-test','{SECOND}');"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    deadline = time.monotonic() + 5
+    blocked = False
+    while time.monotonic() < deadline:
+        blocked = query(f"""SELECT EXISTS(SELECT 1 FROM pg_stat_activity
+          WHERE pid <> pg_backend_pid() AND query LIKE '%{SECOND}%'
+            AND wait_event_type='Lock' AND wait_event='advisory')""") == "t"
+        if blocked or second.poll() is not None:
+            break
+        time.sleep(0.05)
+    assert blocked, "Second session did not wait on the reservation lock"
+    _, error = first.communicate("COMMIT;\n\\q\n", timeout=15)
+    assert first.returncode == 0, error
+    output, error = second.communicate(timeout=15)
+    assert second.returncode == 0, error
+    assert json.loads(output)["error"] == "allowance_exceeded", output
+    assert query(f"SELECT sum(charged_tokens) FROM public.boss_ai_requests WHERE user_id='{USER}'") == "1024"
+    print("PASS: concurrent sessions serialize admission and cannot overspend the allowance")
+finally:
+    for process in [first, second]:
+        if process and process.poll() is None:
+            process.kill()
+            process.communicate(timeout=15)
+    query(f"""
+      DELETE FROM public.boss_ai_requests WHERE user_id='{USER}';
+      DELETE FROM public.boss_ai_allowances WHERE model_id='concurrency-test';
+      DELETE FROM public.boss_ai_models WHERE id='concurrency-test';
+      DELETE FROM public.boss_ai_connections WHERE id='concurrency-test';
+      DELETE FROM auth.users WHERE id='{USER}';
+    """)

--- a/scripts/test/test-boss-ai-concurrency.py
+++ b/scripts/test/test-boss-ai-concurrency.py
@@ -5,9 +5,14 @@ waiting on the advisory lock. No timing sleep is used as evidence of serializati
 """
 import json
 import subprocess
+import sys
 import time
+import tomllib
+from pathlib import Path
 
-PSQL = ["docker", "exec", "-i", "supabase_db_boss-main", "psql", "-XqAt",
+with (Path(__file__).resolve().parents[2] / "supabase/config.toml").open("rb") as config:
+    project_id = tomllib.load(config)["project_id"]
+PSQL = ["docker", "exec", "-i", f"supabase_db_{project_id}", "psql", "-XqAt",
         "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1"]
 USER = "bc000000-0000-4000-8000-000000000001"
 FIRST = "bd000000-0000-4000-8000-000000000001"
@@ -29,6 +34,11 @@ try:
         VALUES('concurrency-test','Test','concurrency-test','private',1024,128,true);
       INSERT INTO public.boss_ai_allowances VALUES('concurrency-test','ai.use',1024,1024,1024,2);
     """)
+    for isolation in ["REPEATABLE READ", "SERIALIZABLE"]:
+        rejected = subprocess.run(PSQL + ["-c",
+            f"BEGIN ISOLATION LEVEL {isolation}; SELECT public.boss_ai_reserve('{USER}','concurrency-test','{FIRST}');"],
+            capture_output=True, text=True, timeout=15)
+        assert rejected.returncode != 0 and "requires READ COMMITTED" in rejected.stderr, rejected.stderr
     first = subprocess.Popen(PSQL, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, text=True, bufsize=1)
     first.stdin.write(f"BEGIN; SET LOCAL statement_timeout='10s';\n"
@@ -58,14 +68,21 @@ try:
     assert query(f"SELECT sum(charged_tokens) FROM public.boss_ai_requests WHERE user_id='{USER}'") == "1024"
     print("PASS: concurrent sessions serialize admission and cannot overspend the allowance")
 finally:
-    for process in [first, second]:
-        if process and process.poll() is None:
-            process.kill()
-            process.communicate(timeout=15)
-    query(f"""
+    original_failure = sys.exc_info()[0] is not None
+    try:
+        for process in [first, second]:
+            if process and process.poll() is None:
+                process.kill()
+                process.communicate(timeout=15)
+        query(f"""
+      SET statement_timeout='5s'; SET lock_timeout='3s';
       DELETE FROM public.boss_ai_requests WHERE user_id='{USER}';
       DELETE FROM public.boss_ai_allowances WHERE model_id='concurrency-test';
       DELETE FROM public.boss_ai_models WHERE id='concurrency-test';
       DELETE FROM public.boss_ai_connections WHERE id='concurrency-test';
       DELETE FROM auth.users WHERE id='{USER}';
-    """)
+        """)
+    except Exception:
+        if not original_failure:
+            raise
+        print("Cleanup also failed; preserving the original test failure. Discard this disposable DB.", file=sys.stderr)

--- a/scripts/test/test-boss-ai-concurrency.py
+++ b/scripts/test/test-boss-ai-concurrency.py
@@ -27,13 +27,15 @@ first = second = None
 try:
     query(f"""
       INSERT INTO auth.users(id,email) VALUES('{USER}','boss-ai-concurrency@pgtap.test');
-      INSERT INTO public.boss_ai_connections VALUES
+      INSERT INTO public.boss_ai_connections(id,base_url,api_key_secret,api_type,enabled) VALUES
         ('concurrency-test','https://example.com/v1','BOSS_AI_TEST','openai_chat',true);
       INSERT INTO public.boss_ai_models
         (id,display_name,connection_id,upstream_model,context_length,max_output_tokens,published)
         VALUES('concurrency-test','Test','concurrency-test','private',1024,128,true);
-      INSERT INTO public.boss_ai_allowances VALUES('concurrency-test','ai.use',1024,1024,1024,2);
+      INSERT INTO public.boss_ai_allowances(model_id,permission_name,tokens_per_day,tokens_per_week,tokens_per_month,max_concurrent)
+        VALUES('concurrency-test','ai.use',1024,1024,1024,2);
     """)
+    assert query(f"SELECT public.user_has_permission('{USER}','ai.use')") == "t", "Baseline AI role grant missing"
     for isolation in ["REPEATABLE READ", "SERIALIZABLE"]:
         rejected = subprocess.run(PSQL + ["-c",
             f"BEGIN ISOLATION LEVEL {isolation}; SELECT public.boss_ai_reserve('{USER}','concurrency-test','{FIRST}');"],

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -404,6 +404,14 @@ enabled = true
 verify_jwt = false
 import_map = "./functions/organisation/deno.json"
 entrypoint = "./functions/organisation/index.ts"
+
+[functions.boss-ai]
+enabled = true
+# The handler validates BOSS sessions at /auth/token and its own audience-scoped
+# credentials everywhere else. Supabase's default JWT verifier cannot verify both.
+verify_jwt = false
+import_map = "./functions/boss-ai/deno.json"
+entrypoint = "./functions/boss-ai/index.ts"
 # Specifies static files to be bundled with the function. Supports glob patterns.
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/redirect/*.html" ]

--- a/supabase/functions/boss-ai/README.md
+++ b/supabase/functions/boss-ai/README.md
@@ -7,9 +7,10 @@ cannot be changed by a share.
 
 ## Deployment
 
-1. Apply `20260912000000_boss_ai.sql`.
+1. Apply `20260912000000_boss_ai.sql` and `20260912001000_boss_ai_hardening.sql`.
 2. Set `BOSS_AI_SIGNING_SECRET` to at least 32 random bytes (encoded as a string). Set upstream API
-   keys as secrets named `BOSS_AI_<NAME>`. Never put these keys in a shared vault entry. Supabase
+   keys as secrets named `BOSS_AI_<NAME>`. The signing-secret name is explicitly prohibited as an
+   upstream key in both SQL and the handler. Never put these keys in a shared vault entry. Supabase
    supplies its URL and service-role key.
 3. Deploy `boss-ai` using this repository's `supabase/config.toml`. `verify_jwt=false` is required
    because the handler verifies two distinct credentials: BOSS sessions on `/auth/token`, AI-scoped
@@ -22,6 +23,14 @@ cannot be changed by a share.
    editing control.
 6. Install a host build with the broker registration and the updated Secret Manager plugin. Existing
    AI Gateway Chat Completions transport is sufficient.
+
+The integration audit checked AI Gateway's `OpenAiChatFormat.buildPayload` in `WireFormat.kt`:
+`model`, `max_tokens`, optional temperature, streaming with usage, tools, and complete message/tool
+history all fit the allowlist. This is a constrained Chat Completions surface, not a promise to
+support every OpenAI parameter. Unknown top-level fields and function/format/image envelopes are
+rejected; JSON Schema contents remain opaque schema data. `reasoning` is descriptive metadata for
+models that reason internally, not an exposed reasoning-effort control. Reasoning usage remains
+included in the output count regardless of that metadata.
 
 No migration publishes a made-up model, invents an API key, or picks an allowance. Those are
 required deployment inputs. Plugin bundling is outside this change.
@@ -101,12 +110,27 @@ trusting client token estimates. It means a request needs that much remaining ca
 eventual usage is small. Set context limits and allowances together. Actual provider-reported input
 plus output tokens replace the reservation on settlement; reasoning is already included in output
 and is not counted twice. Unknown or interrupted outcomes retain the full charge. A rejected
-pre-inference request releases it.
+pre-inference request releases it. Known validation, authentication and billing rejections
+(including OpenRouter 402) are refunded. Fetch rejection, timeout, 408/409 and upstream 5xx remain
+unknown: response headers arriving is not evidence of when inference began, and a proxy can fail
+after forwarding work. Refunding these automatically would allow cancelled requests to evade quotas.
+This intentionally favors a strict spend bound over automatic outage refunds. Operators can inspect
+the request ledger for an audited correction; clients cannot refund themselves.
+
+Missing usage emits `usage_unknown_reservation_retained`; it is never silently treated as zero.
+Published connections must pass both streaming and non-streaming usage checks before rollout. An
+upstream reporting more than the configured context emits `usage_exceeds_configured_context`, and
+the charge is capped at the admitted reservation. A retry of settlement preserves measured usage
+rather than converting it into an unknown outcome. Investigate either diagnostic before continuing
+to publish the connection.
 
 Requests are limited to four minutes, below the five-minute concurrency lease. A worker crash leaves
 the charge in place but releases its concurrency slot after the lease. Usage rows should be retained
-for accounting; archival must preserve all rows contributing to any current period. Missing usage is
-never treated as zero. `/usage` returns model allowances, usage and reset timestamps.
+for accounting; archival must preserve all rows contributing to any current period. Deleting an
+account intentionally cascades its usage rows. `/v1/usage` returns
+`{object:"list",data:[{model,
+allowance}]}`, including UTC reset timestamps; it is inside the same
+broker scope as `/v1/models`.
 
 | State                                              | Admission/accounting behavior                              |
 | -------------------------------------------------- | ---------------------------------------------------------- |
@@ -124,22 +148,32 @@ copied token may remain usable until expiry; this mechanism authenticates a BOSS
 the executable making the request. Live permissions and bans are checked on catalog/inference
 requests. App attestation and device-bound signing are not implemented.
 
-No inference content or credentials are logged. Errors use owned messages. The only error log
-contains a request UUID when settlement fails; the reserved charge remains in the database. No
-automatic cross-provider fallback is enabled.
+No inference content or credentials are logged. Errors use owned messages. Diagnostics contain only
+owned event/phase names, numeric upstream statuses, request UUIDs, and validated database SQLSTATE
+codes, never exception messages, SQL parameters or upstream bodies. Every response carries
+`X-Request-ID`. No automatic cross-provider fallback is enabled.
 
 ## Verification
 
 Run `deno task check` and `deno task test` in this directory. The database test runs the migration
 in PostgreSQL/WASM with an auth/RBAC fixture, including grants, permission revocation, duplicate
-requests, concurrent-slot limits, allowance aggregation and settlement. It does not emulate separate
-concurrent database sessions; test that deployment behavior against staging PostgreSQL before
-launch.
+requests, concurrent-slot limits, allowance aggregation and settlement. CI also runs
+`supabase/tests/boss_ai_test.sql` against the complete migrated Supabase/RBAC schema, covering real
+service-role access, denied client grants, bans, connection revocation, lease expiry and UTC period
+boundaries. `scripts/test/test-boss-ai-concurrency.py` holds one PostgreSQL transaction open while
+proving a second session waits on the advisory lock, then verifies it cannot overspend.
+
+SSE requires the protocol's completed event (`[DONE]` for Chat Completions) and complete data
+frames. A non-null finish reason alone is not enough: usage can arrive in a subsequent chunk.
+Trailing comments are harmless, but partial data frames are failures. Browser CORS and desktop
+executable attestation are intentionally not supplied. Production gateway rate limits should also
+cover `/auth/token`; authenticated model quotas are not a substitute for HTTP abuse protection.
 
 Wire contracts were checked against:
 
 - https://developers.openai.com/api/docs/guides/function-calling
 - https://developers.openai.com/api/docs/guides/streaming-responses
+- https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/retrieve
 - https://supabase.com/docs/guides/functions/limits
 
 Live upstream compatibility, project migrations, and the real role-sharing flow still require

--- a/supabase/functions/boss-ai/README.md
+++ b/supabase/functions/boss-ai/README.md
@@ -1,0 +1,146 @@
+# Managed BOSS AI
+
+The function owns inference routing, authorization and per-user/model allowances. Secret Manager
+discovers the provider from a shared vault definition. It does not ship a BOSS AI provider entry or
+an upstream API key. The host registers only the trusted `boss-ai` credential broker, whose endpoint
+cannot be changed by a share.
+
+## Deployment
+
+1. Apply `20260912000000_boss_ai.sql`.
+2. Set `BOSS_AI_SIGNING_SECRET` to at least 32 random bytes (encoded as a string). Set upstream API
+   keys as secrets named `BOSS_AI_<NAME>`. Never put these keys in a shared vault entry. Supabase
+   supplies its URL and service-role key.
+3. Deploy `boss-ai` using this repository's `supabase/config.toml`. `verify_jwt=false` is required
+   because the handler verifies two distinct credentials: BOSS sessions on `/auth/token`, AI-scoped
+   tokens elsewhere.
+4. Configure one or more connections, models, and permission allowances using the SQL editor or
+   service-role administration. No client role can read/write these tables or impersonate a user
+   through the accounting RPCs.
+5. Create the shared definition below in Secret Manager and share it read-only with the baseline
+   `user` role. Only an administrator with role-sharing permission can do this. The owner retains
+   editing control.
+6. Install a host build with the broker registration and the updated Secret Manager plugin. Existing
+   AI Gateway Chat Completions transport is sufficient.
+
+No migration publishes a made-up model, invents an API key, or picks an allowance. Those are
+required deployment inputs. Plugin bundling is outside this change.
+
+## Shared vault definition
+
+Create a normal secret with website/name `BOSS AI`, username `BOSS sign-in`, password
+`Managed by BOSS` (an inert placeholder, never used as a credential), tag `ai-provider-definition`,
+and these notes:
+
+```json
+{
+  "schema": "boss-managed-provider-v1",
+  "name": "BOSS AI",
+  "brokerId": "boss-ai",
+  "baseUrl": "https://api.risaboss.com/functions/v1/boss-ai/v1",
+  "defaultForNewUsers": true
+}
+```
+
+The provider identity is derived from the secret's UUID, so renaming the shared entry does not lose
+selections. Users' model choices are local preferences and never modify the shared definition. A
+shared note can reference only a broker known to the host and endpoints within that broker's
+declared scope. A forged share cannot send a login token or a broker credential to an arbitrary URL.
+
+Share with `user` to distribute to everyone, or use existing user/role/organisation sharing for
+narrower distribution. Availability of a definition and permission to spend on a model are separate:
+inference always rechecks the model's live policy. The `ai.use` permission is granted to the
+baseline user role by the migration. Additional allowance permissions use the existing RBAC
+administration.
+
+## Server configuration example
+
+This is a template, not an automatically applied seed. Replace the upstream model and all limits
+with the approved production values; verify capabilities against the actual endpoint before setting
+`published=true`.
+
+```sql
+INSERT INTO public.boss_ai_connections
+  (id, base_url, api_key_secret, api_type)
+VALUES ('openrouter', 'https://openrouter.ai/api/v1',
+        'BOSS_AI_OPENROUTER', 'openai_chat');
+
+INSERT INTO public.boss_ai_models
+  (id, display_name, connection_id, upstream_model, capabilities,
+   context_length, max_output_tokens, published, is_default)
+VALUES ('boss-general', 'BOSS General', 'openrouter', '<upstream-model-id>',
+        ARRAY['text','tools'], 32768, 4096, false, true);
+
+INSERT INTO public.boss_ai_allowances
+  (model_id, permission_name, tokens_per_day, tokens_per_week, tokens_per_month)
+VALUES ('boss-general', 'ai.use', 100000, 500000, 2000000);
+```
+
+Repeat the model and allowance inserts to publish multiple models. Connections may use `openai_chat`
+or `openai_responses`; the base URL includes the API version prefix, not `/chat/completions` or
+`/responses`. Modify mappings in a transaction; each admitted request keeps its captured routing
+configuration. Unpublish to stop new requests. In-flight requests are allowed to finish.
+
+The Responses adapter translates client function calls, results, structured output and SSE events
+to/from Chat Completions. It requests `store=false` and disables Responses truncation. No
+upstream-hosted tools, conversation IDs, client-selected providers, redirects, or arbitrary request
+extensions are forwarded. Vision accepts inline PNG/JPEG/WebP images, not remote image URLs. The
+endpoint must enforce the configured context limit; this is part of the upstream contract, not an
+assertion inferred from a model name.
+
+## Allowance semantics
+
+For each model, use the maximum allowance from matching permissions for each period, never the sum.
+Every configured period applies. Days, ISO weeks starting Monday, and months reset at their UTC
+calendar boundaries. Usage belongs to the request's admission period and is never reset by a
+permission change.
+
+Admission reserves the model's entire configured context allowance, including input, output and
+reasoning. This conservative bound works across upstream tokenizers and inline images without
+trusting client token estimates. It means a request needs that much remaining capacity even if its
+eventual usage is small. Set context limits and allowances together. Actual provider-reported input
+plus output tokens replace the reservation on settlement; reasoning is already included in output
+and is not counted twice. Unknown or interrupted outcomes retain the full charge. A rejected
+pre-inference request releases it.
+
+Requests are limited to four minutes, below the five-minute concurrency lease. A worker crash leaves
+the charge in place but releases its concurrency slot after the lease. Usage rows should be retained
+for accounting; archival must preserve all rows contributing to any current period. Missing usage is
+never treated as zero. `/usage` returns model allowances, usage and reset timestamps.
+
+| State                                              | Admission/accounting behavior                              |
+| -------------------------------------------------- | ---------------------------------------------------------- |
+| Missing/invalid BOSS login                         | Token exchange returns 401                                 |
+| Wrong audience, expired or forged AI credential    | No catalog or inference access                             |
+| Permission revoked, user banned, model unpublished | New inference returns 403                                  |
+| Multiple active requests                           | Atomic per-user/model reservation prevents double spending |
+| Client disconnected / worker interrupted           | Full reservation retained                                  |
+| Successful result with usage                       | Charge input plus output once                              |
+| Retried settlement                                 | First settlement wins                                      |
+| Role allowance reduced                             | Existing usage survives; further requests may be refused   |
+
+AI credentials last five minutes and renew automatically. BOSS sign-out clears the client cache. A
+copied token may remain usable until expiry; this mechanism authenticates a BOSS-issued session, not
+the executable making the request. Live permissions and bans are checked on catalog/inference
+requests. App attestation and device-bound signing are not implemented.
+
+No inference content or credentials are logged. Errors use owned messages. The only error log
+contains a request UUID when settlement fails; the reserved charge remains in the database. No
+automatic cross-provider fallback is enabled.
+
+## Verification
+
+Run `deno task check` and `deno task test` in this directory. The database test runs the migration
+in PostgreSQL/WASM with an auth/RBAC fixture, including grants, permission revocation, duplicate
+requests, concurrent-slot limits, allowance aggregation and settlement. It does not emulate separate
+concurrent database sessions; test that deployment behavior against staging PostgreSQL before
+launch.
+
+Wire contracts were checked against:
+
+- https://developers.openai.com/api/docs/guides/function-calling
+- https://developers.openai.com/api/docs/guides/streaming-responses
+- https://supabase.com/docs/guides/functions/limits
+
+Live upstream compatibility, project migrations, and the real role-sharing flow still require
+staging credentials and configured models before production rollout.

--- a/supabase/functions/boss-ai/README.md
+++ b/supabase/functions/boss-ai/README.md
@@ -7,9 +7,10 @@ cannot be changed by a share.
 
 ## Deployment
 
-1. Apply `20260912000000_boss_ai.sql`, `20260912001000_boss_ai_hardening.sql`, and
-   `20260912002000_boss_ai_validation.sql` in order. Earlier files have already been applied to the
-   preview branch; fixes are forward migrations, not edits to applied history.
+1. Apply `20260912000000_boss_ai.sql`, `20260912001000_boss_ai_hardening.sql`,
+   `20260912002000_boss_ai_validation.sql`, and `20260912003000_boss_ai_allowance_preflight.sql` in
+   order. Earlier files have already been applied to the preview branch; fixes are forward
+   migrations, not edits to applied history.
 2. Set `BOSS_AI_SIGNING_SECRET` to at least 32 random bytes (encoded as a string). Set upstream API
    keys as secrets named `BOSS_AI_<NAME>`. The signing-secret name is explicitly prohibited as an
    upstream key in both SQL and the handler. Never put these keys in a shared vault entry. Supabase
@@ -108,7 +109,9 @@ Admission rechecks current policy/configuration under its lock, and the handler 
 the admitted snapshot. Normal malformed/capability-invalid requests create no ledger rows; a
 configuration change between preflight and admission can still require a zero-charge settlement.
 Admission requires READ COMMITTED so the post-lock usage recount sees earlier admissions. Other
-transaction isolation levels are refused explicitly.
+transaction isolation levels are refused explicitly. An effective allowance smaller than the model's
+context cannot admit even one request: preflight returns `503 misconfigured_allowance`, without a
+ledger row. This is distinct from temporary quota exhaustion (`429`).
 
 For each model, use the maximum allowance from matching permissions for each period, never the sum.
 Every configured period applies. Days, ISO weeks starting Monday, and months reset at their UTC
@@ -133,7 +136,9 @@ Published connections must pass both streaming and non-streaming usage checks be
 upstream reporting more than the configured context emits `usage_exceeds_configured_context`, and
 the charge is capped at the admitted reservation. Settlement retries and late stream truncation
 after a usage frame preserve the measured count rather than treating it as unknown. Investigate
-either diagnostic before continuing to publish the connection.
+either diagnostic before continuing to publish the connection. Settlement is attempted twice; if
+both attempts fail, a successful completion is still returned and the full reservation remains
+charged. Each diagnostic event is emitted at most once per request, including across retries.
 
 Requests are limited to four minutes, below the five-minute concurrency lease. A worker crash leaves
 the charge in place but releases its concurrency slot after the lease. Usage rows should be retained
@@ -162,7 +167,9 @@ requests. App attestation and device-bound signing are not implemented.
 No inference content or credentials are logged. Errors use owned messages. Diagnostics contain only
 owned event/phase names, numeric upstream statuses, request UUIDs, and validated database SQLSTATE
 codes, never exception messages, SQL parameters or upstream bodies. Every response carries
-`X-Request-ID`. No automatic cross-provider fallback is enabled.
+`X-Request-ID`. No automatic cross-provider fallback is enabled. Routing secrets and configuration
+are private, but generated content and provider-specific choice metadata are not an
+upstream-identity anonymization boundary.
 
 ## Verification
 

--- a/supabase/functions/boss-ai/README.md
+++ b/supabase/functions/boss-ai/README.md
@@ -32,7 +32,9 @@ history all fit the allowlist. This is a constrained Chat Completions surface, n
 support every OpenAI parameter. Unknown top-level fields and function/format/image envelopes are
 rejected; JSON Schema contents remain opaque schema data. `reasoning` is descriptive metadata for
 models that reason internally, not an exposed reasoning-effort control. Reasoning usage remains
-included in the output count regardless of that metadata.
+included in the output count regardless of that metadata. Streaming always requests usage for
+accounting; `stream_options` accepts only `include_usage=true` (or an empty object), never disabling
+usage or adding vendor fields.
 
 No migration publishes a made-up model, invents an API key, or picks an allowance. Those are
 required deployment inputs. Plugin bundling is outside this change.
@@ -129,9 +131,9 @@ the request ledger for an audited correction; clients cannot refund themselves.
 Missing usage emits `usage_unknown_reservation_retained`; it is never silently treated as zero.
 Published connections must pass both streaming and non-streaming usage checks before rollout. An
 upstream reporting more than the configured context emits `usage_exceeds_configured_context`, and
-the charge is capped at the admitted reservation. A retry of settlement preserves measured usage
-rather than converting it into an unknown outcome. Investigate either diagnostic before continuing
-to publish the connection.
+the charge is capped at the admitted reservation. Settlement retries and late stream truncation
+after a usage frame preserve the measured count rather than treating it as unknown. Investigate
+either diagnostic before continuing to publish the connection.
 
 Requests are limited to four minutes, below the five-minute concurrency lease. A worker crash leaves
 the charge in place but releases its concurrency slot after the lease. Usage rows should be retained

--- a/supabase/functions/boss-ai/README.md
+++ b/supabase/functions/boss-ai/README.md
@@ -7,7 +7,9 @@ cannot be changed by a share.
 
 ## Deployment
 
-1. Apply `20260912000000_boss_ai.sql` and `20260912001000_boss_ai_hardening.sql`.
+1. Apply `20260912000000_boss_ai.sql`, `20260912001000_boss_ai_hardening.sql`, and
+   `20260912002000_boss_ai_validation.sql` in order. Earlier files have already been applied to the
+   preview branch; fixes are forward migrations, not edits to applied history.
 2. Set `BOSS_AI_SIGNING_SECRET` to at least 32 random bytes (encoded as a string). Set upstream API
    keys as secrets named `BOSS_AI_<NAME>`. The signing-secret name is explicitly prohibited as an
    upstream key in both SQL and the handler. Never put these keys in a shared vault entry. Supabase
@@ -99,6 +101,13 @@ assertion inferred from a model name.
 
 ## Allowance semantics
 
+Request validation uses a read-only, permission-filtered preflight before inserting any ledger row.
+Admission rechecks current policy/configuration under its lock, and the handler revalidates against
+the admitted snapshot. Normal malformed/capability-invalid requests create no ledger rows; a
+configuration change between preflight and admission can still require a zero-charge settlement.
+Admission requires READ COMMITTED so the post-lock usage recount sees earlier admissions. Other
+transaction isolation levels are refused explicitly.
+
 For each model, use the maximum allowance from matching permissions for each period, never the sum.
 Every configured period applies. Days, ISO weeks starting Monday, and months reset at their UTC
 calendar boundaries. Usage belongs to the request's admission period and is never reset by a
@@ -161,13 +170,24 @@ requests, concurrent-slot limits, allowance aggregation and settlement. CI also 
 `supabase/tests/boss_ai_test.sql` against the complete migrated Supabase/RBAC schema, covering real
 service-role access, denied client grants, bans, connection revocation, lease expiry and UTC period
 boundaries. `scripts/test/test-boss-ai-concurrency.py` holds one PostgreSQL transaction open while
-proving a second session waits on the advisory lock, then verifies it cannot overspend.
+proving a second session waits on the advisory lock, then verifies it cannot overspend. The same
+script refuses REPEATABLE READ/SERIALIZABLE and derives the local container name from
+`supabase/config.toml`. Run it from the repository with Python 3.11+ after `supabase start` to
+repeat the real concurrency proof locally. Use a disposable local database; a hard-killed test may
+leave fixtures, so discard that test database before retrying. Cleanup failures preserve the
+original error. The committed dependency lockfile is enforced by both Deno tasks; `check` also
+checks formatting and type-checks the test modules.
 
 SSE requires the protocol's completed event (`[DONE]` for Chat Completions) and complete data
 frames. A non-null finish reason alone is not enough: usage can arrive in a subsequent chunk.
 Trailing comments are harmless, but partial data frames are failures. Browser CORS and desktop
 executable attestation are intentionally not supplied. Production gateway rate limits should also
-cover `/auth/token`; authenticated model quotas are not a substitute for HTTP abuse protection.
+cover `/auth/token`; authenticated model quotas are not a substitute for HTTP abuse protection. This
+also applies to valid requests rejected by the upstream: refunded token reservations do not limit
+request frequency or ledger growth. Operators must configure request-rate protection before
+publishing models. A redirecting upstream URL is a configuration error with unknown inference
+outcome, so it retains the reservation just like other ambiguous fetch failures; validate the final
+URL first.
 
 Wire contracts were checked against:
 

--- a/supabase/functions/boss-ai/app.ts
+++ b/supabase/functions/boss-ai/app.ts
@@ -1,0 +1,210 @@
+import { bearer, HttpError, mintToken, signingKey, verifyToken } from "./auth.ts"
+import {
+  completion,
+  Connection,
+  endpoint,
+  events,
+  Model,
+  Obj,
+  readJson,
+  requestBody,
+  StreamAdapter,
+} from "./wire.ts"
+
+export interface Dependencies {
+  sessionUser(token: string): Promise<string | null>
+  rpc(name: string, params: Obj): Promise<unknown>
+  secret(name: string): string | undefined
+  fetch: typeof fetch
+}
+const headers = { "Content-Type": "application/json", "Cache-Control": "no-store" }
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers })
+function failure(error: unknown): Response {
+  const e = error instanceof HttpError
+    ? error
+    : new HttpError(503, "unavailable", "BOSS AI is temporarily unavailable.")
+  return json({ error: { code: e.code, message: e.message } }, e.status)
+}
+
+export function createHandler(deps: Dependencies): (request: Request) => Promise<Response> {
+  return async (request) => {
+    let reservation: string | undefined
+    let dispatched = false
+    try {
+      const path = new URL(request.url).pathname.replace(/^\/functions\/v1/, "").replace(
+        /^\/boss-ai/,
+        "",
+      )
+      const token = bearer(request)
+      const key = signingKey(deps.secret("BOSS_AI_SIGNING_SECRET"))
+      if (request.method === "POST" && path === "/auth/token") {
+        const user = await deps.sessionUser(token)
+        if (!user) throw new HttpError(401, "unauthorized", "Sign in to BOSS to use AI.")
+        return json(await mintToken(user, key))
+      }
+      const user = await verifyToken(token, key)
+      if (request.method === "GET" && (path === "/v1/models" || path === "/usage")) {
+        const data = await deps.rpc("boss_ai_catalog", { p_user_id: user })
+        return json({ object: "list", data })
+      }
+      if (request.method !== "POST" || path !== "/v1/chat/completions") {
+        throw new HttpError(404, "not_found", "Unknown BOSS AI endpoint.")
+      }
+      const input = await readJson(request.body)
+      if (typeof input.model !== "string" || !/^[a-z0-9][a-z0-9._-]{0,99}$/.test(input.model)) {
+        throw new HttpError(400, "invalid_model", "Choose a published BOSS model.")
+      }
+      const requestId = crypto.randomUUID()
+      const result = await deps.rpc("boss_ai_reserve", {
+        p_user_id: user,
+        p_model_id: input.model,
+        p_request_id: requestId,
+      }) as { error?: string; model: Model; connection: Connection }
+      if (result.error) {
+        if (result.error === "forbidden") {
+          throw new HttpError(403, "forbidden", "This model is not available for your account.")
+        }
+        if (result.error === "allowance_exceeded") {
+          throw new HttpError(
+            429,
+            result.error,
+            "Your model allowance has insufficient remaining capacity. Check BOSS AI usage for reset times.",
+          )
+        }
+        throw new HttpError(429, "busy", "Too many requests for this model. Try again shortly.")
+      }
+      reservation = requestId
+      const body = requestBody(input, result.model, result.connection.api_type)
+      const url = endpoint(result.connection)
+      const apiKey = deps.secret(result.connection.api_key_secret)
+      if (!apiKey) throw new HttpError(503, "configuration", "BOSS AI is temporarily unavailable.")
+      // Never follow redirects with an upstream credential. Only configured servers
+      // receive it; request-supplied routing and provider overrides are rejected.
+      const abort = new AbortController()
+      const cancel = () => abort.abort()
+      request.signal.addEventListener("abort", cancel, { once: true })
+      if (request.signal.aborted) abort.abort()
+      const timeout = setTimeout(cancel, 240_000)
+      const cleanup = () => {
+        clearTimeout(timeout)
+        request.signal.removeEventListener("abort", cancel)
+      }
+      let upstream: Response
+      try {
+        dispatched = true
+        upstream = await deps.fetch(url, {
+          method: "POST",
+          redirect: "error",
+          signal: abort.signal,
+          headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        })
+      } catch (e) {
+        cleanup()
+        throw e
+      }
+      if (!upstream.ok) {
+        await upstream.body?.cancel()
+        cleanup()
+        // A rejected request with a known 4xx response performed no inference.
+        if ([400, 401, 403, 404, 422, 429].includes(upstream.status)) dispatched = false
+        throw new HttpError(
+          upstream.status === 429 ? 503 : 502,
+          "upstream_error",
+          "The model is temporarily unavailable. Please try again.",
+        )
+      }
+      const settle = async (tokens: number | null) => {
+        await deps.rpc("boss_ai_settle", { p_request_id: requestId, p_tokens: tokens })
+      }
+      if (input.stream !== true) {
+        try {
+          const output = completion(
+            await readJson(upstream.body, 16 * 1024 * 1024),
+            input.model,
+            result.connection.api_type,
+            requestId,
+          )
+          const tokens = (output.usage as Obj | null)?.total_tokens
+          await settle(typeof tokens === "number" ? tokens : null)
+          reservation = undefined
+          return json(output)
+        } finally {
+          cleanup()
+        }
+      }
+      if (!upstream.body) {
+        cleanup()
+        throw new Error("Missing stream")
+      }
+      const adapter = new StreamAdapter(input.model, result.connection.api_type, requestId)
+      const iterator = events(upstream.body)[Symbol.asyncIterator]()
+      const encoder = new TextEncoder()
+      const frame = (data: unknown) =>
+        encoder.encode(`data: ${typeof data === "string" ? data : JSON.stringify(data)}\n\n`)
+      let closed = false
+      const finish = async (tokens: number | null) => {
+        if (closed) return
+        closed = true
+        abort.abort()
+        cleanup()
+        await iterator.return?.(undefined).catch(() => {})
+        // If settlement fails the full reservation remains charged. Never refund
+        // an unknown outcome merely because a worker or a client disconnected.
+        await settle(tokens).catch(() => console.error("boss-ai settlement failed", requestId))
+      }
+      reservation = undefined // The stream now owns cleanup and settlement.
+      const stream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          try {
+            const next = await iterator.next()
+            if (next.done) {
+              if (!adapter.finished) throw new Error("Truncated stream")
+              await finish(adapter.tokens)
+              controller.enqueue(frame("[DONE]"))
+              controller.close()
+              return
+            }
+            for (const chunk of adapter.accept(next.value)) controller.enqueue(frame(chunk))
+            if (adapter.finished) {
+              await finish(adapter.tokens)
+              controller.enqueue(frame("[DONE]"))
+              controller.close()
+            }
+          } catch {
+            await finish(null)
+            controller.enqueue(
+              frame({
+                error: {
+                  code: "stream_failed",
+                  message: "The model response was interrupted. Please retry.",
+                },
+              }),
+            )
+            controller.close()
+          }
+        },
+        async cancel() {
+          await finish(null)
+        },
+      })
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-store",
+          "X-Request-ID": requestId,
+        },
+      })
+    } catch (error) {
+      if (reservation) {
+        await deps.rpc("boss_ai_settle", {
+          p_request_id: reservation,
+          p_tokens: dispatched ? null : 0,
+        })
+          .catch(() => console.error("boss-ai settlement failed", reservation))
+      }
+      return failure(error)
+    }
+  }
+}

--- a/supabase/functions/boss-ai/app.ts
+++ b/supabase/functions/boss-ai/app.ts
@@ -33,7 +33,10 @@ function failure(error: unknown, requestId: string): Response {
 export function createHandler(deps: Dependencies): (request: Request) => Promise<Response> {
   return async (request) => {
     const requestId = crypto.randomUUID()
+    const auditedEvents = new Set<string>()
     const audit = (event: string) => {
+      if (auditedEvents.has(event)) return
+      auditedEvents.add(event)
       try {
         if (deps.audit) deps.audit(event, requestId)
         else console.warn(JSON.stringify({ event, request_id: requestId }))
@@ -81,9 +84,16 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
       const lookup = await deps.rpc("boss_ai_lookup", {
         p_user_id: user,
         p_model_id: input.model,
-      }) as { model: Model; connection: Connection } | null
+      }) as { error?: string; model: Model; connection: Connection } | null
       if (!lookup) {
         throw new HttpError(403, "forbidden", "This model is not available for your account.")
+      }
+      if (lookup.error) {
+        throw new HttpError(
+          503,
+          "misconfigured_allowance",
+          "This model's allowance cannot fit a request. Contact your BOSS administrator.",
+        )
       }
       requestBody(input, lookup.model, lookup.connection.api_type)
       phase = "reservation"
@@ -164,6 +174,11 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         phase = "settlement"
         await deps.rpc("boss_ai_settle", { p_request_id: requestId, p_tokens: tokens })
       }
+      const settleWithRetry = async (tokens: number | null) => {
+        await settle(tokens).catch(async () => {
+          await settle(tokens).catch(() => audit("settlement_failed"))
+        })
+      }
       if (input.stream !== true) {
         try {
           phase = "upstream_response"
@@ -178,7 +193,7 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
           )
           const tokens = (output.usage as Obj | null)?.total_tokens
           measuredTokens = typeof tokens === "number" ? tokens : null
-          await settle(measuredTokens)
+          await settleWithRetry(measuredTokens)
           reservation = undefined
           return json(output, 200, requestId)
         } finally {
@@ -204,9 +219,7 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         await iterator.return?.(undefined).catch(() => {})
         // If settlement fails the full reservation remains charged. Never refund
         // an unknown outcome merely because a worker or a client disconnected.
-        await settle(tokens).catch(async () => {
-          await settle(tokens).catch(() => audit("settlement_failed"))
-        })
+        await settleWithRetry(tokens)
       }
       reservation = undefined // The stream now owns cleanup and settlement.
       const stream = new ReadableStream<Uint8Array>({
@@ -257,11 +270,13 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
       if (!(error instanceof HttpError) || error.status >= 500) audit(`${phase}_failed`)
       if (reservation) {
         if (dispatched && measuredTokens === null) audit("usage_unknown_reservation_retained")
-        await deps.rpc("boss_ai_settle", {
+        const settlement = {
           p_request_id: reservation,
           p_tokens: dispatched ? measuredTokens : 0,
+        }
+        await deps.rpc("boss_ai_settle", settlement).catch(async () => {
+          await deps.rpc("boss_ai_settle", settlement).catch(() => audit("settlement_failed"))
         })
-          .catch(() => audit("settlement_failed"))
       }
       return failure(error, requestId)
     }

--- a/supabase/functions/boss-ai/app.ts
+++ b/supabase/functions/boss-ai/app.ts
@@ -228,7 +228,7 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
             }
           } catch {
             audit("stream_failed")
-            await finish(null)
+            await finish(adapter.tokens)
             if (clientCancelled) return
             controller.enqueue(
               frame({
@@ -243,7 +243,7 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         },
         async cancel() {
           clientCancelled = true
-          await finish(null)
+          await finish(adapter.tokens)
         },
       })
       return new Response(stream, {

--- a/supabase/functions/boss-ai/app.ts
+++ b/supabase/functions/boss-ai/app.ts
@@ -9,6 +9,7 @@ import {
   readJson,
   requestBody,
   StreamAdapter,
+  upstreamKey,
 } from "./wire.ts"
 
 export interface Dependencies {
@@ -76,6 +77,15 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
       if (typeof input.model !== "string" || !/^[a-z0-9][a-z0-9._-]{0,99}$/.test(input.model)) {
         throw new HttpError(400, "invalid_model", "Choose a published BOSS model.")
       }
+      phase = "validation"
+      const lookup = await deps.rpc("boss_ai_lookup", {
+        p_user_id: user,
+        p_model_id: input.model,
+      }) as { model: Model; connection: Connection } | null
+      if (!lookup) {
+        throw new HttpError(403, "forbidden", "This model is not available for your account.")
+      }
+      requestBody(input, lookup.model, lookup.connection.api_type)
       phase = "reservation"
       const result = await deps.rpc("boss_ai_reserve", {
         p_user_id: user,
@@ -83,6 +93,9 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         p_request_id: requestId,
       }) as { error?: string; model: Model; connection: Connection }
       if (result.error) {
+        if (result.error === "duplicate") {
+          throw new HttpError(409, "duplicate", "This request has already been admitted.")
+        }
         if (result.error === "forbidden") {
           throw new HttpError(403, "forbidden", "This model is not available for your account.")
         }
@@ -98,8 +111,7 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
       reservation = requestId
       const body = requestBody(input, result.model, result.connection.api_type)
       const url = endpoint(result.connection)
-      const apiKey = deps.secret(result.connection.api_key_secret)
-      if (!apiKey) throw new HttpError(503, "configuration", "BOSS AI is temporarily unavailable.")
+      const apiKey = upstreamKey(result.connection, deps.secret)
       // Never follow redirects with an upstream credential. Only configured servers
       // receive it; request-supplied routing and provider overrides are rejected.
       const abort = new AbortController()

--- a/supabase/functions/boss-ai/app.ts
+++ b/supabase/functions/boss-ai/app.ts
@@ -16,24 +16,35 @@ export interface Dependencies {
   rpc(name: string, params: Obj): Promise<unknown>
   secret(name: string): string | undefined
   fetch: typeof fetch
+  upstreamTimeoutMs?: number
+  audit?: (event: string, requestId: string) => void
 }
 const headers = { "Content-Type": "application/json", "Cache-Control": "no-store" }
-const json = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), { status, headers })
-function failure(error: unknown): Response {
+const json = (body: unknown, status = 200, requestId = "") =>
+  new Response(JSON.stringify(body), { status, headers: { ...headers, "X-Request-ID": requestId } })
+function failure(error: unknown, requestId: string): Response {
   const e = error instanceof HttpError
     ? error
     : new HttpError(503, "unavailable", "BOSS AI is temporarily unavailable.")
-  return json({ error: { code: e.code, message: e.message } }, e.status)
+  return json({ error: { code: e.code, message: e.message } }, e.status, requestId)
 }
 
 export function createHandler(deps: Dependencies): (request: Request) => Promise<Response> {
   return async (request) => {
+    const requestId = crypto.randomUUID()
+    const audit = (event: string) => {
+      try {
+        if (deps.audit) deps.audit(event, requestId)
+        else console.warn(JSON.stringify({ event, request_id: requestId }))
+      } catch { /* Observability must not change accounting or response cleanup. */ }
+    }
     let reservation: string | undefined
     let dispatched = false
+    let measuredTokens: number | null = null
+    let phase = "authentication"
     try {
       const path = new URL(request.url).pathname.replace(/^\/functions\/v1/, "").replace(
-        /^\/boss-ai/,
+        /^\/boss-ai(?=\/|$)/,
         "",
       )
       const token = bearer(request)
@@ -41,12 +52,22 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
       if (request.method === "POST" && path === "/auth/token") {
         const user = await deps.sessionUser(token)
         if (!user) throw new HttpError(401, "unauthorized", "Sign in to BOSS to use AI.")
-        return json(await mintToken(user, key))
+        return json(await mintToken(user, key), 200, requestId)
       }
       const user = await verifyToken(token, key)
-      if (request.method === "GET" && (path === "/v1/models" || path === "/usage")) {
+      if (request.method === "GET" && (path === "/v1/models" || path === "/v1/usage")) {
+        phase = "catalog"
         const data = await deps.rpc("boss_ai_catalog", { p_user_id: user })
-        return json({ object: "list", data })
+        return json(
+          {
+            object: "list",
+            data: path === "/v1/models"
+              ? data
+              : (data as Obj[]).map((model) => ({ model: model.id, allowance: model.allowance })),
+          },
+          200,
+          requestId,
+        )
       }
       if (request.method !== "POST" || path !== "/v1/chat/completions") {
         throw new HttpError(404, "not_found", "Unknown BOSS AI endpoint.")
@@ -55,7 +76,7 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
       if (typeof input.model !== "string" || !/^[a-z0-9][a-z0-9._-]{0,99}$/.test(input.model)) {
         throw new HttpError(400, "invalid_model", "Choose a published BOSS model.")
       }
-      const requestId = crypto.randomUUID()
+      phase = "reservation"
       const result = await deps.rpc("boss_ai_reserve", {
         p_user_id: user,
         p_model_id: input.model,
@@ -85,13 +106,17 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
       const cancel = () => abort.abort()
       request.signal.addEventListener("abort", cancel, { once: true })
       if (request.signal.aborted) abort.abort()
-      const timeout = setTimeout(cancel, 240_000)
+      const timeout = setTimeout(cancel, deps.upstreamTimeoutMs ?? 240_000)
       const cleanup = () => {
         clearTimeout(timeout)
         request.signal.removeEventListener("abort", cancel)
       }
       let upstream: Response
       try {
+        if (abort.signal.aborted) {
+          throw new HttpError(499, "cancelled", "The AI request was cancelled.")
+        }
+        phase = "upstream_dispatch"
         dispatched = true
         upstream = await deps.fetch(url, {
           method: "POST",
@@ -107,8 +132,12 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
       if (!upstream.ok) {
         await upstream.body?.cancel()
         cleanup()
-        // A rejected request with a known 4xx response performed no inference.
-        if ([400, 401, 403, 404, 422, 429].includes(upstream.status)) dispatched = false
+        // Known validation/auth/billing rejections can be refunded. A timeout or 5xx
+        // does not prove inference did not run (a proxy can fail after forwarding).
+        if ([400, 401, 402, 403, 404, 405, 406, 413, 415, 422, 429].includes(upstream.status)) {
+          dispatched = false
+        }
+        audit(`upstream_status_${upstream.status}`)
         throw new HttpError(
           upstream.status === 429 ? 503 : 502,
           "upstream_error",
@@ -116,20 +145,30 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         )
       }
       const settle = async (tokens: number | null) => {
+        if (tokens === null) audit("usage_unknown_reservation_retained")
+        if (tokens !== null && tokens > result.model.context_length) {
+          audit("usage_exceeds_configured_context")
+        }
+        phase = "settlement"
         await deps.rpc("boss_ai_settle", { p_request_id: requestId, p_tokens: tokens })
       }
       if (input.stream !== true) {
         try {
+          phase = "upstream_response"
+          const payload = await readJson(upstream.body, 16 * 1024 * 1024).catch(() => {
+            throw new HttpError(502, "upstream_error", "The model returned an invalid response.")
+          })
           const output = completion(
-            await readJson(upstream.body, 16 * 1024 * 1024),
+            payload,
             input.model,
             result.connection.api_type,
             requestId,
           )
           const tokens = (output.usage as Obj | null)?.total_tokens
-          await settle(typeof tokens === "number" ? tokens : null)
+          measuredTokens = typeof tokens === "number" ? tokens : null
+          await settle(measuredTokens)
           reservation = undefined
-          return json(output)
+          return json(output, 200, requestId)
         } finally {
           cleanup()
         }
@@ -139,11 +178,12 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         throw new Error("Missing stream")
       }
       const adapter = new StreamAdapter(input.model, result.connection.api_type, requestId)
-      const iterator = events(upstream.body)[Symbol.asyncIterator]()
+      const iterator = events(upstream.body, abort.signal)[Symbol.asyncIterator]()
       const encoder = new TextEncoder()
       const frame = (data: unknown) =>
         encoder.encode(`data: ${typeof data === "string" ? data : JSON.stringify(data)}\n\n`)
       let closed = false
+      let clientCancelled = false
       const finish = async (tokens: number | null) => {
         if (closed) return
         closed = true
@@ -152,7 +192,9 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         await iterator.return?.(undefined).catch(() => {})
         // If settlement fails the full reservation remains charged. Never refund
         // an unknown outcome merely because a worker or a client disconnected.
-        await settle(tokens).catch(() => console.error("boss-ai settlement failed", requestId))
+        await settle(tokens).catch(async () => {
+          await settle(tokens).catch(() => audit("settlement_failed"))
+        })
       }
       reservation = undefined // The stream now owns cleanup and settlement.
       const stream = new ReadableStream<Uint8Array>({
@@ -173,7 +215,9 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
               controller.close()
             }
           } catch {
+            audit("stream_failed")
             await finish(null)
+            if (clientCancelled) return
             controller.enqueue(
               frame({
                 error: {
@@ -186,6 +230,7 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
           }
         },
         async cancel() {
+          clientCancelled = true
           await finish(null)
         },
       })
@@ -197,14 +242,16 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         },
       })
     } catch (error) {
+      if (!(error instanceof HttpError) || error.status >= 500) audit(`${phase}_failed`)
       if (reservation) {
+        if (dispatched && measuredTokens === null) audit("usage_unknown_reservation_retained")
         await deps.rpc("boss_ai_settle", {
           p_request_id: reservation,
-          p_tokens: dispatched ? null : 0,
+          p_tokens: dispatched ? measuredTokens : 0,
         })
-          .catch(() => console.error("boss-ai settlement failed", reservation))
+          .catch(() => audit("settlement_failed"))
       }
-      return failure(error)
+      return failure(error, requestId)
     }
   }
 }

--- a/supabase/functions/boss-ai/auth.ts
+++ b/supabase/functions/boss-ai/auth.ts
@@ -1,0 +1,53 @@
+import { jwtVerify, SignJWT } from "jose"
+
+const issuer = "boss-ai"
+const audience = "boss-ai-inference"
+const lifetime = 300
+
+export class HttpError extends Error {
+  constructor(public status: number, public code: string, message: string) {
+    super(message)
+  }
+}
+
+export function signingKey(secret: string | undefined): Uint8Array {
+  if (!secret || new TextEncoder().encode(secret).length < 32) {
+    throw new HttpError(503, "unavailable", "BOSS AI is temporarily unavailable.")
+  }
+  return new TextEncoder().encode(secret)
+}
+
+export async function mintToken(userId: string, key: Uint8Array) {
+  const now = Math.floor(Date.now() / 1000)
+  return {
+    access_token: await new SignJWT({ scope: "inference" }).setProtectedHeader({ alg: "HS256" })
+      .setIssuer(issuer).setAudience(audience).setSubject(userId).setIssuedAt(now)
+      .setExpirationTime(now + lifetime).setJti(crypto.randomUUID()).sign(key),
+    expires_at: new Date((now + lifetime) * 1000).toISOString(),
+    refresh_after_seconds: 180,
+  }
+}
+
+export async function verifyToken(token: string, key: Uint8Array): Promise<string> {
+  try {
+    const { payload } = await jwtVerify(token, key, {
+      algorithms: ["HS256"],
+      issuer,
+      audience,
+      maxTokenAge: lifetime,
+      requiredClaims: ["sub", "exp", "iat", "jti"],
+    })
+    if (payload.scope !== "inference" || !payload.sub) throw new Error()
+    return payload.sub
+  } catch {
+    throw new HttpError(401, "unauthorized", "Sign in to BOSS to use AI.")
+  }
+}
+
+export function bearer(request: Request): string {
+  const match = /^Bearer ([^\s]+)$/i.exec(request.headers.get("authorization") ?? "")
+  if (!match || match[1].length > 16384) {
+    throw new HttpError(401, "unauthorized", "Sign in to BOSS to use AI.")
+  }
+  return match[1]
+}

--- a/supabase/functions/boss-ai/deno.json
+++ b/supabase/functions/boss-ai/deno.json
@@ -4,7 +4,10 @@
     "jose": "npm:jose@6.1.0",
     "@std/assert": "jsr:@std/assert@1.0.14"
   },
-  "tasks": { "test": "deno test --allow-env --allow-read", "check": "deno check index.ts" },
+  "tasks": {
+    "test": "deno test --frozen --allow-env --allow-read",
+    "check": "deno fmt --check && deno check --frozen index.ts tests/*.test.ts"
+  },
   "compilerOptions": { "strict": true },
   "fmt": { "semiColons": false, "lineWidth": 100 }
 }

--- a/supabase/functions/boss-ai/deno.json
+++ b/supabase/functions/boss-ai/deno.json
@@ -1,0 +1,10 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.58.0",
+    "jose": "npm:jose@6.1.0",
+    "@std/assert": "jsr:@std/assert@1.0.14"
+  },
+  "tasks": { "test": "deno test --allow-env --allow-read", "check": "deno check index.ts" },
+  "compilerOptions": { "strict": true },
+  "fmt": { "semiColons": false, "lineWidth": 100 }
+}

--- a/supabase/functions/boss-ai/deno.lock
+++ b/supabase/functions/boss-ai/deno.lock
@@ -1,0 +1,120 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1.0.14": "1.0.14",
+    "jsr:@std/internal@^1.0.10": "1.0.14",
+    "npm:@electric-sql/pglite@0.3.14": "0.3.14",
+    "npm:@supabase/supabase-js@2.58.0": "2.58.0",
+    "npm:jose@6.1.0": "6.1.0"
+  },
+  "jsr": {
+    "@std/assert@1.0.14": {
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "npm": {
+    "@electric-sql/pglite@0.3.14": {
+      "integrity": "sha512-3DB258dhqdsArOI1fIt7cb9RpUOgcDg5hXWVgVHAeqVQ/qxtFy605QKs4gx6mFq3jWsSPqDN8TgSEsqC3OfV9Q=="
+    },
+    "@supabase/auth-js@2.72.0": {
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.5.0": {
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.21.4": {
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.15.5": {
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.12.2": {
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/supabase-js@2.58.0": {
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/node-fetch",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "@types/node@26.5.1": {
+      "integrity": "sha512-CzNm2FezW4VR/LjG6yUdiEgLE/rAQ9Slj5gCu/C2VrdcW7I0ahNZ8DRbHT7zOZ6r3ONgd/bsQIeSaoDGrd1C6g==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/phoenix@1.6.7": {
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "jose@6.1.0": {
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA=="
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "undici-types@8.9.0": {
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.21.3": {
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@1.0.14",
+      "npm:@supabase/supabase-js@2.58.0",
+      "npm:jose@6.1.0"
+    ]
+  }
+}

--- a/supabase/functions/boss-ai/index.ts
+++ b/supabase/functions/boss-ai/index.ts
@@ -15,7 +15,12 @@ Deno.serve(createHandler({
   },
   async rpc(name, params) {
     const { data, error } = await client.rpc(name, params)
-    if (error) throw new Error("BOSS AI database operation failed")
+    if (error) {
+      // SQLSTATE only: PostgREST messages/details can contain input or secrets.
+      const code = /^[A-Z0-9]{5}$/.test(error.code ?? "") ? error.code : "unknown"
+      console.error(JSON.stringify({ event: "boss_ai_database_error", code }))
+      throw new Error("BOSS AI database operation failed")
+    }
     return data
   },
   secret: (name) => Deno.env.get(name),

--- a/supabase/functions/boss-ai/index.ts
+++ b/supabase/functions/boss-ai/index.ts
@@ -1,0 +1,23 @@
+import { createClient } from "@supabase/supabase-js"
+import { createHandler } from "./app.ts"
+
+const client = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  {
+    auth: { persistSession: false, autoRefreshToken: false },
+  },
+)
+Deno.serve(createHandler({
+  async sessionUser(token) {
+    const { data, error } = await client.auth.getUser(token)
+    return error || !data.user || data.user.is_anonymous ? null : data.user.id
+  },
+  async rpc(name, params) {
+    const { data, error } = await client.rpc(name, params)
+    if (error) throw new Error("BOSS AI database operation failed")
+    return data
+  },
+  secret: (name) => Deno.env.get(name),
+  fetch,
+}))

--- a/supabase/functions/boss-ai/tests/app.test.ts
+++ b/supabase/functions/boss-ai/tests/app.test.ts
@@ -1,0 +1,139 @@
+import { assert, assertEquals } from "@std/assert"
+import { createHandler } from "../app.ts"
+import { mintToken, signingKey } from "../auth.ts"
+import { Obj } from "../wire.ts"
+
+const secret = "test-signing-secret-at-least-32-bytes-long"
+async function fixture(options: { deny?: string; stream?: string; upstreamStatus?: number } = {}) {
+  const calls: { name: string; params: Obj }[] = []
+  const requests: Request[] = []
+  const token =
+    (await mintToken("00000000-0000-0000-0000-000000000001", signingKey(secret))).access_token
+  const handler = createHandler({
+    sessionUser: async (t) => t === "boss-session" ? "00000000-0000-0000-0000-000000000001" : null,
+    secret: (name) => name === "BOSS_AI_SIGNING_SECRET" ? secret : "upstream-secret",
+    async rpc(name, params) {
+      calls.push({ name, params })
+      if (name === "boss_ai_catalog") return [{ id: "boss-test" }]
+      if (name === "boss_ai_reserve") {
+        return options.deny ? { error: options.deny } : {
+          model: {
+            id: "boss-test",
+            upstream_model: "private",
+            context_length: 4096,
+            max_output_tokens: 512,
+            capabilities: ["text"],
+          },
+          connection: {
+            base_url: "https://upstream.example/v1",
+            api_type: "openai_chat",
+            api_key_secret: "BOSS_AI_TEST",
+          },
+        }
+      }
+      return null
+    },
+    fetch: async (url, init) => {
+      requests.push(new Request(url, init))
+      return new Response(
+        options.stream ??
+          JSON.stringify({
+            choices: [{
+              message: { role: "assistant", content: "hello" },
+              finish_reason: "stop",
+              index: 0,
+            }],
+            usage: { prompt_tokens: 2, completion_tokens: 3 },
+          }),
+        { status: options.upstreamStatus ?? 200 },
+      )
+    },
+  })
+  const request = (body: Obj, credential = token) =>
+    new Request("https://api.example/functions/v1/boss-ai/v1/chat/completions", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${credential}` },
+      body: JSON.stringify(body),
+    })
+  return { calls, requests, handler, request, token }
+}
+const body = { model: "boss-test", messages: [{ role: "user", content: "private prompt" }] }
+
+Deno.test("all inference and catalog access requires AI-scoped authentication", async () => {
+  const f = await fixture()
+  for (const path of ["v1/models", "usage", "v1/chat/completions"]) {
+    assertEquals((await f.handler(new Request(`https://api.example/boss-ai/${path}`))).status, 401)
+  }
+  for (const token of ["boss-session", f.token.slice(0, -5) + "wrong"]) {
+    assertEquals((await f.handler(f.request(body, token))).status, 401)
+  }
+  assertEquals(f.calls.length, 0)
+  assertEquals(f.requests.length, 0)
+})
+
+Deno.test("broker accepts a BOSS session but not an AI token", async () => {
+  const f = await fixture()
+  const req = (t: string) =>
+    new Request("https://api.example/boss-ai/auth/token", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${t}` },
+    })
+  assertEquals((await f.handler(req(f.token))).status, 401)
+  const response = await f.handler(req("boss-session"))
+  assertEquals(response.status, 200)
+  assertEquals((await response.json()).refresh_after_seconds, 180)
+})
+
+Deno.test("permission and allowance denials never dispatch upstream", async () => {
+  for (
+    const [deny, status] of [["forbidden", 403], ["allowance_exceeded", 429], [
+      "concurrency_exceeded",
+      429,
+    ]] as const
+  ) {
+    const f = await fixture({ deny })
+    assertEquals((await f.handler(f.request(body))).status, status)
+    assertEquals(f.requests.length, 0)
+  }
+})
+
+Deno.test("server-selected endpoint, model and key; actual usage settlement", async () => {
+  const f = await fixture()
+  const response = await f.handler(f.request(body))
+  assertEquals(response.status, 200)
+  assertEquals(f.requests[0].url, "https://upstream.example/v1/chat/completions")
+  assertEquals(f.requests[0].headers.get("authorization"), "Bearer upstream-secret")
+  assertEquals(f.requests[0].redirect, "error")
+  assertEquals((await f.requests[0].json()).model, "private")
+  assertEquals(f.calls.at(-1)?.params.p_tokens, 5)
+  const output = await response.text()
+  assert(!output.includes("upstream-secret"))
+  assert(!output.includes("private-model"))
+})
+
+Deno.test("invalid inputs refund reservations without inference", async () => {
+  const f = await fixture()
+  assertEquals((await f.handler(f.request({ ...body, provider: "attacker" }))).status, 400)
+  assertEquals(f.calls.at(-1)?.params.p_tokens, 0)
+  assertEquals(f.requests.length, 0)
+})
+
+Deno.test("truncated streams report failure and retain reserved usage", async () => {
+  const f = await fixture({ stream: 'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n' })
+  const response = await f.handler(f.request({ ...body, stream: true }))
+  const output = await response.text()
+  assert(output.includes("stream_failed"))
+  assert(!output.includes("[DONE]"))
+  assertEquals(f.calls.at(-1)?.params.p_tokens, null)
+})
+
+Deno.test("complete streams settle final usage and terminate once", async () => {
+  const f = await fixture({
+    stream:
+      'data: {"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":5}}\n\ndata: [DONE]\n\n',
+  })
+  const response = await f.handler(f.request({ ...body, stream: true }))
+  assertEquals((await response.text()).split("[DONE]").length, 2)
+  assertEquals(f.calls.at(-1)?.params.p_tokens, 17)
+  assertEquals(f.calls.filter((c) => c.name === "boss_ai_settle").length, 1)
+})

--- a/supabase/functions/boss-ai/tests/app.test.ts
+++ b/supabase/functions/boss-ai/tests/app.test.ts
@@ -10,6 +10,9 @@ async function fixture(options: {
   upstreamStatus?: number
   payload?: Obj
   failFirstSettlement?: boolean
+  failAllSettlements?: boolean
+  lookupDenied?: boolean
+  lookupMisconfigured?: boolean
   failFetch?: boolean
   hang?: boolean
   stallStream?: boolean
@@ -32,6 +35,13 @@ async function fixture(options: {
     secret: (name) => name === "BOSS_AI_SIGNING_SECRET" ? secret : "upstream-secret",
     async rpc(name, params) {
       calls.push({ name, params })
+      if (name === "boss_ai_lookup" && options.lookupDenied) return null
+      if (name === "boss_ai_lookup" && options.lookupMisconfigured) {
+        return { error: "misconfigured_allowance" }
+      }
+      if (name === "boss_ai_settle" && options.failAllSettlements) {
+        throw new Error("database unavailable")
+      }
       if (name === "boss_ai_settle" && options.failFirstSettlement && ++settlements === 1) {
         throw new Error("private database detail")
       }
@@ -297,11 +307,45 @@ Deno.test("failed dispatch and timeout are observable unknown outcomes not infer
 
 Deno.test("known usage survives a settlement retry", async () => {
   const f = await fixture({ failFirstSettlement: true })
-  await f.handler(f.request(body))
+  const response = await f.handler(f.request(body))
+  assertEquals(response.status, 200)
+  assertEquals((await response.json()).choices[0].message.content, "hello")
   assertEquals(
     f.calls.filter((call) => call.name === "boss_ai_settle").map((call) => call.params.p_tokens),
     [5, 5],
   )
+})
+
+Deno.test("settlement outages preserve the completion and deduplicate accounting diagnostics", async () => {
+  const f = await fixture({
+    failAllSettlements: true,
+    payload: { choices: [{ message: { role: "assistant", content: "hello" } }] },
+  })
+  const response = await f.handler(f.request(body))
+  assertEquals(response.status, 200)
+  assertEquals((await response.json()).choices[0].message.content, "hello")
+  assertEquals(
+    f.calls.filter((call) => call.name === "boss_ai_settle").map((call) => call.params.p_tokens),
+    [null, null],
+  )
+  assertEquals(f.audits.filter((event) => event === "usage_unknown_reservation_retained").length, 1)
+  assertEquals(f.audits.filter((event) => event === "settlement_failed").length, 1)
+})
+
+Deno.test("preflight permission denial never creates a reservation", async () => {
+  const f = await fixture({ lookupDenied: true })
+  assertEquals((await f.handler(f.request(body))).status, 403)
+  assertEquals(f.calls.map((call) => call.name), ["boss_ai_lookup"])
+  assertEquals(f.requests.length, 0)
+})
+
+Deno.test("impossible allowances report configuration faults instead of temporary exhaustion", async () => {
+  const f = await fixture({ lookupMisconfigured: true })
+  const response = await f.handler(f.request(body))
+  assertEquals(response.status, 503)
+  assertEquals((await response.json()).error.code, "misconfigured_allowance")
+  assertEquals(f.calls.map((call) => call.name), ["boss_ai_lookup"])
+  assertEquals(f.requests.length, 0)
 })
 
 Deno.test("missing usage emits accounting diagnostics and malformed upstream is a 502", async () => {

--- a/supabase/functions/boss-ai/tests/app.test.ts
+++ b/supabase/functions/boss-ai/tests/app.test.ts
@@ -4,30 +4,51 @@ import { mintToken, signingKey } from "../auth.ts"
 import { Obj } from "../wire.ts"
 
 const secret = "test-signing-secret-at-least-32-bytes-long"
-async function fixture(options: { deny?: string; stream?: string; upstreamStatus?: number } = {}) {
+async function fixture(options: {
+  deny?: string
+  stream?: string
+  upstreamStatus?: number
+  payload?: Obj
+  failFirstSettlement?: boolean
+  failFetch?: boolean
+  hang?: boolean
+  keyName?: string
+  apiType?: "openai_chat" | "openai_responses"
+} = {}) {
   const calls: { name: string; params: Obj }[] = []
   const requests: Request[] = []
+  const audits: string[] = []
+  let settlements = 0
   const token =
     (await mintToken("00000000-0000-0000-0000-000000000001", signingKey(secret))).access_token
   const handler = createHandler({
+    audit: (event) => {
+      audits.push(event)
+    },
+    upstreamTimeoutMs: 20,
     sessionUser: async (t) => t === "boss-session" ? "00000000-0000-0000-0000-000000000001" : null,
     secret: (name) => name === "BOSS_AI_SIGNING_SECRET" ? secret : "upstream-secret",
     async rpc(name, params) {
       calls.push({ name, params })
-      if (name === "boss_ai_catalog") return [{ id: "boss-test" }]
+      if (name === "boss_ai_settle" && options.failFirstSettlement && ++settlements === 1) {
+        throw new Error("private database detail")
+      }
+      if (name === "boss_ai_catalog") {
+        return [{ id: "boss-test", allowance: { day: { remaining: 1024 } } }]
+      }
       if (name === "boss_ai_reserve") {
         return options.deny ? { error: options.deny } : {
           model: {
             id: "boss-test",
-            upstream_model: "private",
+            upstream_model: "private-model",
             context_length: 4096,
             max_output_tokens: 512,
             capabilities: ["text"],
           },
           connection: {
             base_url: "https://upstream.example/v1",
-            api_type: "openai_chat",
-            api_key_secret: "BOSS_AI_TEST",
+            api_type: options.apiType ?? "openai_chat",
+            api_key_secret: options.keyName ?? "BOSS_AI_TEST",
           },
         }
       }
@@ -35,16 +56,26 @@ async function fixture(options: { deny?: string; stream?: string; upstreamStatus
     },
     fetch: async (url, init) => {
       requests.push(new Request(url, init))
+      if (options.failFetch) throw new Error("private network detail")
+      if (options.hang) {
+        await new Promise<void>((_, reject) => {
+          init!.signal!.addEventListener("abort", () => reject(new Error("timeout")), {
+            once: true,
+          })
+        })
+      }
       return new Response(
         options.stream ??
-          JSON.stringify({
-            choices: [{
-              message: { role: "assistant", content: "hello" },
-              finish_reason: "stop",
-              index: 0,
-            }],
-            usage: { prompt_tokens: 2, completion_tokens: 3 },
-          }),
+          JSON.stringify(
+            options.payload ?? {
+              choices: [{
+                message: { role: "assistant", content: "hello" },
+                finish_reason: "stop",
+                index: 0,
+              }],
+              usage: { prompt_tokens: 2, completion_tokens: 3 },
+            },
+          ),
         { status: options.upstreamStatus ?? 200 },
       )
     },
@@ -55,13 +86,13 @@ async function fixture(options: { deny?: string; stream?: string; upstreamStatus
       headers: { Authorization: `Bearer ${credential}` },
       body: JSON.stringify(body),
     })
-  return { calls, requests, handler, request, token }
+  return { calls, requests, handler, request, token, audits }
 }
 const body = { model: "boss-test", messages: [{ role: "user", content: "private prompt" }] }
 
 Deno.test("all inference and catalog access requires AI-scoped authentication", async () => {
   const f = await fixture()
-  for (const path of ["v1/models", "usage", "v1/chat/completions"]) {
+  for (const path of ["v1/models", "v1/usage", "v1/chat/completions"]) {
     assertEquals((await f.handler(new Request(`https://api.example/boss-ai/${path}`))).status, 401)
   }
   for (const token of ["boss-session", f.token.slice(0, -5) + "wrong"]) {
@@ -104,11 +135,13 @@ Deno.test("server-selected endpoint, model and key; actual usage settlement", as
   assertEquals(f.requests[0].url, "https://upstream.example/v1/chat/completions")
   assertEquals(f.requests[0].headers.get("authorization"), "Bearer upstream-secret")
   assertEquals(f.requests[0].redirect, "error")
-  assertEquals((await f.requests[0].json()).model, "private")
+  assertEquals((await f.requests[0].json()).model, "private-model")
   assertEquals(f.calls.at(-1)?.params.p_tokens, 5)
   const output = await response.text()
   assert(!output.includes("upstream-secret"))
   assert(!output.includes("private-model"))
+  assertEquals(typeof JSON.parse(output).created, "number")
+  assert(response.headers.get("x-request-id"))
 })
 
 Deno.test("invalid inputs refund reservations without inference", async () => {
@@ -136,4 +169,94 @@ Deno.test("complete streams settle final usage and terminate once", async () => 
   assertEquals((await response.text()).split("[DONE]").length, 2)
   assertEquals(f.calls.at(-1)?.params.p_tokens, 17)
   assertEquals(f.calls.filter((c) => c.name === "boss_ai_settle").length, 1)
+})
+
+Deno.test("catalog and usage are accessible inside the declared broker scope", async () => {
+  const f = await fixture()
+  const get = (path: string) =>
+    f.handler(
+      new Request(`https://api.example/boss-ai/v1/${path}`, {
+        headers: { Authorization: `Bearer ${f.token}` },
+      }),
+    )
+  assertEquals((await (await get("models")).json()).data[0].id, "boss-test")
+  assertEquals((await (await get("usage")).json()).data, [
+    { model: "boss-test", allowance: { day: { remaining: 1024 } } },
+  ])
+})
+
+Deno.test("explicit upstream rejections refund while ambiguous server faults remain charged", async () => {
+  for (const status of [400, 401, 402, 403, 404, 413, 422, 429, 408, 500, 502, 503, 504]) {
+    const f = await fixture({ upstreamStatus: status })
+    const response = await f.handler(f.request(body))
+    assertEquals(response.status, status === 429 ? 503 : 502)
+    assertEquals(f.calls.at(-1)?.params.p_tokens, status < 500 && status !== 408 ? 0 : null)
+    assert(f.audits.includes(`upstream_status_${status}`))
+  }
+})
+
+Deno.test("failed dispatch and timeout are observable unknown outcomes not inferred refunds", async () => {
+  for (const options of [{ failFetch: true }, { hang: true }]) {
+    const f = await fixture(options)
+    const response = await f.handler(f.request(body))
+    assertEquals(response.status, 503)
+    assertEquals(f.calls.at(-1)?.params.p_tokens, null)
+    assert(f.audits.includes("usage_unknown_reservation_retained"))
+    assert(!(await response.text()).includes("private"))
+  }
+})
+
+Deno.test("known usage survives a settlement retry", async () => {
+  const f = await fixture({ failFirstSettlement: true })
+  await f.handler(f.request(body))
+  assertEquals(
+    f.calls.filter((call) => call.name === "boss_ai_settle").map((call) => call.params.p_tokens),
+    [5, 5],
+  )
+})
+
+Deno.test("missing usage emits accounting diagnostics and malformed upstream is a 502", async () => {
+  const f = await fixture({
+    payload: { choices: [{ message: { role: "assistant", content: "hi" } }] },
+  })
+  assertEquals((await f.handler(f.request(body))).status, 200)
+  assert(f.audits.includes("usage_unknown_reservation_retained"))
+  assertEquals(f.calls.at(-1)?.params.p_tokens, null)
+  const bad = await fixture({ payload: {} })
+  assertEquals((await bad.handler(bad.request(body))).status, 502)
+})
+
+Deno.test("routing cannot disclose infrastructure or signing secrets", async () => {
+  for (const keyName of ["BOSS_AI_SIGNING_SECRET", "SUPABASE_SERVICE_ROLE_KEY"]) {
+    const f = await fixture({ keyName })
+    assertEquals((await f.handler(f.request(body))).status, 503)
+    assertEquals(f.requests.length, 0)
+    assertEquals(f.calls.at(-1)?.params.p_tokens, 0)
+  }
+})
+
+Deno.test("Responses endpoint round trip exposes only the published model", async () => {
+  const f = await fixture({
+    apiType: "openai_responses",
+    payload: {
+      status: "completed",
+      output: [{ type: "message", content: [{ type: "output_text", text: "hello" }] }],
+      usage: { input_tokens: 2, output_tokens: 3 },
+    },
+  })
+  const response = await f.handler(f.request(body))
+  assertEquals(response.status, 200)
+  assertEquals(f.requests[0].url, "https://upstream.example/v1/responses")
+  assertEquals((await response.json()).model, "boss-test")
+  assertEquals(f.calls.at(-1)?.params.p_tokens, 5)
+})
+
+Deno.test("stream cancellation retains usage and does not attempt to write to a closed client", async () => {
+  const f = await fixture({ stream: 'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n' })
+  const response = await f.handler(f.request({ ...body, stream: true }))
+  const reader = response.body!.getReader()
+  await reader.read()
+  await reader.cancel()
+  assertEquals(f.calls.filter((call) => call.name === "boss_ai_settle").length, 1)
+  assertEquals(f.calls.at(-1)?.params.p_tokens, null)
 })

--- a/supabase/functions/boss-ai/tests/app.test.ts
+++ b/supabase/functions/boss-ai/tests/app.test.ts
@@ -13,6 +13,7 @@ async function fixture(options: {
   failFetch?: boolean
   hang?: boolean
   stallStream?: boolean
+  removeToolsAfterPreflight?: boolean
   keyName?: string
   apiType?: "openai_chat" | "openai_responses"
 } = {}) {
@@ -44,7 +45,9 @@ async function fixture(options: {
             upstream_model: "private-model",
             context_length: 4096,
             max_output_tokens: 512,
-            capabilities: ["text"],
+            capabilities: options.removeToolsAfterPreflight && name === "boss_ai_lookup"
+              ? ["text", "tools"]
+              : ["text"],
           },
           connection: {
             base_url: "https://upstream.example/v1",
@@ -111,6 +114,26 @@ Deno.test("all inference and catalog access requires AI-scoped authentication", 
   assertEquals(f.requests.length, 0)
 })
 
+Deno.test("invalid routes and oversized requests fail before database access", async () => {
+  const f = await fixture()
+  for (const [path, method] of [["auth/token", "GET"], ["v1/models", "POST"], ["unknown", "GET"]]) {
+    const response = await f.handler(
+      new Request(`https://api.example/boss-ai/${path}`, {
+        method,
+        headers: { Authorization: `Bearer ${f.token}` },
+      }),
+    )
+    assertEquals(response.status, 404)
+    assert(response.headers.get("x-request-id"))
+  }
+  const response = await f.handler(
+    f.request({ ...body, messages: [{ role: "user", content: "x".repeat(5 * 1024 * 1024) }] }),
+  )
+  assertEquals(response.status, 413)
+  assertEquals(f.calls.length, 0)
+  assertEquals(f.requests.length, 0)
+})
+
 Deno.test("broker accepts a BOSS session but not an AI token", async () => {
   const f = await fixture()
   const req = (t: string) =>
@@ -173,6 +196,17 @@ Deno.test("invalid inputs never create accounting reservations", async () => {
   assertEquals(f.requests.length, 0)
 })
 
+Deno.test("admission revalidates changed model capabilities and refunds without dispatch", async () => {
+  const f = await fixture({ removeToolsAfterPreflight: true })
+  const response = await f.handler(
+    f.request({ ...body, tools: [{ type: "function", function: { name: "test" } }] }),
+  )
+  assertEquals(response.status, 400)
+  assertEquals(f.calls.map((c) => c.name), ["boss_ai_lookup", "boss_ai_reserve", "boss_ai_settle"])
+  assertEquals(f.calls.at(-1)?.params.p_tokens, 0)
+  assertEquals(f.requests.length, 0)
+})
+
 Deno.test("duplicate admission is a conflict and pre-dispatch abort refunds without fetch", async () => {
   const duplicate = await fixture({ deny: "duplicate" })
   assertEquals((await duplicate.handler(duplicate.request(body))).status, 409)
@@ -204,6 +238,15 @@ Deno.test("a stalled SSE body times out and settles without hanging the client",
   assert(!output.includes("[DONE]"))
   assertEquals(f.calls.filter((call) => call.name === "boss_ai_settle").length, 1)
   assertEquals(f.calls.at(-1)?.params.p_tokens, null)
+})
+
+Deno.test("late stream truncation preserves already reported usage", async () => {
+  const f = await fixture({
+    stream: 'data: {"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":5}}\n\n',
+  })
+  const response = await f.handler(f.request({ ...body, stream: true }))
+  assert((await response.text()).includes("stream_failed"))
+  assertEquals(f.calls.at(-1)?.params.p_tokens, 17)
 })
 
 Deno.test("complete streams settle final usage and terminate once", async () => {

--- a/supabase/functions/boss-ai/tests/app.test.ts
+++ b/supabase/functions/boss-ai/tests/app.test.ts
@@ -12,6 +12,7 @@ async function fixture(options: {
   failFirstSettlement?: boolean
   failFetch?: boolean
   hang?: boolean
+  stallStream?: boolean
   keyName?: string
   apiType?: "openai_chat" | "openai_responses"
 } = {}) {
@@ -36,8 +37,8 @@ async function fixture(options: {
       if (name === "boss_ai_catalog") {
         return [{ id: "boss-test", allowance: { day: { remaining: 1024 } } }]
       }
-      if (name === "boss_ai_reserve") {
-        return options.deny ? { error: options.deny } : {
+      if (name === "boss_ai_reserve" || name === "boss_ai_lookup") {
+        return options.deny && name === "boss_ai_reserve" ? { error: options.deny } : {
           model: {
             id: "boss-test",
             upstream_model: "private-model",
@@ -65,17 +66,25 @@ async function fixture(options: {
         })
       }
       return new Response(
-        options.stream ??
-          JSON.stringify(
-            options.payload ?? {
-              choices: [{
-                message: { role: "assistant", content: "hello" },
-                finish_reason: "stop",
-                index: 0,
-              }],
-              usage: { prompt_tokens: 2, completion_tokens: 3 },
+        options.stallStream
+          ? new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                new TextEncoder().encode('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n'),
+              )
             },
-          ),
+          })
+          : options.stream ??
+            JSON.stringify(
+              options.payload ?? {
+                choices: [{
+                  message: { role: "assistant", content: "hello" },
+                  finish_reason: "stop",
+                  index: 0,
+                }],
+                usage: { prompt_tokens: 2, completion_tokens: 3 },
+              },
+            ),
         { status: options.upstreamStatus ?? 200 },
       )
     },
@@ -144,9 +153,35 @@ Deno.test("server-selected endpoint, model and key; actual usage settlement", as
   assert(response.headers.get("x-request-id"))
 })
 
-Deno.test("invalid inputs refund reservations without inference", async () => {
+Deno.test("invalid inputs never create accounting reservations", async () => {
   const f = await fixture()
-  assertEquals((await f.handler(f.request({ ...body, provider: "attacker" }))).status, 400)
+  for (
+    const invalid of [{ model: body.model }, { ...body, provider: "attacker" }, {
+      ...body,
+      messages: [{ role: "user", name: {}, content: "text" }],
+    }, {
+      ...body,
+      messages: [{
+        role: "user",
+        content: [{ type: "image_url", image_url: { url: "data:image/png;base64,YQ==" } }],
+      }],
+    }]
+  ) {
+    assertEquals((await f.handler(f.request(invalid))).status, 400)
+  }
+  assert(f.calls.every((call) => call.name === "boss_ai_lookup"))
+  assertEquals(f.requests.length, 0)
+})
+
+Deno.test("duplicate admission is a conflict and pre-dispatch abort refunds without fetch", async () => {
+  const duplicate = await fixture({ deny: "duplicate" })
+  assertEquals((await duplicate.handler(duplicate.request(body))).status, 409)
+  assertEquals(duplicate.requests.length, 0)
+  const f = await fixture()
+  const abort = new AbortController()
+  abort.abort()
+  const response = await f.handler(new Request(f.request(body), { signal: abort.signal }))
+  assertEquals(response.status, 499)
   assertEquals(f.calls.at(-1)?.params.p_tokens, 0)
   assertEquals(f.requests.length, 0)
 })
@@ -157,6 +192,17 @@ Deno.test("truncated streams report failure and retain reserved usage", async ()
   const output = await response.text()
   assert(output.includes("stream_failed"))
   assert(!output.includes("[DONE]"))
+  assertEquals(f.calls.at(-1)?.params.p_tokens, null)
+})
+
+Deno.test("a stalled SSE body times out and settles without hanging the client", async () => {
+  const f = await fixture({ stallStream: true })
+  const response = await f.handler(f.request({ ...body, stream: true }))
+  const output = await response.text()
+  assert(output.includes("partial"))
+  assert(output.includes("stream_failed"))
+  assert(!output.includes("[DONE]"))
+  assertEquals(f.calls.filter((call) => call.name === "boss_ai_settle").length, 1)
   assertEquals(f.calls.at(-1)?.params.p_tokens, null)
 })
 

--- a/supabase/functions/boss-ai/tests/auth.test.ts
+++ b/supabase/functions/boss-ai/tests/auth.test.ts
@@ -1,0 +1,42 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert"
+import { SignJWT } from "jose"
+import { HttpError, signingKey, verifyToken } from "../auth.ts"
+
+Deno.test("AI credentials require the correct audience issuer scope lifetime and claims", async () => {
+  const key = signingKey("test-only-signing-secret-at-least-32-bytes")
+  const now = Math.floor(Date.now() / 1000)
+  const claims = {
+    sub: "user",
+    iss: "boss-ai",
+    aud: "boss-ai-inference",
+    scope: "inference",
+    iat: now,
+    exp: now + 300,
+    jti: "request",
+  }
+  const signed = (payload: Record<string, unknown>) =>
+    new SignJWT(payload).setProtectedHeader({ alg: "HS256" }).sign(key)
+  assertEquals(await verifyToken(await signed(claims), key), "user")
+  for (
+    const changed of [
+      { ...claims, aud: "another-service" },
+      { ...claims, iss: "another-issuer" },
+      { ...claims, scope: "admin" },
+      { ...claims, exp: now - 1 },
+      { ...claims, iat: now - 301 },
+      Object.fromEntries(Object.entries(claims).filter(([k]) => k !== "exp")),
+      Object.fromEntries(Object.entries(claims).filter(([k]) => k !== "jti")),
+    ]
+  ) {
+    const token = await signed(changed)
+    const error = await assertRejects(() => verifyToken(token, key), HttpError)
+    assertEquals(error.status, 401)
+  }
+})
+
+Deno.test("missing or short AI signing secrets fail closed", () => {
+  for (const secret of [undefined, "", "too-short"]) {
+    const error = assertThrows(() => signingKey(secret), HttpError)
+    assertEquals(error.status, 503)
+  }
+})

--- a/supabase/functions/boss-ai/tests/database.test.ts
+++ b/supabase/functions/boss-ai/tests/database.test.ts
@@ -29,6 +29,11 @@ Deno.test("database policy, reservations, settlement, revocation and grants", as
       ),
     )
     const user = "00000000-0000-0000-0000-000000000001"
+    await db.exec(
+      await Deno.readTextFile(
+        new URL("../../../migrations/20260912002000_boss_ai_validation.sql", import.meta.url),
+      ),
+    )
     const other = "00000000-0000-0000-0000-000000000002"
     await db.exec(`
       INSERT INTO auth.users(id) VALUES('${user}'),('${other}');

--- a/supabase/functions/boss-ai/tests/database.test.ts
+++ b/supabase/functions/boss-ai/tests/database.test.ts
@@ -23,6 +23,11 @@ Deno.test("database policy, reservations, settlement, revocation and grants", as
         new URL("../../../migrations/20260912000000_boss_ai.sql", import.meta.url),
       ),
     )
+    await db.exec(
+      await Deno.readTextFile(
+        new URL("../../../migrations/20260912001000_boss_ai_hardening.sql", import.meta.url),
+      ),
+    )
     const user = "00000000-0000-0000-0000-000000000001"
     const other = "00000000-0000-0000-0000-000000000002"
     await db.exec(`

--- a/supabase/functions/boss-ai/tests/database.test.ts
+++ b/supabase/functions/boss-ai/tests/database.test.ts
@@ -35,6 +35,14 @@ Deno.test("database policy, reservations, settlement, revocation and grants", as
       ),
     )
     const other = "00000000-0000-0000-0000-000000000002"
+    await db.exec(
+      await Deno.readTextFile(
+        new URL(
+          "../../../migrations/20260912003000_boss_ai_allowance_preflight.sql",
+          import.meta.url,
+        ),
+      ),
+    )
     await db.exec(`
       INSERT INTO auth.users(id) VALUES('${user}'),('${other}');
       INSERT INTO public.permissions(name) VALUES('ai.extended');
@@ -48,6 +56,15 @@ Deno.test("database policy, reservations, settlement, revocation and grants", as
       (await db.query<{ value: any }>(sql, params)).rows[0].value
     const policy = () => scalar("SELECT public.boss_ai_policy($1,'test') AS value", [user])
     assertEquals(await policy(), { day: 4096, week: 8192, month: 16384, concurrent: 3 })
+    await db.exec(
+      "BEGIN; UPDATE public.boss_ai_allowances SET tokens_per_day=1 WHERE model_id='test'",
+    )
+    assertEquals(
+      await scalar("SELECT public.boss_ai_lookup($1,'test')->>'error' AS value", [user]),
+      "misconfigured_allowance",
+    )
+    assertEquals(await scalar("SELECT count(*)::int AS value FROM public.boss_ai_requests"), 0)
+    await db.exec("ROLLBACK")
     const reserve = (id: string, who = user) =>
       scalar("SELECT public.boss_ai_reserve($1,'test',$2) AS value", [who, id])
     const ids = Array.from({ length: 5 }, () => crypto.randomUUID())

--- a/supabase/functions/boss-ai/tests/database.test.ts
+++ b/supabase/functions/boss-ai/tests/database.test.ts
@@ -1,0 +1,91 @@
+import { PGlite } from "npm:@electric-sql/pglite@0.3.14"
+import { assertEquals, assertRejects } from "@std/assert"
+
+// Runs the real migration in PostgreSQL/WASM; only the surrounding auth/RBAC
+// schema is a fixture. No Supabase project or Docker daemon is required.
+Deno.test("database policy, reservations, settlement, revocation and grants", async () => {
+  const db = new PGlite()
+  try {
+    await db.exec(`
+      CREATE ROLE anon; CREATE ROLE authenticated; CREATE ROLE service_role;
+      CREATE SCHEMA auth;
+      CREATE TABLE auth.users(id uuid PRIMARY KEY, banned_until timestamptz);
+      CREATE TABLE public.permissions(id uuid PRIMARY KEY DEFAULT gen_random_uuid(), name text UNIQUE, description text, is_system boolean);
+      CREATE TABLE public.roles(id uuid PRIMARY KEY DEFAULT gen_random_uuid(), name text UNIQUE);
+      CREATE TABLE public.role_permissions(role_id uuid, permission_id uuid, UNIQUE(role_id,permission_id));
+      CREATE TABLE public.test_user_permissions(user_id uuid, permission_name text);
+      CREATE FUNCTION public.user_has_permission(p_user_id uuid,p_permission text) RETURNS boolean LANGUAGE sql AS
+        'SELECT EXISTS(SELECT 1 FROM public.test_user_permissions WHERE user_id=p_user_id AND permission_name=p_permission)';
+      INSERT INTO public.roles(name) VALUES('user');
+    `)
+    await db.exec(
+      await Deno.readTextFile(
+        new URL("../../../migrations/20260912000000_boss_ai.sql", import.meta.url),
+      ),
+    )
+    const user = "00000000-0000-0000-0000-000000000001"
+    const other = "00000000-0000-0000-0000-000000000002"
+    await db.exec(`
+      INSERT INTO auth.users(id) VALUES('${user}'),('${other}');
+      INSERT INTO public.permissions(name) VALUES('ai.extended');
+      INSERT INTO public.test_user_permissions VALUES('${user}','ai.use'),('${user}','ai.extended'),('${other}','ai.use');
+      INSERT INTO public.boss_ai_connections VALUES('test','https://example.com/v1','BOSS_AI_TEST','openai_chat',true);
+      INSERT INTO public.boss_ai_models(id,display_name,connection_id,upstream_model,context_length,max_output_tokens,published,is_default)
+        VALUES('test','Test','test','private',1024,128,true,true);
+      INSERT INTO public.boss_ai_allowances VALUES('test','ai.use',2048,4096,8192,2),('test','ai.extended',4096,8192,16384,3);
+    `)
+    const scalar = async (sql: string, params: unknown[] = []) =>
+      (await db.query<{ value: any }>(sql, params)).rows[0].value
+    const policy = () => scalar("SELECT public.boss_ai_policy($1,'test') AS value", [user])
+    assertEquals(await policy(), { day: 4096, week: 8192, month: 16384, concurrent: 3 })
+    const reserve = (id: string, who = user) =>
+      scalar("SELECT public.boss_ai_reserve($1,'test',$2) AS value", [who, id])
+    const ids = Array.from({ length: 5 }, () => crypto.randomUUID())
+    const first = await reserve(ids[0])
+    assertEquals(first.model.upstream_model, "private")
+    assertEquals((await reserve(ids[0])).error, "duplicate")
+    await reserve(ids[1])
+    await reserve(ids[2])
+    assertEquals((await reserve(ids[3])).error, "concurrency_exceeded")
+    // Unknown outcome remains fully charged. Settlement is idempotent.
+    await db.query("SELECT public.boss_ai_settle($1,NULL)", [ids[0]])
+    await db.query("SELECT public.boss_ai_settle($1,0)", [ids[0]])
+    assertEquals(
+      await scalar("SELECT charged_tokens AS value FROM public.boss_ai_requests WHERE id=$1", [
+        ids[0],
+      ]),
+      1024,
+    )
+    await reserve(ids[3])
+    assertEquals((await reserve(ids[4])).error, "allowance_exceeded")
+    // Another user has a separate ledger.
+    assertEquals((await reserve(crypto.randomUUID(), other)).error, undefined)
+    // Release excess based on actual upstream accounting.
+    await db.query("SELECT public.boss_ai_settle($1,10)", [ids[1]])
+    const u = await scalar("SELECT public.boss_ai_usage($1,'test') AS value", [user])
+    assertEquals(u.day.used, 3082)
+    assertEquals(u.week.used, 3082)
+    assertEquals(u.day.remaining, 1014)
+    // Dropping a permission changes the allowance immediately, without resetting usage.
+    await db.query(
+      "DELETE FROM public.test_user_permissions WHERE user_id=$1 AND permission_name='ai.extended'",
+      [user],
+    )
+    assertEquals((await policy()).day, 2048)
+    assertEquals((await reserve(ids[4])).error, "allowance_exceeded")
+    await db.query("DELETE FROM public.test_user_permissions WHERE user_id=$1", [user])
+    assertEquals(await policy(), null)
+    assertEquals(await scalar("SELECT public.boss_ai_catalog($1) AS value", [user]), [])
+    assertEquals((await reserve(ids[4])).error, "forbidden")
+    await db.exec("UPDATE public.boss_ai_models SET published=false")
+    assertEquals((await reserve(crypto.randomUUID(), other)).error, "forbidden")
+    // No anonymous or authenticated RPC/table access to a service-role impersonation API.
+    await db.exec("SET ROLE authenticated")
+    await assertRejects(() => db.query("SELECT * FROM public.boss_ai_connections"))
+    await assertRejects(() => db.query("SELECT public.boss_ai_catalog($1)", [other]))
+    await assertRejects(() => db.query("SELECT public.boss_ai_settle($1,0)", [ids[2]]))
+    await db.exec("RESET ROLE")
+  } finally {
+    await db.close()
+  }
+})

--- a/supabase/functions/boss-ai/tests/wire.test.ts
+++ b/supabase/functions/boss-ai/tests/wire.test.ts
@@ -55,6 +55,22 @@ Deno.test("upstream secret lookup is safe without calling endpoint first", () =>
 })
 const input = { model: model.id, messages: [{ role: "user", content: "hello" }] }
 
+Deno.test("stream options permit accounting usage but reject disabling it or extensions", () => {
+  const input = { messages: [{ role: "user", content: "hello" }], stream: true }
+  assertEquals(
+    requestBody({ ...input, stream_options: { include_usage: true } }, model, "openai_chat")
+      .stream_options,
+    { include_usage: true },
+  )
+  for (
+    const stream_options of [null, { include_usage: false }, { include_usage: "true" }, {
+      provider: "override",
+    }]
+  ) {
+    assertThrows(() => requestBody({ ...input, stream_options }, model, "openai_chat"))
+  }
+})
+
 Deno.test("routing overrides and unadvertised capabilities are refused", () => {
   for (const field of ["base_url", "api_key", "provider", "n", "previous_response_id"]) {
     assertThrows(() => requestBody({ ...input, [field]: "override" }, model, "openai_chat"))

--- a/supabase/functions/boss-ai/tests/wire.test.ts
+++ b/supabase/functions/boss-ai/tests/wire.test.ts
@@ -7,6 +7,7 @@ import {
   readJson,
   requestBody,
   StreamAdapter,
+  upstreamKey,
   usage,
 } from "../wire.ts"
 import { bearer, HttpError } from "../auth.ts"
@@ -18,6 +19,40 @@ const model: Model = {
   context_length: 4096,
   max_output_tokens: 512,
 }
+
+Deno.test("Responses tool results normalize text arrays and reject null or images", () => {
+  const request = (content: unknown) =>
+    requestBody(
+      {
+        messages: [{ role: "tool", tool_call_id: "call-1", content }],
+      },
+      model,
+      "openai_responses",
+    )
+  assertEquals(request([{ type: "text", text: "first" }, { type: "text", text: "second" }]).input, [
+    { type: "function_call_output", call_id: "call-1", output: "firstsecond" },
+  ])
+  assertThrows(() => request(null))
+  assertThrows(() =>
+    request([{ type: "image_url", image_url: { url: "data:image/png;base64,YQ==" } }])
+  )
+})
+
+Deno.test("upstream secret lookup is safe without calling endpoint first", () => {
+  let reads = 0
+  for (const api_key_secret of ["BOSS_AI_SIGNING_SECRET", "SUPABASE_SERVICE_ROLE_KEY"]) {
+    assertThrows(() =>
+      upstreamKey(
+        { base_url: "https://example.com", api_type: "openai_chat", api_key_secret },
+        () => {
+          reads++
+          return "forbidden"
+        },
+      )
+    )
+  }
+  assertEquals(reads, 0)
+})
 const input = { model: model.id, messages: [{ role: "user", content: "hello" }] }
 
 Deno.test("routing overrides and unadvertised capabilities are refused", () => {

--- a/supabase/functions/boss-ai/tests/wire.test.ts
+++ b/supabase/functions/boss-ai/tests/wire.test.ts
@@ -1,0 +1,163 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert"
+import { completion, events, Model, requestBody, StreamAdapter, usage } from "../wire.ts"
+
+const model: Model = {
+  id: "boss-test",
+  upstream_model: "private-model",
+  capabilities: ["text", "tools", "structured_output"],
+  context_length: 4096,
+  max_output_tokens: 512,
+}
+const input = { model: model.id, messages: [{ role: "user", content: "hello" }] }
+
+Deno.test("routing overrides and unadvertised capabilities are refused", () => {
+  for (const field of ["base_url", "api_key", "provider", "n", "previous_response_id"]) {
+    assertThrows(() => requestBody({ ...input, [field]: "override" }, model, "openai_chat"))
+  }
+  assertThrows(() => requestBody({ ...input, max_tokens: 513 }, model, "openai_chat"))
+  assertThrows(() =>
+    requestBody(
+      {
+        ...input,
+        messages: [{
+          role: "user",
+          content: [{ type: "image_url", image_url: { url: "https://example.com/private" } }],
+        }],
+      },
+      model,
+      "openai_chat",
+    )
+  )
+  assertThrows(() =>
+    requestBody({ ...input, tools: [{ type: "web_search" }] }, model, "openai_responses")
+  )
+})
+
+Deno.test("upstream mapping replaces model, disables storage, and bounds output", () => {
+  const body = requestBody({ ...input, stream: true, max_tokens: 40 }, model, "openai_chat")
+  assertEquals(body.model, "private-model")
+  assertEquals(body.max_completion_tokens, 40)
+  assertEquals(body.store, false)
+  assertEquals(body.stream_options, { include_usage: true })
+  assertEquals(body.temperature, undefined)
+})
+
+Deno.test("Responses adapter retains every tool round with call IDs", () => {
+  const body = requestBody(
+    {
+      ...input,
+      messages: [
+        { role: "system", content: "system" },
+        { role: "user", content: "question" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [{
+            id: "call-1",
+            type: "function",
+            function: { name: "lookup", arguments: "{}" },
+          }],
+        },
+        { role: "tool", tool_call_id: "call-1", content: "observation" },
+        { role: "assistant", content: "answer" },
+        { role: "user", content: "next question" },
+      ],
+      tools: [{ type: "function", function: { name: "lookup", parameters: { type: "object" } } }],
+      tool_choice: { type: "function", function: { name: "lookup" } },
+      max_tokens: 128,
+    },
+    model,
+    "openai_responses",
+  )
+  assertEquals(body.input, [
+    { role: "system", content: "system" },
+    { role: "user", content: "question" },
+    { type: "function_call", call_id: "call-1", name: "lookup", arguments: "{}" },
+    { type: "function_call_output", call_id: "call-1", output: "observation" },
+    { role: "assistant", content: "answer" },
+    { role: "user", content: "next question" },
+  ])
+  assertEquals(body.tool_choice, { type: "function", name: "lookup" })
+  assertEquals(body.max_output_tokens, 128)
+  assertEquals(body.truncation, "disabled")
+})
+
+Deno.test("usage includes output reasoning once and rejects unknown accounting", () => {
+  assertEquals(
+    usage(
+      { input_tokens: 12, output_tokens: 20, output_tokens_details: { reasoning_tokens: 15 } },
+      true,
+    )?.total_tokens,
+    32,
+  )
+  assertEquals(usage({ prompt_tokens: -1, completion_tokens: 10 }), null)
+  assertEquals(usage({}), null)
+})
+
+Deno.test("Responses completion translates text and function output", () => {
+  const reply = completion(
+    {
+      status: "completed",
+      output: [
+        { type: "message", content: [{ type: "output_text", text: "hello" }] },
+        { type: "function_call", call_id: "call", name: "lookup", arguments: "{}" },
+      ],
+      usage: { input_tokens: 1, output_tokens: 2 },
+    },
+    model.id,
+    "openai_responses",
+    "request",
+  )
+  assertEquals(reply.model, model.id)
+  assertEquals(reply.usage, { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 })
+  assertEquals((reply.choices as Record<string, unknown>[])[0].finish_reason, "tool_calls")
+})
+
+Deno.test("SSE parser handles byte splits, CRLF and multiline data", async () => {
+  const bytes = new TextEncoder().encode(
+    ': comment\r\n\r\ndata: {"text":\r\ndata: "日"}\r\n\r\ndata: [DONE]\n\n',
+  )
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      for (const byte of bytes) c.enqueue(new Uint8Array([byte]))
+      c.close()
+    },
+  })
+  const result = []
+  for await (const event of events(body)) result.push(event)
+  assertEquals(result, ['{"text":\n"日"}', "[DONE]"])
+  await assertRejects(async () => {
+    for await (const _ of events(new Response("data: unfinished").body!)) { /* drain */ }
+  })
+})
+
+Deno.test("Responses stream maps sparse output indexes to contiguous tool indexes", () => {
+  const adapter = new StreamAdapter(model.id, "openai_responses", "request")
+  const first = adapter.accept(
+    JSON.stringify({
+      type: "response.output_item.added",
+      output_index: 3,
+      item: { type: "function_call", call_id: "call", name: "lookup" },
+    }),
+  )
+  assertEquals((first[0].choices as any)[0].delta.tool_calls[0].index, 0)
+  const delta = adapter.accept(
+    JSON.stringify({
+      type: "response.function_call_arguments.delta",
+      output_index: 3,
+      delta: "{}",
+    }),
+  )
+  assertEquals((delta[0].choices as any)[0].delta.tool_calls[0].function.arguments, "{}")
+  adapter.accept(
+    JSON.stringify({
+      type: "response.completed",
+      response: { usage: { input_tokens: 2, output_tokens: 4 } },
+    }),
+  )
+  assertEquals(adapter.finished, true)
+  assertEquals(adapter.tokens, 6)
+  assertThrows(() =>
+    new StreamAdapter(model.id, "openai_chat", "r").accept('{"error":{"message":"private prompt"}}')
+  )
+})

--- a/supabase/functions/boss-ai/tests/wire.test.ts
+++ b/supabase/functions/boss-ai/tests/wire.test.ts
@@ -71,6 +71,24 @@ Deno.test("stream options permit accounting usage but reject disabling it or ext
   }
 })
 
+Deno.test("assistant tool calls may omit content without breaking the tool round", () => {
+  const input = {
+    messages: [{
+      role: "assistant",
+      tool_calls: [{ id: "call-1", type: "function", function: { name: "test", arguments: "{}" } }],
+    }],
+  }
+  assertEquals(
+    (requestBody(input, model, "openai_chat").messages as Record<string, unknown>[])[0].content,
+    null,
+  )
+  assertEquals(
+    (requestBody(input, model, "openai_responses").input as Record<string, unknown>[])[0].type,
+    "function_call",
+  )
+  assertThrows(() => requestBody({ messages: [{ role: "user" }] }, model, "openai_chat"))
+})
+
 Deno.test("routing overrides and unadvertised capabilities are refused", () => {
   for (const field of ["base_url", "api_key", "provider", "n", "previous_response_id"]) {
     assertThrows(() => requestBody({ ...input, [field]: "override" }, model, "openai_chat"))

--- a/supabase/functions/boss-ai/tests/wire.test.ts
+++ b/supabase/functions/boss-ai/tests/wire.test.ts
@@ -1,5 +1,15 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert"
-import { completion, events, Model, requestBody, StreamAdapter, usage } from "../wire.ts"
+import {
+  completion,
+  endpoint,
+  events,
+  Model,
+  readJson,
+  requestBody,
+  StreamAdapter,
+  usage,
+} from "../wire.ts"
+import { bearer, HttpError } from "../auth.ts"
 
 const model: Model = {
   id: "boss-test",
@@ -160,4 +170,103 @@ Deno.test("Responses stream maps sparse output indexes to contiguous tool indexe
   assertThrows(() =>
     new StreamAdapter(model.id, "openai_chat", "r").accept('{"error":{"message":"private prompt"}}')
   )
+})
+
+Deno.test("vision-enabled models accept inline images but refuse remote images and extensions", () => {
+  const vision = { ...model, capabilities: [...model.capabilities, "vision"] }
+  const image = (url: string, extra = {}) => ({
+    ...input,
+    messages: [{
+      role: "user",
+      content: [
+        { type: "image_url", image_url: { url, detail: "low", ...extra } },
+      ],
+    }],
+  })
+  for (const type of ["openai_chat", "openai_responses"] as const) {
+    requestBody(image("data:image/png;base64,YQ=="), vision, type)
+    assertThrows(() => requestBody(image("https://example.com/private"), vision, type))
+    assertThrows(() =>
+      requestBody(image("data:image/png;base64,YQ==", { provider: "x" }), vision, type)
+    )
+    assertThrows(() =>
+      requestBody(image("data:image/png;base64,YQ==", { detail: "invalid" }), vision, type)
+    )
+  }
+})
+
+Deno.test("function and format envelopes reject vendor extensions", () => {
+  assertThrows(() =>
+    requestBody(
+      {
+        ...input,
+        tools: [{
+          type: "function",
+          function: {
+            name: "lookup",
+            provider: "override",
+          },
+        }],
+      },
+      model,
+      "openai_chat",
+    )
+  )
+  assertThrows(() =>
+    requestBody(
+      {
+        ...input,
+        response_format: {
+          type: "json_object",
+          endpoint: "https://attacker",
+        },
+      },
+      model,
+      "openai_chat",
+    )
+  )
+})
+
+Deno.test("upstream endpoints and bearer headers fail closed", () => {
+  const connection = {
+    base_url: "https://example.com/v1",
+    api_type: "openai_chat" as const,
+    api_key_secret: "BOSS_AI_TEST",
+  }
+  for (
+    const url of [
+      "http://example.com",
+      "https://u:p@example.com",
+      "https://example.com?key=x",
+      "https://example.com#x",
+    ]
+  ) {
+    assertThrows(() => endpoint({ ...connection, base_url: url }))
+  }
+  for (const value of ["Basic x", "Bearer ", `Bearer ${"x".repeat(16385)}`]) {
+    assertThrows(() =>
+      bearer(new Request("https://example.com", { headers: { authorization: value } }))
+    )
+  }
+})
+
+Deno.test("bounded JSON reads reject oversized bodies", async () => {
+  const error = await assertRejects(
+    () => readJson(new Response('{"data":"large"}').body, 4),
+    HttpError,
+  )
+  assertEquals(error.status, 413)
+})
+
+Deno.test("all stream frames carry a stable created timestamp", () => {
+  for (const type of ["openai_chat", "openai_responses"] as const) {
+    const adapter = new StreamAdapter(model.id, type, "request")
+    const event = type === "openai_chat"
+      ? { choices: [{ delta: { content: "hello" } }] }
+      : { type: "response.output_text.delta", delta: "hello" }
+    const first = adapter.accept(JSON.stringify(event))[0]
+    const second = adapter.accept(JSON.stringify(event))[0]
+    assertEquals(typeof first.created, "number")
+    assertEquals(first.created, second.created)
+  }
 })

--- a/supabase/functions/boss-ai/wire.ts
+++ b/supabase/functions/boss-ai/wire.ts
@@ -1,0 +1,385 @@
+import { HttpError } from "./auth.ts"
+
+export type Obj = Record<string, unknown>
+export interface Model {
+  id: string
+  upstream_model: string
+  capabilities: string[]
+  context_length: number
+  max_output_tokens: number
+}
+export interface Connection {
+  base_url: string
+  api_type: "openai_chat" | "openai_responses"
+  api_key_secret: string
+}
+export function object(value: unknown): Obj {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw invalid()
+  return value as Obj
+}
+export function invalid(): HttpError {
+  return new HttpError(
+    400,
+    "invalid_request",
+    "This request is not supported by the selected BOSS model.",
+  )
+}
+
+// Bounded reads apply even when Content-Length is absent or false.
+export async function readJson(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes = 4 * 1024 * 1024,
+): Promise<Obj> {
+  if (!body) throw invalid()
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let size = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      size += value.length
+      if (size > maxBytes) {
+        throw new HttpError(413, "too_large", "The AI request or response is too large.")
+      }
+      chunks.push(value)
+    }
+    const bytes = new Uint8Array(size)
+    let offset = 0
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset)
+      offset += chunk.length
+    }
+    try {
+      return object(JSON.parse(new TextDecoder().decode(bytes)))
+    } catch {
+      throw invalid()
+    }
+  } finally {
+    await reader.cancel().catch(() => {})
+    reader.releaseLock()
+  }
+}
+
+export function endpoint(connection: Connection): string {
+  const url = new URL(connection.base_url)
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
+    throw new HttpError(503, "configuration", "BOSS AI is temporarily unavailable.")
+  }
+  return url.toString().replace(/\/$/, "") +
+    (connection.api_type === "openai_chat" ? "/chat/completions" : "/responses")
+}
+
+export function requestBody(input: Obj, model: Model, type: Connection["api_type"]): Obj {
+  const allowed = new Set([
+    "model",
+    "messages",
+    "stream",
+    "stream_options",
+    "max_tokens",
+    "max_completion_tokens",
+    "temperature",
+    "top_p",
+    "tools",
+    "tool_choice",
+    "parallel_tool_calls",
+    "response_format",
+  ])
+  if (Object.keys(input).some((key) => !allowed.has(key))) throw invalid()
+  if (!Array.isArray(input.messages) || !input.messages.length || input.messages.length > 512) {
+    throw invalid()
+  }
+  if (input.stream !== undefined && typeof input.stream !== "boolean") throw invalid()
+  const messages = input.messages.map((value) => {
+    const m = object(value)
+    if (!["system", "developer", "user", "assistant", "tool"].includes(String(m.role))) {
+      throw invalid()
+    }
+    if (
+      Object.keys(m).some((k) =>
+        !["role", "content", "tool_calls", "tool_call_id", "name"].includes(k)
+      )
+    ) throw invalid()
+    if (m.content !== null && typeof m.content !== "string") {
+      if (!Array.isArray(m.content)) throw invalid()
+      for (const part of m.content) {
+        const p = object(part)
+        if (p.type === "text" && typeof p.text === "string") continue
+        if (p.type === "image_url" && model.capabilities.includes("vision")) {
+          const image = object(p.image_url)
+          if (
+            typeof image.url === "string" &&
+            /^data:image\/(png|jpeg|webp);base64,[A-Za-z0-9+/=]+$/.test(image.url)
+          ) continue
+        }
+        throw invalid()
+      }
+    }
+    if (
+      m.role === "tool" &&
+      (typeof m.tool_call_id !== "string" || !model.capabilities.includes("tools"))
+    ) throw invalid()
+    if (
+      m.tool_calls !== undefined &&
+      (!Array.isArray(m.tool_calls) || !model.capabilities.includes("tools"))
+    ) throw invalid()
+    return m
+  })
+  const max = input.max_completion_tokens ?? input.max_tokens ??
+    Math.min(2000, model.max_output_tokens)
+  if (!Number.isSafeInteger(max) || Number(max) < 1 || Number(max) > model.max_output_tokens) {
+    throw invalid()
+  }
+  const common: Obj = { model: model.upstream_model, stream: input.stream === true, store: false }
+  for (const key of ["temperature", "top_p"]) {
+    if (input[key] !== undefined) {
+      if (typeof input[key] !== "number" || !Number.isFinite(input[key])) throw invalid()
+      common[key] = input[key]
+    }
+  }
+  let tools: Obj[] | undefined
+  if (input.tools !== undefined) {
+    if (
+      !model.capabilities.includes("tools") || !Array.isArray(input.tools) ||
+      input.tools.length > 128
+    ) throw invalid()
+    tools = input.tools.map((value) => {
+      const t = object(value)
+      const f = object(t.function)
+      if (
+        t.type !== "function" || typeof f.name !== "string" || !/^[a-zA-Z0-9_-]{1,64}$/.test(f.name)
+      ) throw invalid()
+      return { type: "function", function: f }
+    })
+    if (!tools.length) tools = undefined
+  }
+  if (input.tool_choice !== undefined) {
+    if (!tools) throw invalid()
+    const choice = input.tool_choice
+    if (typeof choice === "string") {
+      if (!["auto", "none", "required"].includes(choice)) throw invalid()
+      common.tool_choice = choice
+    } else {
+      const c = object(choice), f = object(c.function)
+      if (c.type !== "function" || typeof f.name !== "string") throw invalid()
+      common.tool_choice = type === "openai_chat" ? c : { type: "function", name: f.name }
+    }
+  }
+  if (input.parallel_tool_calls !== undefined) {
+    if (!tools || typeof input.parallel_tool_calls !== "boolean") throw invalid()
+    common.parallel_tool_calls = input.parallel_tool_calls
+  }
+  if (input.response_format !== undefined) {
+    if (!model.capabilities.includes("structured_output")) throw invalid()
+    const format = object(input.response_format)
+    if (!["json_schema", "json_object", "text"].includes(String(format.type))) throw invalid()
+    if (type === "openai_chat") common.response_format = format
+    else {common.text = {
+        format: format.type === "json_schema"
+          ? { ...object(format.json_schema), type: "json_schema" }
+          : format,
+      }}
+  }
+  if (type === "openai_chat") {
+    if (tools) common.tools = tools
+    if (common.stream) common.stream_options = { include_usage: true }
+    return { ...common, messages, max_completion_tokens: max }
+  }
+  const items: Obj[] = []
+  for (const m of messages) {
+    if (m.role === "tool") {
+      items.push({ type: "function_call_output", call_id: m.tool_call_id, output: m.content })
+      continue
+    }
+    if (m.content !== null && m.content !== "") {
+      const content = typeof m.content === "string"
+        ? m.content
+        : (m.content as unknown[]).map((value) => {
+          const p = object(value)
+          return p.type === "text"
+            ? { type: m.role === "assistant" ? "output_text" : "input_text", text: p.text }
+            : {
+              type: "input_image",
+              image_url: object(p.image_url).url,
+              detail: object(p.image_url).detail ?? "auto",
+            }
+        })
+      items.push({ role: m.role, content })
+    }
+    for (const call of (m.tool_calls as unknown[] | undefined) ?? []) {
+      const c = object(call), f = object(c.function)
+      items.push({ type: "function_call", call_id: c.id, name: f.name, arguments: f.arguments })
+    }
+  }
+  if (tools) common.tools = tools.map((t) => ({ ...object(t.function), type: "function" }))
+  return { ...common, input: items, max_output_tokens: max, truncation: "disabled" }
+}
+
+export function usage(value: unknown, responses = false): Obj | null {
+  if (!value || typeof value !== "object") return null
+  const u = value as Obj
+  const prompt = u[responses ? "input_tokens" : "prompt_tokens"]
+  const completion = u[responses ? "output_tokens" : "completion_tokens"]
+  if (
+    !Number.isSafeInteger(prompt) || !Number.isSafeInteger(completion) || Number(prompt) < 0 ||
+    Number(completion) < 0
+  ) return null
+  return {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: Number(prompt) + Number(completion),
+  }
+}
+
+export function completion(
+  value: Obj,
+  model: string,
+  type: Connection["api_type"],
+  id: string,
+): Obj {
+  if (value.error) {
+    throw new HttpError(502, "upstream_error", "The model could not complete this request.")
+  }
+  if (type === "openai_chat") {
+    if (!Array.isArray(value.choices) || value.choices.length !== 1) throw invalid()
+    return {
+      id,
+      object: "chat.completion",
+      model,
+      choices: value.choices,
+      usage: usage(value.usage),
+    }
+  }
+  if (!["completed", "incomplete"].includes(String(value.status))) {
+    throw new HttpError(502, "upstream_error", "The model could not complete this request.")
+  }
+  const output = Array.isArray(value.output) ? value.output.map(object) : []
+  const calls = output.filter((x) => x.type === "function_call").map((x) => ({
+    id: x.call_id,
+    type: "function",
+    function: { name: x.name, arguments: x.arguments },
+  }))
+  const text = output.filter((x) => x.type === "message").flatMap((x) =>
+    Array.isArray(x.content) ? x.content.map(object) : []
+  )
+    .map((x) => x.type === "output_text" ? x.text : x.type === "refusal" ? x.refusal : "").join("")
+  return {
+    id,
+    object: "chat.completion",
+    model,
+    choices: [{
+      index: 0,
+      message: { role: "assistant", content: text, ...(calls.length ? { tool_calls: calls } : {}) },
+      finish_reason: value.status === "incomplete"
+        ? "length"
+        : calls.length
+        ? "tool_calls"
+        : "stop",
+    }],
+    usage: usage(value.usage, true),
+  }
+}
+
+// SSE frames can split anywhere, including within UTF-8 characters and CRLF pairs.
+export async function* events(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = body.pipeThrough(new TextDecoderStream()).getReader()
+  let buffer = ""
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += value
+      if (buffer.length > 4 * 1024 * 1024) throw new Error("Oversized frame")
+      while (true) {
+        const match = /\r?\n\r?\n/.exec(buffer)
+        if (!match) break
+        const frame = buffer.slice(0, match.index)
+        buffer = buffer.slice(match.index + match[0].length)
+        const data = frame.split(/\r?\n/).filter((line) => line.startsWith("data:")).map((line) =>
+          line.slice(5).replace(/^ /, "")
+        ).join("\n")
+        if (data) yield data
+      }
+    }
+    if (buffer.trim()) throw new Error("Truncated frame")
+  } finally {
+    await reader.cancel().catch(() => {})
+    reader.releaseLock()
+  }
+}
+
+export class StreamAdapter {
+  finished = false
+  tokens: number | null = null
+  private toolIndexes = new Map<number, number>()
+  constructor(private model: string, private type: Connection["api_type"], private id: string) {}
+  private chunk(delta: Obj, finish: string | null = null): Obj {
+    return {
+      id: this.id,
+      object: "chat.completion.chunk",
+      model: this.model,
+      choices: [{ index: 0, delta, finish_reason: finish }],
+    }
+  }
+  accept(data: string): Obj[] {
+    if (data === "[DONE]") {
+      if (this.type === "openai_chat") this.finished = true
+      return []
+    }
+    const e = object(JSON.parse(data))
+    if (e.error || ["error", "response.failed"].includes(String(e.type))) {
+      throw new Error("Upstream error")
+    }
+    if (this.type === "openai_chat") {
+      const u = usage(e.usage)
+      if (u) this.tokens = Number(u.total_tokens)
+      return [{
+        id: this.id,
+        object: "chat.completion.chunk",
+        model: this.model,
+        choices: e.choices ?? [],
+        ...(u ? { usage: u } : {}),
+      }]
+    }
+    if (e.type === "response.output_text.delta") return [this.chunk({ content: e.delta })]
+    if (e.type === "response.refusal.delta") return [this.chunk({ content: e.delta })]
+    if (e.type === "response.output_item.added") {
+      const item = object(e.item)
+      if (item.type !== "function_call") return []
+      const index = this.toolIndexes.size
+      this.toolIndexes.set(Number(e.output_index), index)
+      return [
+        this.chunk({
+          tool_calls: [{
+            index,
+            id: item.call_id,
+            type: "function",
+            function: { name: item.name, arguments: item.arguments ?? "" },
+          }],
+        }),
+      ]
+    }
+    if (e.type === "response.function_call_arguments.delta") {
+      const index = this.toolIndexes.get(Number(e.output_index))
+      if (index === undefined) throw new Error("Unknown tool")
+      return [this.chunk({ tool_calls: [{ index, function: { arguments: e.delta } }] })]
+    }
+    if (["response.completed", "response.incomplete"].includes(String(e.type))) {
+      const response = object(e.response), u = usage(response.usage, true)
+      if (u) this.tokens = Number(u.total_tokens)
+      this.finished = true
+      return [
+        this.chunk(
+          {},
+          e.type === "response.incomplete"
+            ? "length"
+            : this.toolIndexes.size
+            ? "tool_calls"
+            : "stop",
+        ),
+        { id: this.id, object: "chat.completion.chunk", model: this.model, choices: [], usage: u },
+      ]
+    }
+    return []
+  }
+}

--- a/supabase/functions/boss-ai/wire.ts
+++ b/supabase/functions/boss-ai/wire.ts
@@ -127,6 +127,12 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
     throw invalid()
   }
   if (input.stream !== undefined && typeof input.stream !== "boolean") throw invalid()
+  if (input.stream_options !== undefined) {
+    const options = object(input.stream_options)
+    onlyKeys(options, ["include_usage"])
+    // Accounting requires usage. Gateway requests true; explicitly declining it is unsupported.
+    if (options.include_usage !== undefined && options.include_usage !== true) throw invalid()
+  }
   const messages = input.messages.map((value) => {
     const m = object(value)
     if (

--- a/supabase/functions/boss-ai/wire.ts
+++ b/supabase/functions/boss-ai/wire.ts
@@ -91,6 +91,22 @@ export function endpoint(connection: Connection): string {
     (connection.api_type === "openai_chat" ? "/chat/completions" : "/responses")
 }
 
+/** Validate at the secret lookup itself, independent of endpoint call ordering. */
+export function upstreamKey(
+  connection: Connection,
+  read: (name: string) => string | undefined,
+): string {
+  if (
+    !/^BOSS_AI_[A-Z0-9_]+$/.test(connection.api_key_secret) ||
+    connection.api_key_secret === "BOSS_AI_SIGNING_SECRET"
+  ) {
+    throw new HttpError(503, "configuration", "BOSS AI is temporarily unavailable.")
+  }
+  const key = read(connection.api_key_secret)
+  if (!key) throw new HttpError(503, "configuration", "BOSS AI is temporarily unavailable.")
+  return key
+}
+
 export function requestBody(input: Obj, model: Model, type: Connection["api_type"]): Obj {
   const allowed = new Set([
     "model",
@@ -113,6 +129,11 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
   if (input.stream !== undefined && typeof input.stream !== "boolean") throw invalid()
   const messages = input.messages.map((value) => {
     const m = object(value)
+    if (
+      m.name !== undefined && (typeof m.name !== "string" || !/^[a-zA-Z0-9_-]{1,64}$/.test(m.name))
+    ) {
+      throw invalid()
+    }
     if (!["system", "developer", "user", "assistant", "tool"].includes(String(m.role))) {
       throw invalid()
     }
@@ -153,6 +174,12 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
       (!Array.isArray(m.tool_calls) || !model.capabilities.includes("tools"))
     ) throw invalid()
     if (Array.isArray(m.tool_calls)) m.tool_calls.forEach(functionCall)
+    if (
+      m.role === "tool" && (m.content === null ||
+        (Array.isArray(m.content) && m.content.some((part) => object(part).type !== "text")))
+    ) {
+      throw invalid()
+    }
     return m
   })
   const max = input.max_completion_tokens ?? input.max_tokens ??
@@ -236,7 +263,10 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
   const items: Obj[] = []
   for (const m of messages) {
     if (m.role === "tool") {
-      items.push({ type: "function_call_output", call_id: m.tool_call_id, output: m.content })
+      const output = typeof m.content === "string"
+        ? m.content
+        : (m.content as Obj[]).map((part) => part.text).join("")
+      items.push({ type: "function_call_output", call_id: m.tool_call_id, output })
       continue
     }
     if (m.content !== null && m.content !== "") {

--- a/supabase/functions/boss-ai/wire.ts
+++ b/supabase/functions/boss-ai/wire.ts
@@ -25,6 +25,21 @@ export function invalid(): HttpError {
   )
 }
 
+function onlyKeys(value: Obj, keys: string[]) {
+  if (Object.keys(value).some((key) => !keys.includes(key))) throw invalid()
+}
+
+function functionCall(value: unknown): Obj {
+  const call = object(value), f = object(call.function)
+  onlyKeys(call, ["id", "type", "function"])
+  onlyKeys(f, ["name", "arguments"])
+  if (
+    call.type !== "function" || typeof call.id !== "string" ||
+    typeof f.name !== "string" || typeof f.arguments !== "string"
+  ) throw invalid()
+  return call
+}
+
 // Bounded reads apply even when Content-Length is absent or false.
 export async function readJson(
   body: ReadableStream<Uint8Array> | null,
@@ -62,6 +77,12 @@ export async function readJson(
 }
 
 export function endpoint(connection: Connection): string {
+  if (
+    !/^BOSS_AI_[A-Z0-9_]+$/.test(connection.api_key_secret) ||
+    connection.api_key_secret === "BOSS_AI_SIGNING_SECRET"
+  ) {
+    throw new HttpError(503, "configuration", "BOSS AI is temporarily unavailable.")
+  }
   const url = new URL(connection.base_url)
   if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
     throw new HttpError(503, "configuration", "BOSS AI is temporarily unavailable.")
@@ -104,9 +125,17 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
       if (!Array.isArray(m.content)) throw invalid()
       for (const part of m.content) {
         const p = object(part)
-        if (p.type === "text" && typeof p.text === "string") continue
+        if (p.type === "text" && typeof p.text === "string") {
+          onlyKeys(p, ["type", "text"])
+          continue
+        }
         if (p.type === "image_url" && model.capabilities.includes("vision")) {
+          onlyKeys(p, ["type", "image_url"])
           const image = object(p.image_url)
+          onlyKeys(image, ["url", "detail"])
+          if (
+            image.detail !== undefined && !["auto", "low", "high"].includes(String(image.detail))
+          ) throw invalid()
           if (
             typeof image.url === "string" &&
             /^data:image\/(png|jpeg|webp);base64,[A-Za-z0-9+/=]+$/.test(image.url)
@@ -123,6 +152,7 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
       m.tool_calls !== undefined &&
       (!Array.isArray(m.tool_calls) || !model.capabilities.includes("tools"))
     ) throw invalid()
+    if (Array.isArray(m.tool_calls)) m.tool_calls.forEach(functionCall)
     return m
   })
   const max = input.max_completion_tokens ?? input.max_tokens ??
@@ -146,6 +176,11 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
     tools = input.tools.map((value) => {
       const t = object(value)
       const f = object(t.function)
+      onlyKeys(t, ["type", "function"])
+      onlyKeys(f, ["name", "description", "parameters", "strict"])
+      if (f.description !== undefined && typeof f.description !== "string") throw invalid()
+      if (f.strict !== undefined && typeof f.strict !== "boolean") throw invalid()
+      if (f.parameters !== undefined) object(f.parameters)
       if (
         t.type !== "function" || typeof f.name !== "string" || !/^[a-zA-Z0-9_-]{1,64}$/.test(f.name)
       ) throw invalid()
@@ -161,6 +196,8 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
       common.tool_choice = choice
     } else {
       const c = object(choice), f = object(c.function)
+      onlyKeys(c, ["type", "function"])
+      onlyKeys(f, ["name"])
       if (c.type !== "function" || typeof f.name !== "string") throw invalid()
       common.tool_choice = type === "openai_chat" ? c : { type: "function", name: f.name }
     }
@@ -172,7 +209,18 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
   if (input.response_format !== undefined) {
     if (!model.capabilities.includes("structured_output")) throw invalid()
     const format = object(input.response_format)
+    onlyKeys(format, ["type", "json_schema"])
     if (!["json_schema", "json_object", "text"].includes(String(format.type))) throw invalid()
+    if (format.type === "json_schema") {
+      const schema = object(format.json_schema)
+      onlyKeys(schema, ["name", "description", "schema", "strict"])
+      if (
+        typeof schema.name !== "string" ||
+        (schema.description !== undefined && typeof schema.description !== "string") ||
+        (schema.strict !== undefined && typeof schema.strict !== "boolean")
+      ) throw invalid()
+      object(schema.schema)
+    }
     if (type === "openai_chat") common.response_format = format
     else {common.text = {
         format: format.type === "json_schema"
@@ -222,7 +270,7 @@ export function usage(value: unknown, responses = false): Obj | null {
   const completion = u[responses ? "output_tokens" : "completion_tokens"]
   if (
     !Number.isSafeInteger(prompt) || !Number.isSafeInteger(completion) || Number(prompt) < 0 ||
-    Number(completion) < 0
+    Number(completion) < 0 || !Number.isSafeInteger(Number(prompt) + Number(completion))
   ) return null
   return {
     prompt_tokens: prompt,
@@ -237,14 +285,31 @@ export function completion(
   type: Connection["api_type"],
   id: string,
 ): Obj {
+  try {
+    return decodeCompletion(value, model, type, id)
+  } catch {
+    // Every decoding failure here belongs to the upstream, never to the caller.
+    throw new HttpError(502, "upstream_error", "The model returned an invalid response.")
+  }
+}
+
+function decodeCompletion(
+  value: Obj,
+  model: string,
+  type: Connection["api_type"],
+  id: string,
+): Obj {
   if (value.error) {
     throw new HttpError(502, "upstream_error", "The model could not complete this request.")
   }
   if (type === "openai_chat") {
-    if (!Array.isArray(value.choices) || value.choices.length !== 1) throw invalid()
+    if (!Array.isArray(value.choices) || value.choices.length !== 1) {
+      throw new HttpError(502, "upstream_error", "The model returned an invalid response.")
+    }
     return {
       id,
       object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
       model,
       choices: value.choices,
       usage: usage(value.usage),
@@ -266,10 +331,15 @@ export function completion(
   return {
     id,
     object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
     model,
     choices: [{
       index: 0,
-      message: { role: "assistant", content: text, ...(calls.length ? { tool_calls: calls } : {}) },
+      message: {
+        role: "assistant",
+        content: text || null,
+        ...(calls.length ? { tool_calls: calls } : {}),
+      },
       finish_reason: value.status === "incomplete"
         ? "length"
         : calls.length
@@ -281,8 +351,16 @@ export function completion(
 }
 
 // SSE frames can split anywhere, including within UTF-8 characters and CRLF pairs.
-export async function* events(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+export async function* events(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): AsyncGenerator<string> {
   const reader = body.pipeThrough(new TextDecoderStream()).getReader()
+  const cancel = () => {
+    void reader.cancel().catch(() => {})
+  }
+  signal?.addEventListener("abort", cancel, { once: true })
+  if (signal?.aborted) cancel()
   let buffer = ""
   try {
     while (true) {
@@ -301,8 +379,12 @@ export async function* events(body: ReadableStream<Uint8Array>): AsyncGenerator<
         if (data) yield data
       }
     }
-    if (buffer.trim()) throw new Error("Truncated frame")
+    // Comments contain no application data and need not turn a completed stream into an error.
+    if (buffer.split(/\r?\n/).some((line) => line.trim() && !line.startsWith(":"))) {
+      throw new Error("Truncated frame")
+    }
   } finally {
+    signal?.removeEventListener("abort", cancel)
     await reader.cancel().catch(() => {})
     reader.releaseLock()
   }
@@ -312,13 +394,15 @@ export class StreamAdapter {
   finished = false
   tokens: number | null = null
   private toolIndexes = new Map<number, number>()
+  private created = Math.floor(Date.now() / 1000)
   constructor(private model: string, private type: Connection["api_type"], private id: string) {}
   private chunk(delta: Obj, finish: string | null = null): Obj {
     return {
       id: this.id,
       object: "chat.completion.chunk",
+      created: this.created,
       model: this.model,
-      choices: [{ index: 0, delta, finish_reason: finish }],
+      choices: [{ index: 0, delta: { role: "assistant", ...delta }, finish_reason: finish }],
     }
   }
   accept(data: string): Obj[] {
@@ -336,6 +420,7 @@ export class StreamAdapter {
       return [{
         id: this.id,
         object: "chat.completion.chunk",
+        created: this.created,
         model: this.model,
         choices: e.choices ?? [],
         ...(u ? { usage: u } : {}),
@@ -377,7 +462,14 @@ export class StreamAdapter {
             ? "tool_calls"
             : "stop",
         ),
-        { id: this.id, object: "chat.completion.chunk", model: this.model, choices: [], usage: u },
+        {
+          id: this.id,
+          object: "chat.completion.chunk",
+          created: this.created,
+          model: this.model,
+          choices: [],
+          usage: u,
+        },
       ]
     }
     return []

--- a/supabase/functions/boss-ai/wire.ts
+++ b/supabase/functions/boss-ai/wire.ts
@@ -134,7 +134,11 @@ export function requestBody(input: Obj, model: Model, type: Connection["api_type
     if (options.include_usage !== undefined && options.include_usage !== true) throw invalid()
   }
   const messages = input.messages.map((value) => {
-    const m = object(value)
+    const original = object(value)
+    const m = original.role === "assistant" && original.content === undefined &&
+        Array.isArray(original.tool_calls) && original.tool_calls.length > 0
+      ? { ...original, content: null }
+      : original
     if (
       m.name !== undefined && (typeof m.name !== "string" || !/^[a-zA-Z0-9_-]{1,64}$/.test(m.name))
     ) {

--- a/supabase/migrations/20260912000000_boss_ai.sql
+++ b/supabase/migrations/20260912000000_boss_ai.sql
@@ -1,0 +1,166 @@
+-- Managed inference. Only the Edge Function's service role can access this surface.
+-- Usage is per user/model, regardless of which permission supplied the allowance.
+BEGIN;
+CREATE TABLE public.boss_ai_connections (
+  id text PRIMARY KEY,
+  base_url text NOT NULL CHECK (base_url ~ '^https://[^/?#]+'),
+  api_key_secret text NOT NULL CHECK (api_key_secret ~ '^BOSS_AI_[A-Z0-9_]+$'),
+  api_type text NOT NULL CHECK (api_type IN ('openai_chat', 'openai_responses')),
+  enabled boolean NOT NULL DEFAULT true
+);
+CREATE TABLE public.boss_ai_models (
+  id text PRIMARY KEY CHECK (id ~ '^[a-z0-9][a-z0-9._-]{0,99}$'),
+  display_name text NOT NULL,
+  connection_id text NOT NULL REFERENCES public.boss_ai_connections(id),
+  upstream_model text NOT NULL CHECK (length(upstream_model) > 0),
+  capabilities text[] NOT NULL DEFAULT ARRAY['text'],
+  context_length integer NOT NULL CHECK (context_length BETWEEN 1024 AND 2000000),
+  max_output_tokens integer NOT NULL CHECK (max_output_tokens BETWEEN 1 AND 2000000),
+  published boolean NOT NULL DEFAULT false,
+  enabled boolean NOT NULL DEFAULT true,
+  is_default boolean NOT NULL DEFAULT false,
+  CHECK (max_output_tokens <= context_length),
+  CHECK (capabilities <@ ARRAY['text','tools','vision','structured_output','reasoning']::text[])
+);
+CREATE UNIQUE INDEX boss_ai_one_default ON public.boss_ai_models(is_default) WHERE is_default;
+CREATE TABLE public.boss_ai_allowances (
+  model_id text NOT NULL REFERENCES public.boss_ai_models(id),
+  permission_name text NOT NULL REFERENCES public.permissions(name),
+  tokens_per_day bigint NOT NULL CHECK (tokens_per_day > 0),
+  tokens_per_week bigint NOT NULL CHECK (tokens_per_week > 0),
+  tokens_per_month bigint NOT NULL CHECK (tokens_per_month > 0),
+  max_concurrent integer NOT NULL DEFAULT 2 CHECK (max_concurrent BETWEEN 1 AND 100),
+  PRIMARY KEY (model_id, permission_name)
+);
+CREATE TABLE public.boss_ai_requests (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  model_id text NOT NULL REFERENCES public.boss_ai_models(id),
+  started_at timestamptz NOT NULL DEFAULT now(),
+  lease_until timestamptz NOT NULL DEFAULT now() + interval '5 minutes',
+  reserved_tokens bigint NOT NULL CHECK (reserved_tokens > 0),
+  charged_tokens bigint NOT NULL CHECK (charged_tokens >= 0),
+  settled boolean NOT NULL DEFAULT false
+);
+CREATE INDEX boss_ai_usage_lookup ON public.boss_ai_requests(user_id, model_id, started_at);
+
+ALTER TABLE public.boss_ai_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.boss_ai_models ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.boss_ai_allowances ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.boss_ai_requests ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.boss_ai_connections, public.boss_ai_models, public.boss_ai_allowances,
+  public.boss_ai_requests FROM PUBLIC, anon, authenticated;
+GRANT ALL ON public.boss_ai_connections, public.boss_ai_models, public.boss_ai_allowances,
+  public.boss_ai_requests TO service_role;
+
+INSERT INTO public.permissions(name, description, is_system)
+VALUES ('ai.use', 'Use the included BOSS AI models within their allowance', true)
+ON CONFLICT (name) DO NOTHING;
+INSERT INTO public.role_permissions(role_id, permission_id)
+SELECT r.id, p.id FROM public.roles r CROSS JOIN public.permissions p
+WHERE r.name = 'user' AND p.name = 'ai.use'
+ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+CREATE FUNCTION public.boss_ai_policy(p_user_id uuid, p_model_id text)
+RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT CASE WHEN count(*) = 0 THEN NULL ELSE jsonb_build_object(
+    'day', max(a.tokens_per_day), 'week', max(a.tokens_per_week),
+    'month', max(a.tokens_per_month), 'concurrent', max(a.max_concurrent)) END
+  FROM public.boss_ai_allowances a
+  JOIN public.boss_ai_models m ON m.id = a.model_id AND m.published AND m.enabled
+  JOIN public.boss_ai_connections c ON c.id = m.connection_id AND c.enabled
+  WHERE a.model_id = p_model_id
+    AND EXISTS (SELECT 1 FROM auth.users u WHERE u.id = p_user_id
+      AND (u.banned_until IS NULL OR u.banned_until < now()))
+    AND public.user_has_permission(p_user_id, a.permission_name);
+$$;
+
+CREATE FUNCTION public.boss_ai_usage(p_user_id uuid, p_model_id text)
+RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_policy jsonb := public.boss_ai_policy(p_user_id, p_model_id);
+  v_result jsonb := '{}'::jsonb;
+  v_period text;
+  v_start timestamptz;
+  v_used bigint;
+BEGIN
+  IF v_policy IS NULL THEN RETURN NULL; END IF;
+  FOREACH v_period IN ARRAY ARRAY['day','week','month'] LOOP
+    v_start := date_trunc(v_period, now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+    SELECT coalesce(sum(charged_tokens),0) INTO v_used FROM public.boss_ai_requests
+      WHERE user_id = p_user_id AND model_id = p_model_id AND started_at >= v_start;
+    v_result := v_result || jsonb_build_object(v_period, jsonb_build_object(
+      'limit', (v_policy->>v_period)::bigint, 'used', v_used,
+      'remaining', greatest(0, (v_policy->>v_period)::bigint - v_used),
+      'resets_at', (v_start AT TIME ZONE 'UTC' + ('1 ' || v_period)::interval) AT TIME ZONE 'UTC'));
+  END LOOP;
+  RETURN v_result;
+END;
+$$;
+
+CREATE FUNCTION public.boss_ai_catalog(p_user_id uuid)
+RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT coalesce(jsonb_agg(jsonb_build_object(
+    'id', m.id, 'object', 'model', 'name', m.display_name,
+    'context_length', m.context_length, 'max_output_tokens', m.max_output_tokens,
+    'capabilities', m.capabilities, 'is_default', m.is_default,
+    'allowance', public.boss_ai_usage(p_user_id, m.id))
+    ORDER BY m.is_default DESC, m.id), '[]'::jsonb)
+  FROM public.boss_ai_models m WHERE public.boss_ai_policy(p_user_id, m.id) IS NOT NULL;
+$$;
+
+-- Authorize and reserve under the same transaction lock. Every period counts the
+-- reservation immediately, including requests whose worker dies before settlement.
+CREATE FUNCTION public.boss_ai_reserve(p_user_id uuid, p_model_id text, p_request_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_model public.boss_ai_models;
+  v_connection public.boss_ai_connections;
+  v_policy jsonb;
+  v_usage jsonb;
+  v_period text;
+  v_active integer;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id::text || ':' || p_model_id, 0));
+  SELECT * INTO v_model FROM public.boss_ai_models WHERE id = p_model_id FOR SHARE;
+  SELECT * INTO v_connection FROM public.boss_ai_connections WHERE id = v_model.connection_id FOR SHARE;
+  v_policy := public.boss_ai_policy(p_user_id, p_model_id);
+  IF v_policy IS NULL THEN RETURN jsonb_build_object('error','forbidden'); END IF;
+  IF EXISTS (SELECT 1 FROM public.boss_ai_requests WHERE id = p_request_id) THEN
+    RETURN jsonb_build_object('error','duplicate');
+  END IF;
+  v_usage := public.boss_ai_usage(p_user_id, p_model_id);
+  FOREACH v_period IN ARRAY ARRAY['day','week','month'] LOOP
+    IF (v_usage->v_period->>'remaining')::bigint < v_model.context_length THEN
+      RETURN jsonb_build_object('error','allowance_exceeded', 'usage',v_usage);
+    END IF;
+  END LOOP;
+  SELECT count(*) INTO v_active FROM public.boss_ai_requests WHERE user_id = p_user_id
+    AND model_id = p_model_id AND NOT settled AND lease_until > now();
+  IF v_active >= (v_policy->>'concurrent')::integer THEN
+    RETURN jsonb_build_object('error','concurrency_exceeded');
+  END IF;
+  -- Reserve the full configured context as an upper bound, including image and
+  -- reasoning tokens. No client estimate is trusted. Successful calls release excess.
+  INSERT INTO public.boss_ai_requests(id,user_id,model_id,reserved_tokens,charged_tokens)
+    VALUES(p_request_id,p_user_id,p_model_id,v_model.context_length,v_model.context_length);
+  RETURN jsonb_build_object('model',to_jsonb(v_model),'connection',to_jsonb(v_connection));
+END;
+$$;
+
+CREATE FUNCTION public.boss_ai_settle(p_request_id uuid, p_tokens bigint)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF p_tokens IS NOT NULL AND p_tokens < 0 THEN RAISE EXCEPTION 'Invalid usage'; END IF;
+  UPDATE public.boss_ai_requests SET charged_tokens = coalesce(p_tokens,reserved_tokens), settled = true
+    WHERE id = p_request_id AND NOT settled;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.boss_ai_policy(uuid,text), public.boss_ai_usage(uuid,text),
+  public.boss_ai_catalog(uuid), public.boss_ai_reserve(uuid,text,uuid),
+  public.boss_ai_settle(uuid,bigint) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.boss_ai_policy(uuid,text), public.boss_ai_usage(uuid,text),
+  public.boss_ai_catalog(uuid), public.boss_ai_reserve(uuid,text,uuid),
+  public.boss_ai_settle(uuid,bigint) TO service_role;
+COMMIT;

--- a/supabase/migrations/20260912001000_boss_ai_hardening.sql
+++ b/supabase/migrations/20260912001000_boss_ai_hardening.sql
@@ -1,0 +1,18 @@
+BEGIN;
+-- Never allow a routing configuration to disclose the AI-token signing key.
+ALTER TABLE public.boss_ai_connections
+  DROP CONSTRAINT boss_ai_connections_api_key_secret_check,
+  ADD CONSTRAINT boss_ai_connections_api_key_secret_check
+    CHECK (api_key_secret ~ '^BOSS_AI_[A-Z0-9_]+$' AND api_key_secret <> 'BOSS_AI_SIGNING_SECRET');
+
+-- A malformed upstream counter must not charge beyond the admitted request bound.
+CREATE OR REPLACE FUNCTION public.boss_ai_settle(p_request_id uuid, p_tokens bigint)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF p_tokens IS NOT NULL AND p_tokens < 0 THEN RAISE EXCEPTION 'Invalid usage'; END IF;
+  UPDATE public.boss_ai_requests
+    SET charged_tokens = least(coalesce(p_tokens,reserved_tokens),reserved_tokens), settled = true
+    WHERE id = p_request_id AND NOT settled;
+END;
+$$;
+COMMIT;

--- a/supabase/migrations/20260912002000_boss_ai_validation.sql
+++ b/supabase/migrations/20260912002000_boss_ai_validation.sql
@@ -1,0 +1,52 @@
+BEGIN;
+-- Read-only preflight. Admission rechecks policy and returns its own current config,
+-- so an edit/revocation between validation and reservation cannot authorize a call.
+CREATE FUNCTION public.boss_ai_lookup(p_user_id uuid, p_model_id text)
+RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT jsonb_build_object('model',to_jsonb(m),'connection',to_jsonb(c))
+  FROM public.boss_ai_models m JOIN public.boss_ai_connections c ON c.id=m.connection_id
+  WHERE m.id=p_model_id AND public.boss_ai_policy(p_user_id,p_model_id) IS NOT NULL;
+$$;
+REVOKE ALL ON FUNCTION public.boss_ai_lookup(uuid,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.boss_ai_lookup(uuid,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.boss_ai_reserve(p_user_id uuid, p_model_id text, p_request_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_model public.boss_ai_models;
+  v_connection public.boss_ai_connections;
+  v_policy jsonb;
+  v_usage jsonb;
+  v_period text;
+  v_active integer;
+BEGIN
+  -- The post-lock recount needs a fresh snapshot, not a repeatable-read snapshot
+  -- taken before waiting. PostgREST's default is READ COMMITTED; fail other callers closed.
+  IF current_setting('transaction_isolation') <> 'read committed' THEN
+    RAISE EXCEPTION 'BOSS AI admission requires READ COMMITTED' USING ERRCODE='25000';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id::text || ':' || p_model_id, 0));
+  SELECT * INTO v_model FROM public.boss_ai_models WHERE id = p_model_id FOR SHARE;
+  SELECT * INTO v_connection FROM public.boss_ai_connections WHERE id = v_model.connection_id FOR SHARE;
+  v_policy := public.boss_ai_policy(p_user_id, p_model_id);
+  IF v_policy IS NULL THEN RETURN jsonb_build_object('error','forbidden'); END IF;
+  IF EXISTS (SELECT 1 FROM public.boss_ai_requests WHERE id = p_request_id) THEN
+    RETURN jsonb_build_object('error','duplicate');
+  END IF;
+  v_usage := public.boss_ai_usage(p_user_id, p_model_id);
+  FOREACH v_period IN ARRAY ARRAY['day','week','month'] LOOP
+    IF (v_usage->v_period->>'remaining')::bigint < v_model.context_length THEN
+      RETURN jsonb_build_object('error','allowance_exceeded', 'usage',v_usage);
+    END IF;
+  END LOOP;
+  SELECT count(*) INTO v_active FROM public.boss_ai_requests WHERE user_id = p_user_id
+    AND model_id = p_model_id AND NOT settled AND lease_until > now();
+  IF v_active >= (v_policy->>'concurrent')::integer THEN
+    RETURN jsonb_build_object('error','concurrency_exceeded');
+  END IF;
+  INSERT INTO public.boss_ai_requests(id,user_id,model_id,reserved_tokens,charged_tokens)
+    VALUES(p_request_id,p_user_id,p_model_id,v_model.context_length,v_model.context_length);
+  RETURN jsonb_build_object('model',to_jsonb(v_model),'connection',to_jsonb(v_connection));
+END;
+$$;
+COMMIT;

--- a/supabase/migrations/20260912003000_boss_ai_allowance_preflight.sql
+++ b/supabase/migrations/20260912003000_boss_ai_allowance_preflight.sql
@@ -1,0 +1,18 @@
+BEGIN;
+-- Distinguish an allowance that can never fit one request from temporary exhaustion.
+-- CREATE OR REPLACE retains the service-role-only grants on this read-only RPC.
+CREATE OR REPLACE FUNCTION public.boss_ai_lookup(p_user_id uuid, p_model_id text)
+RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  WITH config AS MATERIALIZED (
+    SELECT to_jsonb(m) AS model, to_jsonb(c) AS connection, m.context_length,
+      public.boss_ai_policy(p_user_id,p_model_id) AS policy
+    FROM public.boss_ai_models m JOIN public.boss_ai_connections c ON c.id=m.connection_id
+    WHERE m.id=p_model_id
+  )
+  SELECT CASE WHEN least((policy->>'day')::bigint,(policy->>'week')::bigint,
+    (policy->>'month')::bigint) < context_length
+    THEN jsonb_build_object('error','misconfigured_allowance')
+    ELSE jsonb_build_object('model',model,'connection',connection) END
+  FROM config WHERE policy IS NOT NULL;
+$$;
+COMMIT;

--- a/supabase/tests/boss_ai_test.sql
+++ b/supabase/tests/boss_ai_test.sql
@@ -4,12 +4,13 @@ SELECT no_plan();
 INSERT INTO auth.users(id,email) VALUES
  ('ba000000-0000-4000-8000-000000000001','boss-ai-one@pgtap.test'),
  ('ba000000-0000-4000-8000-000000000002','boss-ai-two@pgtap.test');
-INSERT INTO public.boss_ai_connections VALUES
+INSERT INTO public.boss_ai_connections(id,base_url,api_key_secret,api_type,enabled) VALUES
  ('pgtap','https://example.com/v1','BOSS_AI_TEST','openai_chat',true);
 INSERT INTO public.boss_ai_models
  (id,display_name,connection_id,upstream_model,context_length,max_output_tokens,published)
  VALUES('pgtap','Test','pgtap','private',1024,128,true);
-INSERT INTO public.boss_ai_allowances VALUES('pgtap','ai.use',10240,20480,40960,2);
+INSERT INTO public.boss_ai_allowances(model_id,permission_name,tokens_per_day,tokens_per_week,tokens_per_month,max_concurrent)
+ VALUES('pgtap','ai.use',10240,20480,40960,2);
 
 SELECT ok(public.user_has_permission('ba000000-0000-4000-8000-000000000001','ai.use'),
  'new users inherit the baseline AI permission through real RBAC');

--- a/supabase/tests/boss_ai_test.sql
+++ b/supabase/tests/boss_ai_test.sql
@@ -24,6 +24,10 @@ SELECT ok(public.boss_ai_lookup('ba000000-0000-4000-8000-000000000001','pgtap') 
  'authorized service-role preflight returns configuration');
 SELECT is((SELECT count(*) FROM public.boss_ai_requests WHERE model_id='pgtap'),0::bigint,
  'preflight creates no accounting rows');
+UPDATE public.boss_ai_allowances SET tokens_per_day=1 WHERE model_id='pgtap';
+SELECT is(public.boss_ai_lookup('ba000000-0000-4000-8000-000000000001','pgtap')->>'error',
+ 'misconfigured_allowance','an allowance smaller than one context is a configuration fault');
+UPDATE public.boss_ai_allowances SET tokens_per_day=10240 WHERE model_id='pgtap';
 SELECT is((SELECT count(*) FROM public.boss_ai_connections WHERE id='pgtap'),1::bigint,
  'real service role can read RLS-protected routing');
 SELECT ok(public.boss_ai_reserve('ba000000-0000-4000-8000-000000000001','pgtap',

--- a/supabase/tests/boss_ai_test.sql
+++ b/supabase/tests/boss_ai_test.sql
@@ -1,0 +1,98 @@
+-- Real RBAC/auth schema integration; all fixtures roll back with the test.
+BEGIN;
+SELECT no_plan();
+INSERT INTO auth.users(id,email) VALUES
+ ('ba000000-0000-4000-8000-000000000001','boss-ai-one@pgtap.test'),
+ ('ba000000-0000-4000-8000-000000000002','boss-ai-two@pgtap.test');
+INSERT INTO public.boss_ai_connections VALUES
+ ('pgtap','https://example.com/v1','BOSS_AI_TEST','openai_chat',true);
+INSERT INTO public.boss_ai_models
+ (id,display_name,connection_id,upstream_model,context_length,max_output_tokens,published)
+ VALUES('pgtap','Test','pgtap','private',1024,128,true);
+INSERT INTO public.boss_ai_allowances VALUES('pgtap','ai.use',10240,20480,40960,2);
+
+SELECT ok(public.user_has_permission('ba000000-0000-4000-8000-000000000001','ai.use'),
+ 'new users inherit the baseline AI permission through real RBAC');
+SELECT is((public.boss_ai_policy('ba000000-0000-4000-8000-000000000001','pgtap')->>'day')::bigint,
+ 10240::bigint,'baseline permission selects the allowance');
+SELECT throws_ok($$UPDATE public.boss_ai_connections SET api_key_secret='BOSS_AI_SIGNING_SECRET'
+ WHERE id='pgtap'$$, '23514', NULL, 'signing secret cannot become an upstream key');
+
+SET LOCAL ROLE service_role;
+SELECT is((SELECT count(*) FROM public.boss_ai_connections WHERE id='pgtap'),1::bigint,
+ 'real service role can read RLS-protected routing');
+SELECT ok(public.boss_ai_reserve('ba000000-0000-4000-8000-000000000001','pgtap',
+ 'bb000000-0000-4000-8000-000000000001') ? 'model','service role can reserve through real RBAC');
+SELECT is(public.boss_ai_reserve('ba000000-0000-4000-8000-000000000001','pgtap',
+ 'bb000000-0000-4000-8000-000000000001')->>'error','duplicate','duplicate requests are refused');
+SELECT ok(public.boss_ai_reserve('ba000000-0000-4000-8000-000000000001','pgtap',
+ 'bb000000-0000-4000-8000-000000000002') ? 'model','second concurrency slot admitted');
+SELECT is(public.boss_ai_reserve('ba000000-0000-4000-8000-000000000001','pgtap',
+ 'bb000000-0000-4000-8000-000000000003')->>'error','concurrency_exceeded','slot cap enforced');
+SELECT ok(public.boss_ai_reserve('ba000000-0000-4000-8000-000000000002','pgtap',
+ 'bb000000-0000-4000-8000-000000000004') ? 'model','other users have separate slots and usage');
+UPDATE public.boss_ai_requests SET lease_until=now()-interval '1 second'
+ WHERE id='bb000000-0000-4000-8000-000000000001';
+SELECT ok(public.boss_ai_reserve('ba000000-0000-4000-8000-000000000001','pgtap',
+ 'bb000000-0000-4000-8000-000000000003') ? 'model','expired lease releases its slot');
+SELECT is((SELECT charged_tokens FROM public.boss_ai_requests
+ WHERE id='bb000000-0000-4000-8000-000000000001'),1024::bigint,'expired lease keeps unknown usage charged');
+SELECT public.boss_ai_settle('bb000000-0000-4000-8000-000000000001',99999999999);
+SELECT is((SELECT charged_tokens FROM public.boss_ai_requests
+ WHERE id='bb000000-0000-4000-8000-000000000001'),1024::bigint,'upstream usage cannot exceed the admitted bound');
+SELECT public.boss_ai_settle('bb000000-0000-4000-8000-000000000002',7);
+SELECT public.boss_ai_settle('bb000000-0000-4000-8000-000000000002',0);
+SELECT is((SELECT charged_tokens FROM public.boss_ai_requests
+ WHERE id='bb000000-0000-4000-8000-000000000002'),7::bigint,'settlement is first-writer-wins');
+RESET ROLE;
+
+UPDATE auth.users SET banned_until=now()+interval '1 hour'
+ WHERE id='ba000000-0000-4000-8000-000000000001';
+SELECT is(public.boss_ai_policy('ba000000-0000-4000-8000-000000000001','pgtap'),NULL::jsonb,
+ 'banned users lose model permission');
+UPDATE auth.users SET banned_until=NULL WHERE id='ba000000-0000-4000-8000-000000000001';
+UPDATE public.boss_ai_connections SET enabled=false WHERE id='pgtap';
+SELECT is(public.boss_ai_catalog('ba000000-0000-4000-8000-000000000001'),'[]'::jsonb,
+ 'disabled connections disappear from the catalog');
+UPDATE public.boss_ai_connections SET enabled=true WHERE id='pgtap';
+UPDATE public.boss_ai_models SET published=false WHERE id='pgtap';
+SELECT is(public.boss_ai_policy('ba000000-0000-4000-8000-000000000001','pgtap'),NULL::jsonb,
+ 'unpublished models deny admission');
+UPDATE public.boss_ai_models SET published=true WHERE id='pgtap';
+
+-- Exercise the actual usage function on both sides of every current UTC boundary,
+-- with a non-UTC database timezone. Separate windows are isolated by deleting fixtures.
+SET LOCAL timezone='Pacific/Honolulu';
+SELECT lives_ok($test$
+DO $body$
+DECLARE period text; boundary timestamptz; usage jsonb;
+BEGIN
+ FOREACH period IN ARRAY ARRAY['day','week','month'] LOOP
+  DELETE FROM public.boss_ai_requests WHERE model_id='pgtap';
+  boundary := date_trunc(period,now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+  INSERT INTO public.boss_ai_requests(id,user_id,model_id,started_at,reserved_tokens,charged_tokens,settled)
+  VALUES(gen_random_uuid(),'ba000000-0000-4000-8000-000000000001','pgtap',boundary-interval '1 microsecond',1024,30,true),
+        (gen_random_uuid(),'ba000000-0000-4000-8000-000000000001','pgtap',boundary,1024,7,true);
+  usage := public.boss_ai_usage('ba000000-0000-4000-8000-000000000001','pgtap')->period;
+  IF (usage->>'used')::bigint <> 7 THEN RAISE EXCEPTION 'bad % rollover',period; END IF;
+  IF (usage->>'resets_at')::timestamptz <>
+    ((boundary AT TIME ZONE 'UTC')+('1 '||period)::interval) AT TIME ZONE 'UTC'
+  THEN RAISE EXCEPTION 'bad % reset',period; END IF;
+ END LOOP;
+END $body$;
+$test$, 'UTC day, Monday-week and month boundaries exclude the preceding window');
+
+DELETE FROM public.role_permissions WHERE permission_id=(SELECT id FROM public.permissions WHERE name='ai.use');
+SELECT is(public.boss_ai_policy('ba000000-0000-4000-8000-000000000001','pgtap'),NULL::jsonb,
+ 'revoking the real baseline grant takes effect immediately');
+SET LOCAL ROLE authenticated;
+SELECT throws_ok('SELECT * FROM public.boss_ai_connections','42501',NULL,'authenticated cannot read keys/routing');
+SELECT throws_ok($$SELECT public.boss_ai_catalog('ba000000-0000-4000-8000-000000000001')$$,
+ '42501',NULL,'authenticated cannot impersonate a catalog user');
+SET LOCAL ROLE anon;
+SELECT throws_ok('SELECT * FROM public.boss_ai_requests','42501',NULL,'anonymous cannot read accounting');
+SELECT throws_ok($$SELECT public.boss_ai_settle('bb000000-0000-4000-8000-000000000001',0)$$,
+ '42501',NULL,'anonymous cannot refund requests');
+RESET ROLE;
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/boss_ai_test.sql
+++ b/supabase/tests/boss_ai_test.sql
@@ -19,6 +19,10 @@ SELECT throws_ok($$UPDATE public.boss_ai_connections SET api_key_secret='BOSS_AI
  WHERE id='pgtap'$$, '23514', NULL, 'signing secret cannot become an upstream key');
 
 SET LOCAL ROLE service_role;
+SELECT ok(public.boss_ai_lookup('ba000000-0000-4000-8000-000000000001','pgtap') ? 'model',
+ 'authorized service-role preflight returns configuration');
+SELECT is((SELECT count(*) FROM public.boss_ai_requests WHERE model_id='pgtap'),0::bigint,
+ 'preflight creates no accounting rows');
 SELECT is((SELECT count(*) FROM public.boss_ai_connections WHERE id='pgtap'),1::bigint,
  'real service role can read RLS-protected routing');
 SELECT ok(public.boss_ai_reserve('ba000000-0000-4000-8000-000000000001','pgtap',
@@ -41,6 +45,8 @@ SELECT public.boss_ai_settle('bb000000-0000-4000-8000-000000000001',99999999999)
 SELECT is((SELECT charged_tokens FROM public.boss_ai_requests
  WHERE id='bb000000-0000-4000-8000-000000000001'),1024::bigint,'upstream usage cannot exceed the admitted bound');
 SELECT public.boss_ai_settle('bb000000-0000-4000-8000-000000000002',7);
+SELECT throws_ok($$SELECT public.boss_ai_settle('bb000000-0000-4000-8000-000000000002',-1)$$,
+ 'P0001','Invalid usage','negative settlement is rejected');
 SELECT public.boss_ai_settle('bb000000-0000-4000-8000-000000000002',0);
 SELECT is((SELECT charged_tokens FROM public.boss_ai_requests
  WHERE id='bb000000-0000-4000-8000-000000000002'),7::bigint,'settlement is first-writer-wins');
@@ -86,6 +92,8 @@ DELETE FROM public.role_permissions WHERE permission_id=(SELECT id FROM public.p
 SELECT is(public.boss_ai_policy('ba000000-0000-4000-8000-000000000001','pgtap'),NULL::jsonb,
  'revoking the real baseline grant takes effect immediately');
 SET LOCAL ROLE authenticated;
+SELECT throws_ok($$SELECT public.boss_ai_lookup('ba000000-0000-4000-8000-000000000001','pgtap')$$,
+ '42501',NULL,'authenticated cannot read upstream config through preflight');
 SELECT throws_ok('SELECT * FROM public.boss_ai_connections','42501',NULL,'authenticated cannot read keys/routing');
 SELECT throws_ok($$SELECT public.boss_ai_catalog('ba000000-0000-4000-8000-000000000001')$$,
  '42501',NULL,'authenticated cannot impersonate a catalog user');

--- a/supabase/tests/plugin_create_permission_test.sql
+++ b/supabase/tests/plugin_create_permission_test.sql
@@ -69,7 +69,10 @@ select set_eq(
               -- everyone gets their own vault and Settings > AI Providers. Inherited,
               -- not direct: this role still cannot share a secret with a role, which is
               -- what the secret.share.role assertion below pins.
-              ('secret.read') $$,
+              ('secret.read'),
+              -- Managed AI is also a baseline user permission (20260912000000).
+              -- Model access still requires a published model and an allowance.
+              ('ai.use') $$,
     'boss_plugin_admin EFFECTIVE = direct + the inherited user.* baseline'
 );
 


### PR DESCRIPTION
## Summary

- Add the authenticated `boss-ai` Supabase edge function with a multi-model catalog, streaming inference, and Chat Completions/Responses upstream adapters.
- Configure connections, published models, capabilities, and permission-based daily/weekly/monthly allowances server-side. Reserve usage transactionally per user/model and reconcile actual usage.
- Register the trusted host credential broker. The provider itself is distributed through Secret Manager's existing sharing feature, not a hardcoded provider preset; upstream keys never enter shared definitions.
- Document deployment, the shared-definition schema, security boundaries, and rollout requirements; add backend CI checks.

## Validation

- Deno type check and all 15 backend tests passed, including the real migration in PGlite.
- Host production Kotlin compilation passed. Targeted host tests were blocked during test compilation by unrelated existing local favicon tests; those files are excluded from this PR.
- Working-tree self-review and whitespace checks completed before pushing.

## Rollout and limitations

- Companion Secret Manager change: https://github.com/risa-labs-inc/boss-plugin-secret-manager/pull/28.
- Not deployed: apply the migration, configure upstream secrets/connections/models and approved allowances, deploy the function, and publish an admin-owned provider definition through vault sharing.
- Admission reserves the full configured context limit; callers need that much allowance headroom. Unknown/canceled outcomes retain the reservation. The configured bound must match upstream enforcement.
- Access uses authenticated BOSS sessions and short-lived bearer tokens, not desktop executable attestation. Copied tokens remain usable until expiry, subject to live model authorization.
- Staging validation with actual upstreams and independent PostgreSQL sessions remains outstanding. Fresh-install plugin bundling is out of scope.
