### PR TITLE
fix(keymap): map Cmd to Ctrl in native menu accelerators on Windows/Linux

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/menu/MenuShortcutBridge.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/menu/MenuShortcutBridge.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.model.canonicalKeyName
 import ai.rever.boss.keymap.model.canonicalModifiers
+import ai.rever.boss.utils.SystemUtils
 import androidx.compose.ui.input.key.Key
 import java.awt.event.KeyEvent as AwtKeyEvent
 
@@ -67,10 +68,22 @@ class MenuShortcutBridge(
         val hasShift = "shift" in modifiers
         val hasAlt = "alt" in modifiers
 
+        // Platform-aware modifier mapping: the rest of the keymap system treats "Cmd"
+        // as the primary modifier (Meta on macOS, Ctrl on Windows/Linux). Compose
+        // Desktop's KeyShortcut uses `meta` for the Super/Windows key, so a "Cmd"
+        // binding on non-mac would incorrectly require the Super key unless we swap it
+        // to `ctrl`. Note that we do *not* also map a literal "Ctrl" binding to
+        // `meta` on non-mac: the native menu accelerator and its display string both
+        // speak in the same physical key, while the AWT/Compose interceptors swap the
+        // two to give non-mac users a way to trigger an explicit Ctrl binding.
+        val isMacOS = SystemUtils.isMacOS
+        val effectiveCtrl = if (isMacOS) hasCtrl else (hasCtrl || hasCmd)
+        val effectiveMeta = if (isMacOS) hasCmd else false
+
         return androidx.compose.ui.input.key.KeyShortcut(
             key = key,
-            meta = hasCmd,
-            ctrl = hasCtrl,
+            meta = effectiveMeta,
+            ctrl = effectiveCtrl,
             shift = hasShift,
             alt = hasAlt,
         )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/menu/MenuShortcutBridge.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/menu/MenuShortcutBridge.kt
@@ -9,6 +9,37 @@ import ai.rever.boss.utils.SystemUtils
 import androidx.compose.ui.input.key.Key
 import java.awt.event.KeyEvent as AwtKeyEvent
 
+/** The (ctrl, meta) pair a Compose menu accelerator carries for a binding's primary modifiers. */
+internal data class MenuAcceleratorModifiers(
+    val ctrl: Boolean,
+    val meta: Boolean,
+)
+
+/**
+ * The (ctrl, meta) pair a Compose [androidx.compose.ui.input.key.KeyShortcut] must carry for a
+ * binding with [hasCmd] and [hasCtrl] on the platform named by [isMacOS].
+ *
+ * Pure, and taking the platform as a parameter, so a test can pin BOTH branches on any runner:
+ * `SystemUtils.isMacOS` is an `actual val` initialised once from `os.name`, which a test cannot
+ * override, so a platform-conditional test only ever exercises the branch of the OS it runs on.
+ *
+ * The rest of the keymap system treats "Cmd" as the primary modifier (Meta on macOS, Ctrl on
+ * Windows/Linux). Compose Desktop's KeyShortcut uses `meta` for the Super/Windows key, so a
+ * "Cmd" binding on non-mac must swap to `ctrl` or it would incorrectly require the Super key.
+ * Note that we do *not* also map a literal "Ctrl" binding to `meta` on non-mac: the native menu
+ * accelerator and its display string both speak in the same physical key, while the AWT/Compose
+ * interceptors swap the two to give non-mac users a way to trigger an explicit Ctrl binding.
+ */
+internal fun menuAcceleratorModifiers(
+    hasCmd: Boolean,
+    hasCtrl: Boolean,
+    isMacOS: Boolean,
+): MenuAcceleratorModifiers {
+    val ctrl = if (isMacOS) hasCtrl else hasCtrl || hasCmd
+    val meta = if (isMacOS) hasCmd else false
+    return MenuAcceleratorModifiers(ctrl = ctrl, meta = meta)
+}
+
 /**
  * Bridge between menu items and the keymap system.
  * Maps menu actions to keymap action IDs and provides shortcut display strings.
@@ -68,17 +99,7 @@ class MenuShortcutBridge(
         val hasShift = "shift" in modifiers
         val hasAlt = "alt" in modifiers
 
-        // Platform-aware modifier mapping: the rest of the keymap system treats "Cmd"
-        // as the primary modifier (Meta on macOS, Ctrl on Windows/Linux). Compose
-        // Desktop's KeyShortcut uses `meta` for the Super/Windows key, so a "Cmd"
-        // binding on non-mac would incorrectly require the Super key unless we swap it
-        // to `ctrl`. Note that we do *not* also map a literal "Ctrl" binding to
-        // `meta` on non-mac: the native menu accelerator and its display string both
-        // speak in the same physical key, while the AWT/Compose interceptors swap the
-        // two to give non-mac users a way to trigger an explicit Ctrl binding.
-        val isMacOS = SystemUtils.isMacOS
-        val effectiveCtrl = if (isMacOS) hasCtrl else (hasCtrl || hasCmd)
-        val effectiveMeta = if (isMacOS) hasCmd else false
+        val (effectiveCtrl, effectiveMeta) = menuAcceleratorModifiers(hasCmd, hasCtrl, SystemUtils.isMacOS)
 
         return androidx.compose.ui.input.key.KeyShortcut(
             key = key,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/ActiveBrowserRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/ActiveBrowserRegistry.kt
@@ -58,7 +58,8 @@ object ActiveBrowserRegistry {
     /**
      * Windows where a browser is the surface the user is actually in.
      *
-     * The browser menu items (Back, Forward, Developer Tools) must grey out where the chord
+     * The browser menu items (Back, Forward, Developer Tools, Actual Size, Zoom In, Zoom Out, Reload)
+     * must grey out where the chord
      * should not act, and not merely no-op: a Compose MenuBar accelerator fires from anywhere in
      * the window regardless of the binding's ShortcutContext, so an always-enabled item silently
      * swallows its chord for every other tab type. Cmd+[ and Cmd+] are outdent/indent in an
@@ -201,8 +202,10 @@ object ActiveBrowserRegistry {
  * surface of the panel the user is in, so a sidebar-slot browser or the background half of a
  * split answers false. The menu items this gates fire their accelerator window-wide regardless
  * of ShortcutContext, so "a browser exists somewhere" would swallow Cmd+[ and Cmd+] from an
- * editor. Zoom and Reload stay ungated and keep acting on [selectActiveHandleId]'s broader
- * answer, which predates this and is out of scope here.
+ * editor. The menu gate is deliberately stricter than the dispatch target: a sidebar-slot
+ * browser or the background half of a split can no longer be zoomed or reloaded from the View
+ * menu - accepted, because the broader "a browser exists somewhere" gate would swallow Ctrl+R
+ * (and Cmd+[/Cmd+]) from a terminal or editor tab.
  */
 internal fun activeBrowserWindows(
     candidates: Collection<ActiveBrowserRegistry.Entry>,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -726,6 +726,11 @@ fun ApplicationScope.BossWindow(
                     onClick = {
                         MenuActionsHandler.triggerActualSize(windowState.id)
                     },
+                    // Their bindings are BROWSER-context: AWTKeyboardInterceptor declines them
+                    // outside a browser tab, so the menu must not out-broaden the interceptor.
+                    // Un-gated, a now-live Ctrl accelerator (Windows/Linux) would fire these
+                    // from a terminal or editor tab. Back/Forward/DevTools already gate this way.
+                    enabled = hasBrowser,
                 )
                 Item(
                     "Zoom In",
@@ -733,6 +738,7 @@ fun ApplicationScope.BossWindow(
                     onClick = {
                         MenuActionsHandler.triggerZoomIn(windowState.id)
                     },
+                    enabled = hasBrowser,
                 )
                 Item(
                     "Zoom Out",
@@ -740,6 +746,7 @@ fun ApplicationScope.BossWindow(
                     onClick = {
                         MenuActionsHandler.triggerZoomOut(windowState.id)
                     },
+                    enabled = hasBrowser,
                 )
                 Item(
                     "Reload",
@@ -747,6 +754,7 @@ fun ApplicationScope.BossWindow(
                     onClick = {
                         MenuActionsHandler.triggerReloadBrowser(windowState.id)
                     },
+                    enabled = hasBrowser,
                 )
                 Item(
                     "Back",

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/ShortcutCaptureConsumersTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/ShortcutCaptureConsumersTest.kt
@@ -1,7 +1,9 @@
 package ai.rever.boss.keymap
 
 import ai.rever.boss.components.settings.keymap.isShortcutCaptureKey
+import ai.rever.boss.keymap.menu.MenuAcceleratorModifiers
 import ai.rever.boss.keymap.menu.MenuShortcutBridge
+import ai.rever.boss.keymap.menu.menuAcceleratorModifiers
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.KeyStroke
 import ai.rever.boss.keymap.model.KeymapSettings
@@ -52,6 +54,8 @@ class ShortcutCaptureConsumersTest {
         val binding =
             KeyBinding(
                 actionId = "window.new",
+                // Packed-keycode spelling, on purpose: the bridge's only exercise of
+                // canonicalKeyName's legacy numeric branch.
                 key = Key.N.keyCode.toString(),
                 modifiers = listOf("Cmd"),
             )
@@ -63,6 +67,54 @@ class ShortcutCaptureConsumersTest {
         } else {
             assertEquals(KeyShortcut(Key.N, ctrl = true), shortcut)
         }
+    }
+
+    @Test
+    fun `the platform modifier mapping pins both branches on any runner`() {
+        // Cmd is the primary modifier everywhere: Meta on macOS, Ctrl on Windows/Linux, never
+        // Compose's meta (the Super key). A platform-conditional test could only ever assert
+        // the branch of the OS it runs on; the pure function takes the platform, so both
+        // branches are asserted unconditionally here.
+        assertEquals(
+            MenuAcceleratorModifiers(ctrl = true, meta = false),
+            menuAcceleratorModifiers(hasCmd = true, hasCtrl = false, isMacOS = false),
+        )
+        assertEquals(
+            MenuAcceleratorModifiers(ctrl = false, meta = true),
+            menuAcceleratorModifiers(hasCmd = true, hasCtrl = false, isMacOS = true),
+        )
+
+        // An explicit Ctrl stays Ctrl on every platform and never becomes meta: that is the
+        // asymmetry the interceptor relies on, and a regression of it would otherwise only
+        // surface on the OS the author is not using.
+        assertEquals(
+            MenuAcceleratorModifiers(ctrl = true, meta = false),
+            menuAcceleratorModifiers(hasCmd = false, hasCtrl = true, isMacOS = false),
+        )
+        assertEquals(
+            MenuAcceleratorModifiers(ctrl = true, meta = false),
+            menuAcceleratorModifiers(hasCmd = false, hasCtrl = true, isMacOS = true),
+        )
+
+        // Both modifiers: mac keeps them distinct, non-mac collapses onto ctrl.
+        assertEquals(
+            MenuAcceleratorModifiers(ctrl = true, meta = true),
+            menuAcceleratorModifiers(hasCmd = true, hasCtrl = true, isMacOS = true),
+        )
+        assertEquals(
+            MenuAcceleratorModifiers(ctrl = true, meta = false),
+            menuAcceleratorModifiers(hasCmd = true, hasCtrl = true, isMacOS = false),
+        )
+
+        // Neither: nothing to map.
+        assertEquals(
+            MenuAcceleratorModifiers(ctrl = false, meta = false),
+            menuAcceleratorModifiers(hasCmd = false, hasCtrl = false, isMacOS = false),
+        )
+        assertEquals(
+            MenuAcceleratorModifiers(ctrl = false, meta = false),
+            menuAcceleratorModifiers(hasCmd = false, hasCtrl = false, isMacOS = true),
+        )
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/ShortcutCaptureConsumersTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/keymap/ShortcutCaptureConsumersTest.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.keymap.model.KeyStroke
 import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.model.formatShortcutLabel
 import ai.rever.boss.keymap.model.storedKeyName
+import ai.rever.boss.utils.SystemUtils
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyShortcut
 import kotlinx.coroutines.test.runTest
@@ -47,10 +48,52 @@ class ShortcutCaptureConsumersTest {
     }
 
     @Test
-    fun `native menu accelerator resolves a legacy numeric key`() {
-        val binding = KeyBinding(actionId = "window.new", key = Key.N.keyCode.toString(), modifiers = listOf("Cmd"))
+    fun `native menu accelerator maps a Cmd binding to the platform primary modifier`() {
+        val binding =
+            KeyBinding(
+                actionId = "window.new",
+                key = Key.N.keyCode.toString(),
+                modifiers = listOf("Cmd"),
+            )
         val bridge = MenuShortcutBridge(KeymapSettings(shortcuts = mapOf(binding.actionId to binding)))
-        assertEquals(KeyShortcut(Key.N, meta = true), bridge.getKeyShortcut(binding.actionId))
+        val shortcut = bridge.getKeyShortcut(binding.actionId)
+
+        if (SystemUtils.isMacOS) {
+            assertEquals(KeyShortcut(Key.N, meta = true), shortcut)
+        } else {
+            assertEquals(KeyShortcut(Key.N, ctrl = true), shortcut)
+        }
+    }
+
+    @Test
+    fun `native menu accelerator keeps an explicit Ctrl binding on Ctrl on every platform`() {
+        val binding =
+            KeyBinding(
+                actionId = "window.close",
+                key = "W",
+                modifiers = listOf("Ctrl"),
+            )
+        val bridge = MenuShortcutBridge(KeymapSettings(shortcuts = mapOf(binding.actionId to binding)))
+        val shortcut = bridge.getKeyShortcut(binding.actionId)
+        assertEquals(KeyShortcut(Key.W, ctrl = true), shortcut)
+    }
+
+    @Test
+    fun `native menu accelerator carries Shift and Alt through the platform mapping`() {
+        val binding =
+            KeyBinding(
+                actionId = "window.new",
+                key = "N",
+                modifiers = listOf("Cmd", "Shift", "Alt"),
+            )
+        val bridge = MenuShortcutBridge(KeymapSettings(shortcuts = mapOf(binding.actionId to binding)))
+        val shortcut = bridge.getKeyShortcut(binding.actionId)
+
+        if (SystemUtils.isMacOS) {
+            assertEquals(KeyShortcut(Key.N, meta = true, shift = true, alt = true), shortcut)
+        } else {
+            assertEquals(KeyShortcut(Key.N, ctrl = true, shift = true, alt = true), shortcut)
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ActiveBrowserWindowStateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ActiveBrowserWindowStateTest.kt
@@ -92,10 +92,11 @@ class ActiveBrowserWindowStateTest {
 
     @Test
     fun `the gate is stricter than the dispatch target, deliberately`() {
-        // selectActiveHandleId ranks and always answers when a candidate exists, so a sidebar
-        // browser still gets Zoom and Reload. This gate filters, because its menu items would
-        // otherwise steal their chords from the editor the user is actually in. Pinned so the
-        // asymmetry is a decision rather than a later "bug fix" that reopens the swallowing.
+        // selectActiveHandleId ranks and always answers when a candidate exists; this gate
+        // filters. The gate is deliberately stricter than the dispatch target: a sidebar browser
+        // answers false here, so its Zoom/Reload menu items grey out even though the dispatch
+        // target would still find it. Pinned so the asymmetry is a decision rather than a later
+        // "bug fix" that reopens the chord swallowing.
         val sidebarOnly = listOf(entry("sidebar", inMainPanel = false))
 
         assertTrue(activeBrowserWindows(sidebarOnly, allLive).isEmpty())


### PR DESCRIPTION
## Problem

`MenuShortcutBridge.getKeyShortcut()` set `meta = hasCmd` for all "Cmd" bindings. On Windows and Linux, Compose Desktop maps `meta = true` to `KeyEvent.VK_WINDOWS` (META_DOWN_MASK), so native menu accelerators built from standard presets like `Cmd+N` (Settings, New Tab, Open Project) required the Super/Windows key and `Ctrl+N` / `Ctrl+Comma` failed to fire.

## Triage / Root cause

The rest of the keymap system (`KeymapMatcher`, `AWTKeyboardInterceptor`, `KeyBinding.displayString()`) maps "Cmd" to Ctrl on non-mac and to Meta on macOS. `MenuShortcutBridge` was the one site that did not apply this platform-aware swap before handing the binding to Compose's `KeyShortcut`.

## Fix

- Import `ai.rever.boss.utils.SystemUtils` and resolve `effectiveCtrl` / `effectiveMeta` from `SystemUtils.isMacOS` before constructing `KeyShortcut`.
- macOS: Cmd → `meta`, Ctrl → `ctrl` (unchanged).
- Windows/Linux: Cmd → `ctrl`, so `Ctrl+N` / `Ctrl+Comma` are native accelerators; `meta` stays off for a Cmd binding. An explicit Ctrl binding stays on `ctrl` so the menu accelerator and its display string agree.
- Added an inline comment explaining the asymmetry with the AWT/Compose interceptors.
- Extended `ShortcutCaptureConsumersTest.kt` with platform-aware assertions for Cmd, explicit Ctrl, and Cmd+Shift+Alt.

## Verification

- `./gradlew :composeApp:desktopTest --tests "ai.rever.boss.keymap.ShortcutCaptureConsumersTest"` passes.
- `./gradlew :composeApp:ktlintCheck :composeApp:detekt` passes.
- `preflight_ship.py` confirms issue #513 is open, no PR body references, bug marker still present on upstream `main`, and fix marker absent.

## Notes / Risks

- This is a focused, surgical change to `MenuShortcutBridge` only; it does not refactor `KeymapMatcher`, `AWTKeyboardInterceptor`, or other keymap files.
- The native menu display string already renders "Cmd" as "Ctrl" on Windows/Linux via `KeyBinding.displayString()`, so the new accelerator flag now matches what the user sees.
- A binding that explicitly contains both "Cmd" and "Ctrl" on Windows/Linux will collapse both onto `ctrl`; this is consistent with the menu being unable to represent two physical primary modifiers separately.

Fixes #513

## Assistance

AI-assisted. I wrote and verified this change.

---

## Preparation note (review, 2026-09-11)

Rebased onto current `dev` — single commit, no code changes (the cherry-pick applied cleanly; `MenuShortcutBridge`, `KeymapMatcher`, `AWTKeyboardInterceptor`, and `KeyBinding.displayString` were verified unchanged in their swap semantics on `dev`, confirming the single-construction-site analysis).

## Round 2 — Claude review response (2026-09-11)

- The View menu's **Actual Size / Zoom In / Zoom Out / Reload** now carry `enabled = hasBrowser`, in lockstep with Back / Forward / Developer Tools: their bindings are `BROWSER`-context and `AWTKeyboardInterceptor` declines them outside a browser tab, so the menu must not out-broaden the interceptor (before this, the newly-live Ctrl accelerators on Windows/Linux could fire them from a terminal or editor tab).
- The platform modifier mapping is extracted into the pure `menuAcceleratorModifiers(hasCmd, hasCtrl, isMacOS)` (the asymmetry comment moved with it), and the test now pins **both** platform branches unconditionally on any runner; the bridge-level tests keep asserting the live `SystemUtils.isMacOS` wiring.
- One-line comment keeps the legacy packed-keycode coverage attached to `Key.N.keyCode.toString()`.
- The mirror-image AWT bug (explicit `Ctrl` matches `isMetaDown` on non-mac, so the default Ctrl+Tab / Ctrl+Shift+Tab actually require Super+Tab while the UI says Ctrl+Tab) is tracked as issue #553 with options for the design decision.

## Round 3 — delta review response (2026-09-11)

Claude delta review at `928d3b206` verified the menu gating, the extracted per-platform mapping, and mutation-checked the new tests ("nothing blocks merge"). Three stale comments that contradicted the new gating were corrected in `f7da94268`: `windowsWithActiveBrowser` now enumerates all seven gated items; `activeBrowserWindows` records the deliberate decision that the menu gate is stricter than the dispatch target (a sidebar-slot or background-split browser can no longer be zoomed/reloaded from the View menu — the broader gate would swallow Ctrl+R and Cmd+[/Cmd+]); the "gate is stricter" test restates that asymmetry. Final head: `f7da94268`.
