### PR TITLE
fix(ui): keep rail stationary during drawer hover to preserve Fitts's Law hit-targets

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
@@ -333,13 +333,22 @@ internal enum class VerticalBarHost {
  *
  * Three states, not two, and an enum rather than a pair of booleans because two of the three are
  * the same bar: an EXPANDED left bar has a foot under its split map, a COLLAPSED one is a rail
- * whose bottom is the only room it has, and a collapsed bar whose hover drawer is OPEN has a foot
- * again for as long as the drawer is up, because the drawer is a full bar. Carried as two flags
- * these would admit "a foot AND a rail", which is not a window that exists.
+ * whose bottom is the only room it has.
+ *
+ * Permanent Activity Bar: a collapsed rail stays a rail even while its hover drawer is open.
+ * The drawer is a sibling beside the rail, not a replacement that absorbs it. Switching the
+ * host from RAIL to FOOT on drawerVisible moved Settings/Search/Sign-Out from a vertical
+ * column at the foot of a 36dp rail into a horizontal wrapping row under the drawer's split
+ * map - the exact vertical→horizontal jump that violated Fitts's Law and forced users to chase
+ * the target. Keeping the rail stationary means the hit-target never moves out from under the
+ * cursor; the drawer carries only the tab list and the window's own footer chrome.
+ *
+ * Carried as two flags these would admit "a foot AND a rail", which is not a window that exists.
  *
  * Pure and named because it is the one input to [focusQuickActionsPlacement] that is not a
  * standing preference, and because the scaffold that reads it is at detekt's complexity ceiling.
  */
+@Suppress("UNUSED_PARAMETER")
 internal fun verticalBarHost(
     tabBarOnLeft: Boolean,
     barCollapsed: Boolean,
@@ -347,6 +356,6 @@ internal fun verticalBarHost(
 ): VerticalBarHost =
     when {
         !tabBarOnLeft -> VerticalBarHost.NONE
-        !barCollapsed || drawerVisible -> VerticalBarHost.FOOT
+        !barCollapsed -> VerticalBarHost.FOOT
         else -> VerticalBarHost.RAIL
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -27,6 +27,7 @@ import ai.rever.boss.components.window_panel.components.main_window_panels.remem
 import ai.rever.boss.components.window_panel.components.main_window_panels.rememberToggleCollapseAction
 import ai.rever.boss.components.window_panel.components.main_window_panels.rememberWindowTabGroups
 import ai.rever.boss.icons.FileIcons
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.platform.bossFileDropTarget
 import ai.rever.boss.plugin.api.Panel
 import ai.rever.boss.plugin.api.TabIcon
@@ -2005,10 +2006,10 @@ fun SplitViewPanel(
     /**
      * Reports whether the hover-revealed bar is on screen.
      *
-     * The window needs it because it decides where the host's actions go: a collapsed bar puts
-     * them at the foot of its rail, and a revealed drawer IS a full bar, so while it is up they
-     * move from the rail's bottom into the bar's foot. Only this composable knows: the reveal
-     * state machine lives here. See `verticalBarHost`.
+     * Permanent Activity Bar: the drawer is a sibling beside the permanent rail, so its
+     * visibility no longer moves host actions between rail and bar foot. Kept for the
+     * scaffold's drawer bookkeeping and traffic-light inset; placement now ignores it.
+     * See `verticalBarHost`.
      */
     onDrawerVisibleChange: (Boolean) -> Unit = {},
     /**
@@ -2265,9 +2266,14 @@ private fun rememberSplitTree(
 /**
  * The hover-revealed bar, with everything the pinned one carries.
  *
+ * Permanent Activity Bar: the drawer sits BESIDE the permanent rail rather than over it.
+ * The in-flow rail stays visible and keeps the host actions (Settings/Search/Sign-Out) at
+ * its foot; the drawer carries only the tab list and the window footer. ContentRegion is
+ * therefore offset by the rail width before it is handed to the drawer.
+ *
  * Split out of [SplitViewPanel], which is at detekt's length ceiling. Both slots are passed
- * because while this is open it is the only bar on screen - the in-flow one is down to its rail -
- * so anything missing here is missing outright, not merely missing from a preview.
+ * because while this is open the rail is still on screen - so anything missing here is
+ * missing from the drawer, not from the window.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -2280,14 +2286,15 @@ private fun BoxScope.RevealedBar(
     footer: @Composable () -> Unit,
     belowMap: @Composable () -> Unit,
 ) {
+    val railWidth = BossChrome.dimens.stripWidth
     WindowRevealedTabBarDrawer(
         splitViewState = splitViewState,
         bar = bar,
         reveal = reveal,
-        // Started BELOW the traffic-light clearance rather than padded inside it. The drawer is
-        // its own always-on-top window, so the lights are behind it whatever it pads - the only
-        // way to leave them visible is to not cover them. The region is already in dp.
-        contentRegion = contentRegion.below(topInset),
+        // Started BELOW the traffic-light clearance and BESIDE the permanent rail.
+        // The drawer is its own always-on-top window; offsetting leaves the rail visible
+        // and keeps its hit-targets stationary (Fitts's Law) instead of covering them.
+        contentRegion = contentRegion.below(topInset).besideRail(railWidth),
         footer = footer,
         belowMap = belowMap,
         onPin = rememberPinDrawerAction(reveal, bar),
@@ -2305,6 +2312,19 @@ private fun IntRect?.below(inset: Dp): IntRect? {
     val region = this ?: return null
     val dp = inset.value.roundToInt()
     return if (dp <= 0) region else region.copy(top = region.top + dp)
+}
+
+/**
+ * The region with its left moved by the permanent rail width.
+ *
+ * Permanent Activity Bar: the drawer is a sibling beside the rail, not an overlay over it.
+ * Offsetting the region keeps the rail's 40dp hit-targets visible and stationary (Fitts's Law)
+ * instead of covering them for the duration of the drawer.
+ */
+private fun IntRect?.besideRail(railWidth: Dp): IntRect? {
+    val region = this ?: return null
+    val dp = railWidth.value.roundToInt()
+    return if (dp <= 0) region else region.copy(left = region.left + dp)
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/VerticalTabBarDrawer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/VerticalTabBarDrawer.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.window_panel.components.main_window_panels
 
 import ai.rever.boss.components.overlays.OverlayCorner
 import ai.rever.boss.components.overlays.overlayCornerIsHeavyweight
+import ai.rever.boss.layout.BossChrome
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,8 +26,13 @@ import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
 
 /**
- * The full vertical tab bar shown as a temporary drawer over a panel whose bar is down to its
- * rail.
+ * The full vertical tab bar shown as a temporary drawer beside the permanent activity rail.
+ *
+ * Permanent Activity Bar: the drawer is a sibling beside the 40dp rail, not an overlay over it.
+ * The rail's Settings/Search/Sign-Out icons stay stationary at the window edge (Fitts's Law);
+ * this drawer carries only the tab list and the window footer. The heavyweight region is
+ * therefore offset by the rail width before placement (see `SplitView.RevealedBar.besideRail`);
+ * the lightweight path offsets in the Compose scene for the same reason.
  *
  * **Why this is not just a Box with an offset.** Under HARDWARE_ACCELERATED JxBrowser - the
  * default on every platform - a browser tab is Chromium's own native window composited ABOVE the
@@ -43,8 +50,9 @@ import kotlin.math.roundToInt
  *
  * @param hoverSource the drawer's hover interaction source, owned by the caller because the
  *   reveal decision needs it alongside the rail's.
- * @param panelRegion this panel's rectangle in dp relative to the window's content pane. Null
- *   means not yet measured, and nothing is drawn - see [overlayRegionInWindow].
+ * @param panelRegion this panel's rectangle in dp relative to the window's content pane, already
+ *   offset beside the rail for the permanent activity bar. Null means not yet measured, and
+ *   nothing is drawn - see [overlayRegionInWindow].
  * @param onDismissOutside installs a click-catcher over the rest of the panel that invokes this.
  *   Non-null only for a drawer opened by the chevron; a hover-revealed one must NOT swallow the
  *   click that focuses the content behind it, since the pointer leaving is what closes it.
@@ -88,9 +96,11 @@ fun BoxScope.VerticalTabBarDrawer(
         // drawer can slide in the scene. Reachable via BOSS_RENDERING_MODE=OFF_SCREEN, which is a
         // supported escape hatch rather than a dead branch. The heavyweight path gets no slide -
         // animating a native window's bounds per frame is a different and much worse trade.
+        // Permanent Activity Bar: offset beside the 40dp rail so its hit-targets stay exposed.
+        val railWidth = BossChrome.dimens.stripWidth
         AnimatedVisibility(
             visible = true,
-            modifier = Modifier.align(Alignment.CenterStart).fillMaxHeight(),
+            modifier = Modifier.align(Alignment.CenterStart).fillMaxHeight().padding(start = railWidth),
             enter = slideInHorizontally(initialOffsetX = { -it }),
             exit = slideOutHorizontally(targetOffsetX = { -it }),
         ) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/WindowVerticalTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/WindowVerticalTabBar.kt
@@ -213,13 +213,11 @@ fun WindowVerticalTabBar(
      *
      * A second slot rather than [belowMap] handed to both branches, which is what this was, and
      * the reason is that the two are on screen at once. `SplitViewPanel` composes the in-flow rail
-     * and the hover drawer together - the drawer is an overlay over the rail, not a replacement
-     * for it - and the drawer being open makes the LIVE placement `TAB_BAR_FOOTER`. One shared
-     * slot therefore drew the full bar's wrapping row twice: once in the drawer's foot, and once
-     * behind it at the bottom of a 36dp rail, where four 32dp buttons wrap to four lines of
-     * squeezed icons. Hidden while the drawer covers it, and visible for the frame after it is
-     * dismissed - `drawerVisible` is reported through a `LaunchedEffect`, so the uncovered rail
-     * draws the wrong layout for one frame before the placement catches up.
+     * and the hover drawer together as siblings (Permanent Activity Bar) - the drawer sits beside
+     * the rail, not over it. The rail keeps the host actions stationary (Fitts's Law) while the
+     * drawer carries only the tab list and footer; a shared slot previously drew the full bar's
+     * wrapping row behind the 36dp rail where four 32dp buttons wrapped to four lines of squeezed
+     * icons.
      *
      * With two slots each branch is handed only its own layout, so there is nothing to get wrong.
      */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
@@ -33,12 +33,10 @@ import kotlin.test.assertNull
  * them, where every failure is silent. Two hosts drawing at once is Sign Out twice; a host drawing
  * for a placement it does not own is Sign Out in a container nothing is composing.
  *
- * The first test exists because that second failure SHIPPED in this change's first draft: one slot
- * was handed to both the collapsed rail and the hover drawer on the reasoning that "a rail is
- * TAB_BAR_RAIL and a full bar is TAB_BAR_FOOTER, never both". `SplitViewPanel` composes the rail
- * and the drawer TOGETHER - the drawer is an overlay over the rail, not a replacement - so with
- * the drawer up the rail drew the full bar's wrapping row at 36dp wide, four lines of squeezed
- * icons, visible for the frame after dismissal.
+ * Permanent Activity Bar: the drawer is a sibling beside the rail, not an overlay over it. The
+ * rail keeps the host actions (Settings/Search/Sign-Out) stationary at its foot while the drawer
+ * carries only the tab list. This test verifies that opening the drawer never moves the actions
+ * out of the rail or doubles them.
  */
 class HostActionsWiringTest {
     @get:Rule
@@ -61,13 +59,14 @@ class HostActionsWiringTest {
     )
 
     @Test
-    fun `the hover drawer moves the actions out of the rail, never doubles them`() {
+    fun `the hover drawer keeps the actions in the rail, never doubles them`() {
         val drawerVisible = mutableStateOf(false)
         rule.setContent {
             val placement = placementFor(drawerVisible = drawerVisible.value)
             // Both hosts composed together on purpose: that is the configuration the bug was in,
             // and asserting on the CONTENT rather than on which slot receives it keeps this
             // honest even if someone shares one slot between the branches again.
+            // Permanent Activity Bar: drawer is a sibling beside the rail, not a replacement.
             Column(modifier = Modifier.width(BAR_WIDTH)) {
                 VerticalBarRailActions(
                     focusQuickActionsTabRail(placement, {}, {}, {}, { _, _ -> }),
@@ -83,11 +82,11 @@ class HostActionsWiringTest {
 
         drawerVisible.value = true
         rule.waitForIdle()
-        assertOnly(VERTICAL_BAR_HOST_ACTIONS_TAG, "the drawer is a full bar, so its foot takes them")
+        assertOnly(VERTICAL_BAR_RAIL_ACTIONS_TAG, "the drawer is a sibling beside the rail, so it keeps them")
 
         drawerVisible.value = false
         rule.waitForIdle()
-        assertOnly(VERTICAL_BAR_RAIL_ACTIONS_TAG, "and dismissing it hands them back to the rail")
+        assertOnly(VERTICAL_BAR_RAIL_ACTIONS_TAG, "and dismissing it leaves them in the rail")
     }
 
     /** Exactly one of the two bar layouts on screen, and it is [expected]. */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
@@ -98,10 +98,11 @@ class QuickActionsFooterPlacementTest {
             placement(rightStripHidden = true, verticalBar = collapsedOnLeft),
         )
 
-        // The drawer is the third state: a collapsed bar with it open HAS a foot again.
+        // Permanent Activity Bar: drawer open keeps the rail stationary (Fitts's Law).
+        // The collapsed rail is a sibling beside the drawer, not absorbed by it.
         val drawerOpen = verticalBarHost(tabBarOnLeft = true, barCollapsed = true, drawerVisible = true)
         assertEquals(
-            FocusQuickActionsPlacement.TAB_BAR_FOOTER,
+            FocusQuickActionsPlacement.TAB_BAR_RAIL,
             placement(rightStripHidden = true, verticalBar = drawerOpen),
         )
     }
@@ -250,10 +251,11 @@ class VerticalBarHostTest {
     }
 
     @Test
-    fun `a collapsed bar with the drawer open has a foot again`() {
-        // The drawer is a full bar, split map and all, for as long as it is up.
+    fun `a collapsed bar with the drawer open keeps the rail`() {
+        // Permanent Activity Bar: drawer is a sibling beside the rail, not a full bar that
+        // replaces it. Hit-targets stay in the stationary rail (Fitts's Law).
         assertEquals(
-            VerticalBarHost.FOOT,
+            VerticalBarHost.RAIL,
             verticalBarHost(tabBarOnLeft = true, barCollapsed = true, drawerVisible = true),
         )
     }


### PR DESCRIPTION
## Problem

When hovering to expand the sidebar drawer, host quick-action icons (Settings/Search/Sign-Out) jump from a vertical rail into a horizontal footer, moving the hit-target out from under the cursor. This violates Fitts's Law and forces users to chase buttons with their mouse.

The root cause is erticalBarHost() switching from RAIL to FOOT when drawerVisible=true, which restructures the entire action layout from vertical to horizontal.

## Solution

**Permanent Activity Bar** - the 40dp vertical rail stays stationary while the hover drawer slides out as a sibling beside it.

### Changes (6 files, +78/-40)

1. **\erticalBarHost()\** - Collapsed rail now returns \RAIL\ even when drawer is open (\drawerVisible\ ignored)
2. **\RevealedBar\** - Heavyweight drawer offset by rail width via new \esideRail()\ extension
3. **\VerticalTabBarDrawer\** - Lightweight path adds \padding(start = railWidth)\
4. **Tests updated** - \drawerVisible=true\ now expects \TAB_BAR_RAIL\ (was \TAB_BAR_FOOTER\)

### What this fixes
- Settings/Search/Sign-Out icons stay in the vertical column at the rail's foot
- Drawer appears beside the rail, not over it
- Hit-targets never move out from under the cursor

### What this does NOT change
- No new components or visual design changes
- No changes to drawer content, tab list, or favorites
- No changes to the top bar or right sidebar
- Existing icons, colors, typography preserved exactly

Fixes #411