### PR TITLE
Restrict completed_authentications to the service-role Edge Function

### DIFF
--- a/supabase/migrations/20260911000000_restrict_completed_authentications_rls.sql
+++ b/supabase/migrations/20260911000000_restrict_completed_authentications_rls.sql
@@ -1,0 +1,71 @@
+-- Restrict completed_authentications to the service-role Edge Function only.
+--
+-- Problem
+-- -------
+-- completed_authentications holds the freshly minted `access_token` and
+-- `refresh_token` for the cross-device (QR) login flow. Its anon policies
+-- (20251023000013_rls_policies.sql :359, :373, :387) are each guarded only by
+-- `session_id IS NOT NULL`.
+--
+-- `session_id` is NOT NULL on every real row, so that predicate is TRUE for all
+-- of them: the policies are `USING (true)` written the long way. Nothing anywhere
+-- requires the caller to actually know a session id, so the "unguessable UUID
+-- acts as a temporary bearer token" model the surrounding comments describe is
+-- not enforced. Combined with `GRANT ALL ON TABLE ... TO anon`
+-- (20251023000014_grants.sql:545) and an anon key that is public by construction
+-- (it ships in the desktop app and this repo is open source), that is reachable
+-- by anyone who can reach PostgREST:
+--
+--   1. Token harvest. `GET /rest/v1/completed_authentications?select=*` returns
+--      every in-flight login's access_token and refresh_token. Polling faster
+--      than the legitimate desktop wins the race to any QR-logging-in user's
+--      session, which is account takeover rather than a leak.
+--   2. Denial of service. `DELETE /rest/v1/completed_authentications` wipes all
+--      in-flight logins at once.
+--   3. Session fixation. anon INSERT lets an attacker pre-seed a victim's
+--      session_id with attacker-controlled tokens, which the victim's desktop
+--      then imports as its own session.
+--
+-- Reported as BossConsole#528.
+--
+-- Why this is safe
+-- ----------------
+-- No client reaches this table directly any more. Verified on dev:
+--
+--   - `grep -rn completed_authentications --include=*.kt` over the desktop source
+--     returns nothing outside build output. The desktop polls the Edge Function
+--     instead: `GET /passkey/auth/status/{sessionId}`
+--     (SupabaseApiClient.kt:103).
+--   - Every read and write of the table happens inside the passkey Edge
+--     Function, whose Supabase client is built with SUPABASE_SERVICE_ROLE_KEY
+--     (supabase/functions/passkey/index.ts:36).
+--
+-- service_role bypasses RLS, so the anon and authenticated policies and their
+-- table grants are dead code on the live path. Dropping them changes nothing for
+-- the application and closes all three defects above.
+--
+-- The authenticated policies go with the anon ones for the same reason: the flow
+-- does not use them either, and leaving a role with standing access to a table of
+-- bearer tokens is the condition that made this exploitable in the first place.
+
+-- Belt and braces, matching 20260910120000_restrict_plugin_downloads_rls.sql:
+-- revoke the base-table privileges as well, so the gate does not rest on RLS
+-- alone. PUBLIC is included because a grant there would survive revoking the two
+-- named roles.
+REVOKE ALL ON TABLE public.completed_authentications FROM PUBLIC, anon, authenticated;
+
+DROP POLICY IF EXISTS "Anon can insert completed authentications" ON public.completed_authentications;
+DROP POLICY IF EXISTS "Anon can select by session_id" ON public.completed_authentications;
+DROP POLICY IF EXISTS "Anon can delete by session_id" ON public.completed_authentications;
+DROP POLICY IF EXISTS "Authenticated users can insert own results" ON public.completed_authentications;
+DROP POLICY IF EXISTS "Authenticated users can select own results" ON public.completed_authentications;
+DROP POLICY IF EXISTS "Authenticated users can delete own results" ON public.completed_authentications;
+
+-- The service_role policy (20251023000013_rls_policies.sql:347) and its grant
+-- (20251023000014_grants.sql:547) are deliberately untouched: that is the path
+-- the Edge Function uses and the only one that has to keep working.
+
+COMMENT ON TABLE public.completed_authentications IS
+    'Cross-device login handoff: holds freshly minted access/refresh tokens until the desktop claims them. '
+    'Service-role only. anon and authenticated hold no policy and no table privilege (BossConsole#528); '
+    'clients reach this data through the passkey Edge Function, never through PostgREST.';

--- a/supabase/migrations/20260911000000_restrict_completed_authentications_rls.sql
+++ b/supabase/migrations/20260911000000_restrict_completed_authentications_rls.sql
@@ -65,7 +65,16 @@ DROP POLICY IF EXISTS "Authenticated users can delete own results" ON public.com
 -- (20251023000014_grants.sql:547) are deliberately untouched: that is the path
 -- the Edge Function uses and the only one that has to keep working.
 
+-- The cleanup RPC is granted to both client roles
+-- (20251023000014_grants.sql:240-241), but no client code calls it: it returns
+-- void, only deletes rows past expires_at_timestamp, and after the revoke above
+-- it cannot even execute its DELETE as a client (no table privilege). Revoke the
+-- client EXECUTE so no client role keeps any handle to this table's data; the
+-- service_role grant is left for the server-side path.
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_completed_authentications() FROM anon, authenticated;
+
 COMMENT ON TABLE public.completed_authentications IS
     'Cross-device login handoff: holds freshly minted access/refresh tokens until the desktop claims them. '
     'Service-role only. anon and authenticated hold no policy and no table privilege (BossConsole#528); '
-    'clients reach this data through the passkey Edge Function, never through PostgREST.';
+    'clients reach this data through the passkey Edge Function, never through PostgREST. '
+    'The expired-row cleanup RPC is likewise service-role only.';

--- a/supabase/migrations/20260911000000_restrict_completed_authentications_rls.sql
+++ b/supabase/migrations/20260911000000_restrict_completed_authentications_rls.sql
@@ -67,13 +67,17 @@ DROP POLICY IF EXISTS "Authenticated users can delete own results" ON public.com
 
 -- The cleanup RPC is granted to both client roles
 -- (20251023000014_grants.sql:240-241), but no client code calls it: it returns
--- void, only deletes rows past expires_at_timestamp, and after the revoke above
--- it cannot even execute its DELETE as a client (no table privilege). Revoke the
--- client EXECUTE so no client role keeps any handle to this table's data; the
--- service_role grant is left for the server-side path. PUBLIC is included
--- because PostgreSQL grants EXECUTE on functions to PUBLIC by default, so
--- revoking the two named roles alone would leave the door open (verified:
--- has_function_privilege still returned true for both client roles).
+-- void and only deletes rows past expires_at_timestamp. The REVOKE EXECUTE below
+-- is the gate: no client role keeps any handle to this table's data; the
+-- service_role grant is left for the server-side path. (A second, weaker
+-- argument - with the table privileges revoked above, the DELETE would also
+-- fail if a client ran the function - only holds while the function is SECURITY
+-- INVOKER. Its own header comment at 20251023000003_passkey_functions.sql:221
+-- claims SECURITY DEFINER, so if someone ever "fixes" the function to match that
+-- comment, only this revoke still holds.) PUBLIC is included because PostgreSQL
+-- grants EXECUTE on functions to PUBLIC by default, so revoking the two named
+-- roles alone would leave the door open (verified: has_function_privilege still
+-- returned true for both client roles).
 REVOKE EXECUTE ON FUNCTION public.cleanup_expired_completed_authentications() FROM PUBLIC, anon, authenticated;
 
 COMMENT ON TABLE public.completed_authentications IS

--- a/supabase/migrations/20260911000000_restrict_completed_authentications_rls.sql
+++ b/supabase/migrations/20260911000000_restrict_completed_authentications_rls.sql
@@ -70,8 +70,11 @@ DROP POLICY IF EXISTS "Authenticated users can delete own results" ON public.com
 -- void, only deletes rows past expires_at_timestamp, and after the revoke above
 -- it cannot even execute its DELETE as a client (no table privilege). Revoke the
 -- client EXECUTE so no client role keeps any handle to this table's data; the
--- service_role grant is left for the server-side path.
-REVOKE EXECUTE ON FUNCTION public.cleanup_expired_completed_authentications() FROM anon, authenticated;
+-- service_role grant is left for the server-side path. PUBLIC is included
+-- because PostgreSQL grants EXECUTE on functions to PUBLIC by default, so
+-- revoking the two named roles alone would leave the door open (verified:
+-- has_function_privilege still returned true for both client roles).
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_completed_authentications() FROM PUBLIC, anon, authenticated;
 
 COMMENT ON TABLE public.completed_authentications IS
     'Cross-device login handoff: holds freshly minted access/refresh tokens until the desktop claims them. '

--- a/supabase/tests/completed_authentications_rls_test.sql
+++ b/supabase/tests/completed_authentications_rls_test.sql
@@ -10,10 +10,12 @@
 -- These assertions are about the absence of access, which is exactly the kind of
 -- thing that is easy to reintroduce: a later migration adding a convenience
 -- policy "so the client can poll directly" would restore the hole without
--- failing anything else in the suite.
+-- failing anything else in the suite. The final four assertions (service_role
+-- keeps every verb) carry over unchanged from the companion submission
+-- BossConsole#530 by @Rushikeshiitb.
 
 begin;
-select plan(11);
+select plan(15);
 
 -- 1-4: no policy remains for either client role, service_role keeps its own,
 -- and RLS is still enabled.
@@ -77,6 +79,26 @@ select ok(
 select ok(
     not has_table_privilege('authenticated', 'public.completed_authentications', 'DELETE'),
     'authenticated cannot DELETE from the token table'
+);
+
+-- 12-15: the live path must keep working. If any of these fails, the migration
+-- went too far and the Edge Function can no longer store or read the handoff.
+-- (Carried over from BossConsole#530, @Rushikeshiitb.)
+select ok(
+    has_table_privilege('service_role', 'public.completed_authentications', 'SELECT'),
+    'service_role can still SELECT the token table'
+);
+select ok(
+    has_table_privilege('service_role', 'public.completed_authentications', 'INSERT'),
+    'service_role can still INSERT into the token table'
+);
+select ok(
+    has_table_privilege('service_role', 'public.completed_authentications', 'UPDATE'),
+    'service_role can still UPDATE the token table'
+);
+select ok(
+    has_table_privilege('service_role', 'public.completed_authentications', 'DELETE'),
+    'service_role can still DELETE from the token table'
 );
 
 select * from finish();

--- a/supabase/tests/completed_authentications_rls_test.sql
+++ b/supabase/tests/completed_authentications_rls_test.sql
@@ -10,27 +10,22 @@
 -- These assertions are about the absence of access, which is exactly the kind of
 -- thing that is easy to reintroduce: a later migration adding a convenience
 -- policy "so the client can poll directly" would restore the hole without
--- failing anything else in the suite. The final four assertions (service_role
--- keeps every verb) carry over unchanged from the companion submission
--- BossConsole#530 by @Rushikeshiitb.
+-- failing anything else in the suite. The policy-set assertion below fails on
+-- that - including a policy created without a TO clause, which applies to
+-- everyone and shows up in pg_policies as roles = {public}, where a per-role
+-- check would see neither 'anon' nor 'authenticated' and pass. The four
+-- service_role table-privilege assertions carry over unchanged from the
+-- companion submission BossConsole#530 by @Rushikeshiitb.
 
 begin;
-select plan(18);
+select plan(24);
 
--- 1-4: no policy remains for either client role, service_role keeps its own,
--- and RLS is still enabled.
+-- 1-3: exactly one policy remains - the service_role one - and RLS is still on.
 select is_empty(
     $$ select policyname from pg_policies
        where schemaname = 'public' and tablename = 'completed_authentications'
-         and 'anon' = any(roles) $$,
-    'anon holds no policy on completed_authentications'
-);
-
-select is_empty(
-    $$ select policyname from pg_policies
-       where schemaname = 'public' and tablename = 'completed_authentications'
-         and 'authenticated' = any(roles) $$,
-    'authenticated holds no policy on completed_authentications'
+         and roles <> '{service_role}'::name[] $$,
+    'no policy remains for any role but service_role, unscoped ones included'
 );
 
 -- The service-role policy is the live path and must survive. If this fails, the
@@ -48,9 +43,11 @@ select ok(
     'row level security is still enabled on the table'
 );
 
--- 5-11: no table privilege either, so the gate does not rest on RLS alone.
--- has_table_privilege is checked per verb rather than via ALL, so a partial
--- regrant of a single verb cannot pass.
+-- 4-17: no table privilege either, so the gate does not rest on RLS alone.
+-- has_table_privilege is checked per verb for both client roles rather than via
+-- ALL, so a partial regrant of a single verb cannot pass. TRUNCATE is asserted
+-- for both: it is not subject to row level security at all, so the REVOKE ALL
+-- above is its only gate.
 select ok(
     not has_table_privilege('anon', 'public.completed_authentications', 'SELECT'),
     'anon cannot SELECT the token table'
@@ -67,6 +64,18 @@ select ok(
     not has_table_privilege('anon', 'public.completed_authentications', 'DELETE'),
     'anon cannot DELETE from the token table'
 );
+select ok(
+    not has_table_privilege('anon', 'public.completed_authentications', 'TRUNCATE'),
+    'anon cannot TRUNCATE the token table, which no policy could stop'
+);
+select ok(
+    not has_table_privilege('anon', 'public.completed_authentications', 'REFERENCES'),
+    'anon has no REFERENCES privilege on the token table'
+);
+select ok(
+    not has_table_privilege('anon', 'public.completed_authentications', 'TRIGGER'),
+    'anon has no TRIGGER privilege on the token table'
+);
 
 select ok(
     not has_table_privilege('authenticated', 'public.completed_authentications', 'SELECT'),
@@ -77,11 +86,27 @@ select ok(
     'authenticated cannot INSERT into the token table'
 );
 select ok(
+    not has_table_privilege('authenticated', 'public.completed_authentications', 'UPDATE'),
+    'authenticated cannot UPDATE the token table'
+);
+select ok(
     not has_table_privilege('authenticated', 'public.completed_authentications', 'DELETE'),
     'authenticated cannot DELETE from the token table'
 );
+select ok(
+    not has_table_privilege('authenticated', 'public.completed_authentications', 'TRUNCATE'),
+    'authenticated cannot TRUNCATE the token table, which no policy could stop'
+);
+select ok(
+    not has_table_privilege('authenticated', 'public.completed_authentications', 'REFERENCES'),
+    'authenticated has no REFERENCES privilege on the token table'
+);
+select ok(
+    not has_table_privilege('authenticated', 'public.completed_authentications', 'TRIGGER'),
+    'authenticated has no TRIGGER privilege on the token table'
+);
 
--- 12-15: the live path must keep working. If any of these fails, the migration
+-- 18-21: the live path must keep working. If any of these fails, the migration
 -- went too far and the Edge Function can no longer store or read the handoff.
 -- (Carried over from BossConsole#530, @Rushikeshiitb.)
 select ok(
@@ -101,7 +126,7 @@ select ok(
     'service_role can still DELETE from the token table'
 );
 
--- 16-18: the expired-row cleanup RPC keeps no client handle either. It returns
+-- 22-24: the expired-row cleanup RPC keeps no client handle either. It returns
 -- void, so this is not a data leak, but after the table revoke it could do
 -- nothing as a client anyway; the grants are dead weight on a token table.
 select ok(

--- a/supabase/tests/completed_authentications_rls_test.sql
+++ b/supabase/tests/completed_authentications_rls_test.sql
@@ -15,7 +15,7 @@
 -- BossConsole#530 by @Rushikeshiitb.
 
 begin;
-select plan(15);
+select plan(18);
 
 -- 1-4: no policy remains for either client role, service_role keeps its own,
 -- and RLS is still enabled.
@@ -99,6 +99,22 @@ select ok(
 select ok(
     has_table_privilege('service_role', 'public.completed_authentications', 'DELETE'),
     'service_role can still DELETE from the token table'
+);
+
+-- 16-18: the expired-row cleanup RPC keeps no client handle either. It returns
+-- void, so this is not a data leak, but after the table revoke it could do
+-- nothing as a client anyway; the grants are dead weight on a token table.
+select ok(
+    not has_function_privilege('anon', 'public.cleanup_expired_completed_authentications()', 'EXECUTE'),
+    'anon cannot execute the expired-row cleanup RPC'
+);
+select ok(
+    not has_function_privilege('authenticated', 'public.cleanup_expired_completed_authentications()', 'EXECUTE'),
+    'authenticated cannot execute the expired-row cleanup RPC'
+);
+select ok(
+    has_function_privilege('service_role', 'public.cleanup_expired_completed_authentications()', 'EXECUTE'),
+    'service_role can still execute the cleanup RPC'
 );
 
 select * from finish();

--- a/supabase/tests/completed_authentications_rls_test.sql
+++ b/supabase/tests/completed_authentications_rls_test.sql
@@ -1,0 +1,83 @@
+-- pgTAP tests for completed_authentications access (20260911000000).
+-- Run with: supabase test db
+--
+-- completed_authentications holds live access and refresh tokens for the
+-- cross-device login handoff. Before BossConsole#528 its anon policies were
+-- guarded by `session_id IS NOT NULL`, which is TRUE on every real row, so any
+-- holder of the public anon key could read every in-flight login's tokens,
+-- delete them all, or pre-seed a victim's session with attacker-controlled ones.
+--
+-- These assertions are about the absence of access, which is exactly the kind of
+-- thing that is easy to reintroduce: a later migration adding a convenience
+-- policy "so the client can poll directly" would restore the hole without
+-- failing anything else in the suite.
+
+begin;
+select plan(11);
+
+-- 1-4: no policy remains for either client role, service_role keeps its own,
+-- and RLS is still enabled.
+select is_empty(
+    $$ select policyname from pg_policies
+       where schemaname = 'public' and tablename = 'completed_authentications'
+         and 'anon' = any(roles) $$,
+    'anon holds no policy on completed_authentications'
+);
+
+select is_empty(
+    $$ select policyname from pg_policies
+       where schemaname = 'public' and tablename = 'completed_authentications'
+         and 'authenticated' = any(roles) $$,
+    'authenticated holds no policy on completed_authentications'
+);
+
+-- The service-role policy is the live path and must survive. If this fails, the
+-- migration went too far and cross-device login is broken.
+select isnt_empty(
+    $$ select policyname from pg_policies
+       where schemaname = 'public' and tablename = 'completed_authentications'
+         and 'service_role' = any(roles) $$,
+    'service_role keeps its policy, so the Edge Function flow still works'
+);
+
+select ok(
+    (select relrowsecurity from pg_class
+      where oid = 'public.completed_authentications'::regclass),
+    'row level security is still enabled on the table'
+);
+
+-- 5-11: no table privilege either, so the gate does not rest on RLS alone.
+-- has_table_privilege is checked per verb rather than via ALL, so a partial
+-- regrant of a single verb cannot pass.
+select ok(
+    not has_table_privilege('anon', 'public.completed_authentications', 'SELECT'),
+    'anon cannot SELECT the token table'
+);
+select ok(
+    not has_table_privilege('anon', 'public.completed_authentications', 'INSERT'),
+    'anon cannot INSERT into the token table'
+);
+select ok(
+    not has_table_privilege('anon', 'public.completed_authentications', 'UPDATE'),
+    'anon cannot UPDATE the token table'
+);
+select ok(
+    not has_table_privilege('anon', 'public.completed_authentications', 'DELETE'),
+    'anon cannot DELETE from the token table'
+);
+
+select ok(
+    not has_table_privilege('authenticated', 'public.completed_authentications', 'SELECT'),
+    'authenticated cannot SELECT the token table'
+);
+select ok(
+    not has_table_privilege('authenticated', 'public.completed_authentications', 'INSERT'),
+    'authenticated cannot INSERT into the token table'
+);
+select ok(
+    not has_table_privilege('authenticated', 'public.completed_authentications', 'DELETE'),
+    'authenticated cannot DELETE from the token table'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #528. Reported by @Rushikeshiitb, whose issue specified the fix shape used here.

## The defect

`completed_authentications` holds the freshly minted `access_token` and `refresh_token` for the cross-device (QR) login handoff. Its three anon policies were each guarded only by `session_id IS NOT NULL`:

```sql
CREATE POLICY "Anon can select by session_id" ON completed_authentications
    FOR SELECT TO anon USING (session_id IS NOT NULL);
```

`session_id` is NOT NULL on every real row, so that is `USING (true)` written the long way. Nothing required the caller to actually know a session id, so the "unguessable UUID acts as a temporary bearer token" model the surrounding comments describe was not enforced anywhere. With `GRANT ALL ON TABLE ... TO anon` and an anon key that is public by construction, this was reachable by anyone who can reach PostgREST: token harvest leading to account takeover, a one-request wipe of all in-flight logins, and session fixation via anon INSERT.

## Why it is safe to remove

I verified the claim rather than taking it from the issue:

- `grep -rn completed_authentications --include=*.kt` over the desktop source returns **nothing** outside build output. The desktop polls the Edge Function instead: `GET /passkey/auth/status/{sessionId}` at `SupabaseApiClient.kt:103`.
- Every read and write happens inside the passkey Edge Function, whose Supabase client is built with `SUPABASE_SERVICE_ROLE_KEY` at `supabase/functions/passkey/index.ts:36`.

`service_role` bypasses RLS, so the anon and authenticated policies and their table grants are dead code on the live path. The service_role policy and grant are deliberately untouched.

The authenticated policies go with the anon ones because the flow does not use them either, and leaving a role with standing access to a table of bearer tokens is the condition that made this exploitable in the first place.

## Shape

Follows `20260910120000_restrict_plugin_downloads_rls.sql`, the most recent precedent: drop the policies **and** revoke the base-table privileges, so the gate does not rest on RLS alone. `PUBLIC` is included in the revoke because a grant there would survive revoking the two named roles.

## One failure mode worth naming

`DROP POLICY IF EXISTS` with a mistyped name is a **silent no-op** that would leave the hole open and fail nothing. So the six names were diffed programmatically against `20251023000013_rls_policies.sql`: six created policies dropped, zero names that never existed, and the only survivor is `"Service role can manage completed authentications"`.

The pgTAP test then asserts **absence** rather than trusting the drop, which is the assertion that would catch it if a name ever drifts.

## Tests

`supabase/tests/completed_authentications_rls_test.sql`, **24 assertions**: the full policy set is exactly the service_role one - including a policy created without a `TO` clause, which applies to everyone and shows up in `pg_policies` as `roles = {public}`, where a per-role check sees neither client role; service_role keeps its policy (so a too-aggressive migration breaks the test rather than cross-device login); RLS still enabled; `has_table_privilege` checked **per verb** for both client roles - `SELECT`/`INSERT`/`UPDATE`/`DELETE` plus `TRUNCATE`, `REFERENCES`, `TRIGGER`, the last because TRUNCATE is not subject to row level security at all and the `REVOKE ALL` is its only gate; service_role keeps **every verb** on the table (carried over unchanged from the companion submission #530 by @Rushikeshiitb); and the expired-row cleanup RPC keeps no client EXECUTE while service_role retains it.

These are assertions about the absence of access, which is the kind of thing quietly reintroduced later by a convenience policy added "so the client can poll directly". That is why they are pinned.

## What I could not verify

I could not run `supabase test db` locally: no Supabase CLI, no psql, no Docker on this machine. The hosted **Database (pgTAP)** job in `build.yml` covers it, and that run is the real check on this PR.

## Cleanup RPC, now restricted

`cleanup_expired_completed_authentications()` was granted to anon and authenticated at `20251023000014_grants.sql:240-241`, but no client code calls it: it returns void and only deletes rows past `expires_at_timestamp`. The `REVOKE EXECUTE` in this migration (from `PUBLIC, anon, authenticated`; service_role keeps it) is the gate, pinned with three pgTAP assertions. `PUBLIC` is included because PostgreSQL grants function EXECUTE to PUBLIC by default, so revoking only the two named roles leaves the door open.

## Review follow-ups (maintainer)

`5dc3577` carried the #530 service_role assertions over. `602e9b3` revoked client EXECUTE on the cleanup RPC. `6caceb8` added the `PUBLIC` EXECUTE revoke after the first CI run showed `has_function_privilege` still true for both client roles (PostgreSQL's default function grants). `308a74a` landed the Claude review: the policy-set assertion (catches a `TO`-clause-less policy), the TRUNCATE/REFERENCES/TRIGGER and authenticated-UPDATE assertions, plan 18 -> 24, and the comment reword that names the stale `SECURITY DEFINER` header on `cleanup_expired_completed_authentications` (`20251023000003_passkey_functions.sql:221`) as the reason the "no table privilege" fallback argument is fragile.

## Consolidation and contributors

This PR fully supersedes the companion submission #530 (same issue #528, same `20260911000000` migration slot; only one can exist). #530's contribution - the service_role "keeps every verb" assertions - is carried over unchanged into the test suite above.

- **@arjun28115** - migration shape (PUBLIC + anon + authenticated revoke, policy drops, table comment), 15-assertion pgTAP suite, and the writer-verification for the service-role path.
- **@Rushikeshiitb** - original #528 report that fixed the fix shape, and the service_role privilege assertions now in the suite (via #530, closed as consolidated).

Maintainer follow-up work (assertion carry-over, cleanup-RPC revoke) is not part of the entrant attribution.

## Note on rollout

If any desktop build still in the field polls this table with the anon key, it would lose cross-device login the moment this merges. My reading of the source says none does. That is a supported-version question rather than a SQL one, so if you would rather land the policy drops first and the `REVOKE` separately, say so and I will split it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

