### PR TITLE
fix(plugin-store): stop the update check mis-ordering versions it cannot parse

### DIFF
--- a/plugin-platform/plugin-repository/build.gradle.kts
+++ b/plugin-platform/plugin-repository/build.gradle.kts
@@ -38,6 +38,9 @@ kotlin {
                 // Minimal plugin-api-core
                 api(projects.pluginPlatform.pluginApiCore)
 
+                // SemanticVersion: the sole version-comparison primitive for update checks.
+                implementation(projects.pluginPlatform.pluginDependency)
+
                 // Logging
                 implementation(projects.pluginPlatform.pluginLogging)
 

--- a/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryManager.kt
+++ b/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryManager.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin.repository
 
+import ai.rever.boss.plugin.dependency.SemanticVersion
 import ai.rever.boss.plugin.logging.BossLogger
 import ai.rever.boss.plugin.logging.LogCategory
 import kotlinx.coroutines.async
@@ -367,23 +368,35 @@ class PluginRepositoryManager {
         }
 
     /**
-     * Compare two version strings to determine if the first is newer.
+     * True when [candidate] is a genuine upgrade over [installed].
+     *
+     * Delegates to [SemanticVersion], which documents itself as the sole
+     * version-comparison primitive for plugin update and floor checks, and which
+     * PluginUpdateManager already uses. The hand-rolled comparison this
+     * replaced split on "." and dropped any segment that was not a bare integer,
+     * which shifted every later segment into the wrong position: "1.0.0+build.7"
+     * became [1, 7] and so read as newer than an installed "1.0.0", offering an
+     * update to the version already installed on every check.
+     *
+     * An unparseable [candidate] is never offered, because nothing can be said
+     * about it. An unparseable [installed] with a parseable [candidate] IS
+     * offered: that is a plugin whose recorded version is already broken, and
+     * withholding the update would strand it there permanently. Internal for
+     * test access.
      */
-    private fun isNewerVersion(
-        version1: String,
-        version2: String,
+    internal fun isNewerVersion(
+        candidate: String,
+        installed: String,
     ): Boolean {
-        val v1Parts = version1.split(".").mapNotNull { it.toIntOrNull() }
-        val v2Parts = version2.split(".").mapNotNull { it.toIntOrNull() }
-
-        for (i in 0 until maxOf(v1Parts.size, v2Parts.size)) {
-            val v1 = v1Parts.getOrElse(i) { 0 }
-            val v2 = v2Parts.getOrElse(i) { 0 }
-
-            if (v1 > v2) return true
-            if (v1 < v2) return false
+        val candidateVersion = SemanticVersion.parse(candidate)
+        val installedVersion = SemanticVersion.parse(installed)
+        // Single expression rather than early returns: detekt caps this function at
+        // two, and widening the rule to keep a guard-clause shape would be the wrong
+        // trade for three mutually exclusive cases.
+        return when {
+            candidateVersion == null -> false
+            installedVersion == null -> true
+            else -> candidateVersion > installedVersion
         }
-
-        return false
     }
 }

--- a/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryManager.kt
+++ b/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryManager.kt
@@ -334,6 +334,12 @@ class PluginRepositoryManager {
     /**
      * Check if any updates are available for installed plugins.
      *
+     * No production caller today: the Toolbox's update path goes
+     * PluginUpdateBridge -> PluginUpdateManager.checkForUpdates, which uses this
+     * manager only for lookups and downloads. It stays, pinned by tests, so the
+     * repository layer answers the same question the updater does if the paths
+     * are ever merged.
+     *
      * @param installedPlugins Map of plugin ID to installed version
      * @return List of plugins with available updates
      */
@@ -358,14 +364,42 @@ class PluginRepositoryManager {
                             error = failure,
                         )
                     }
-                    if (latestPlugin != null && isNewerVersion(latestPlugin.plugin.version, installedVersion)) {
-                        updates.add(latestPlugin)
+                    if (latestPlugin != null) {
+                        offerUpdateIfNewer(pluginId, installedVersion, latestPlugin, updates)
                     }
                 }
 
                 updates
             }
         }
+
+    /**
+     * Append [latestPlugin] to [updates] when it is a genuine upgrade over the
+     * installed version, and leave a log trace when the refusal came from an
+     * unparseable store version rather than from an actual comparison.
+     */
+    private fun offerUpdateIfNewer(
+        pluginId: String,
+        installedVersion: String,
+        latestPlugin: PluginWithSource,
+        updates: MutableList<PluginWithSource>,
+    ) {
+        val candidateVersion = latestPlugin.plugin.version
+        if (isNewerVersion(candidateVersion, installedVersion)) {
+            updates.add(latestPlugin)
+        } else if (SemanticVersion.parse(candidateVersion) == null) {
+            // The old comparison made a guess here; the new one refuses. The refusal is
+            // the right answer - you cannot order what you cannot read - but it must not
+            // vanish without a trace, for the same reason the lookup failure above is
+            // logged: "no update offered" and "we could not tell" must stay
+            // distinguishable in the log.
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Update check did not offer a candidate whose store version is not parseable",
+                mapOf("pluginId" to pluginId, "version" to candidateVersion),
+            )
+        }
+    }
 
     /**
      * True when [candidate] is a genuine upgrade over [installed].
@@ -375,14 +409,23 @@ class PluginRepositoryManager {
      * PluginUpdateManager already uses. The hand-rolled comparison this
      * replaced split on "." and dropped any segment that was not a bare integer,
      * which shifted every later segment into the wrong position: "1.0.0+build.7"
-     * became [1, 7] and so read as newer than an installed "1.0.0", offering an
+     * became [1, 0, 7] - the "0+build" segment dropped, the 7 landing in the
+     * PATCH slot - and so read as newer than an installed "1.0.0", offering an
      * update to the version already installed on every check.
      *
      * An unparseable [candidate] is never offered, because nothing can be said
      * about it. An unparseable [installed] with a parseable [candidate] IS
      * offered: that is a plugin whose recorded version is already broken, and
-     * withholding the update would strand it there permanently. Internal for
-     * test access.
+     * withholding the update would strand it there permanently.
+     *
+     * The live-path counterpart, `PluginUpdateManager.isNewerVersion` in
+     * plugin-updater, fails CLOSED on an unparseable installed version instead
+     * of open. The divergence is deliberate on both pages (see its KDoc) and
+     * belongs in its own change to settle, but until then a plugin with an
+     * unreadable installed record is offered an update by one path and withheld
+     * by the other.
+     *
+     * Internal for test access.
      */
     internal fun isNewerVersion(
         candidate: String,

--- a/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryManager.kt
+++ b/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryManager.kt
@@ -336,9 +336,10 @@ class PluginRepositoryManager {
      *
      * No production caller today: the Toolbox's update path goes
      * PluginUpdateBridge -> PluginUpdateManager.checkForUpdates, which uses this
-     * manager only for lookups and downloads. It stays, pinned by tests, so the
-     * repository layer answers the same question the updater does if the paths
-     * are ever merged.
+     * manager only for lookups and downloads. It is kept because the repository
+     * layer should answer the same question the updater does if the paths are
+     * ever merged, and PluginRepositoryVersionTest drives it end to end so the
+     * offer/refusal branches cannot rot untested.
      *
      * @param installedPlugins Map of plugin ID to installed version
      * @return List of plugins with available updates

--- a/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryVersionTest.kt
+++ b/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryVersionTest.kt
@@ -1,0 +1,95 @@
+package ai.rever.boss.plugin.repository
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Update-check version ordering.
+ *
+ * Every case below is one the previous hand-rolled comparison got wrong. It
+ * split on "." and dropped any segment that was not a bare integer, so a
+ * dropped segment shifted every later one into the wrong position: "1.0.0+build.7"
+ * parsed as [1, 7] and compared 7 against the MINOR of the installed version.
+ *
+ * The two that a user would actually notice are pinned first.
+ */
+class PluginRepositoryVersionTest {
+    private val manager = PluginRepositoryManager()
+
+    @Test
+    fun `build metadata does not make a version newer than itself`() {
+        // The loop case. "1.0.0+build.7" read as [1, 7], beating [1, 0, 0], so the
+        // store offered an update to the version already installed, on every check,
+        // forever. SemVer section 10 says build metadata is ignored for precedence.
+        assertFalse(manager.isNewerVersion("1.0.0+build.7", "1.0.0"))
+    }
+
+    @Test
+    fun `a release candidate is never offered over its own release`() {
+        // "2.0.0-rc.1" read as [2, 0]; installed "2.0.0" read as [2, 0, 0]. Equal
+        // through both present positions, and the old code then compared 0 with 0
+        // and fell through to true on the earlier segment, offering a downgrade.
+        assertFalse(manager.isNewerVersion("2.0.0-rc.1", "2.0.0"))
+    }
+
+    @Test
+    fun `a real upgrade over a pre-release install is still offered`() {
+        // The silent-stall case. Installed "1.0-beta.5" read as [1, 5], so 5 sat in
+        // the MINOR position and beat the 2 of "1.2.3". The genuine update was never
+        // offered at all.
+        assertTrue(manager.isNewerVersion("1.2.3", "1.0-beta.5"))
+    }
+
+    @Test
+    fun `ordinary upgrades are offered`() {
+        assertTrue(manager.isNewerVersion("1.2.4", "1.2.3"))
+        assertTrue(manager.isNewerVersion("1.10.0", "1.9.0"))
+        assertTrue(manager.isNewerVersion("2.0.0", "1.9.9"))
+    }
+
+    @Test
+    fun `downgrades and equal versions are not offered`() {
+        assertFalse(manager.isNewerVersion("1.2.3", "1.2.4"))
+        assertFalse(manager.isNewerVersion("1.2.3", "1.2.3"))
+        assertFalse(manager.isNewerVersion("1.9.0", "1.10.0"))
+    }
+
+    @Test
+    fun `a release is newer than its own pre-release`() {
+        assertTrue(manager.isNewerVersion("1.2.3", "1.2.3-rc1"))
+        assertFalse(manager.isNewerVersion("1.2.3-rc1", "1.2.3"))
+    }
+
+    @Test
+    fun `pre-releases order among themselves the way SemVer says`() {
+        // alpha < beta < rc, by identifier comparison.
+        assertTrue(manager.isNewerVersion("1.2.3-rc1", "1.2.3-beta.1"))
+        assertFalse(manager.isNewerVersion("1.2.3-beta.1", "1.2.3-rc1"))
+    }
+
+    @Test
+    fun `a missing patch or minor counts as zero rather than as absent`() {
+        assertFalse(manager.isNewerVersion("1.2", "1.2.0"))
+        assertFalse(manager.isNewerVersion("1", "1.0.0"))
+        assertTrue(manager.isNewerVersion("1.2.1", "1.2"))
+    }
+
+    @Test
+    fun `an unreadable candidate version is never offered`() {
+        // Nothing can be said about it, so proposing it would be a guess. A
+        // "v"-prefixed tag is the common case: it is not a SemVer version.
+        assertFalse(manager.isNewerVersion("v1.2.3", "1.2.3"))
+        assertFalse(manager.isNewerVersion("", "1.2.3"))
+        assertFalse(manager.isNewerVersion("not-a-version", "1.2.3"))
+    }
+
+    @Test
+    fun `a plugin whose installed version is unreadable is still offered an update`() {
+        // Deliberately the opposite of the rule above, and the one behaviour this
+        // change had to preserve from the old comparison. Such a plugin is already
+        // in a broken state; withholding every future update would strand it there.
+        assertTrue(manager.isNewerVersion("1.2.3", ""))
+        assertTrue(manager.isNewerVersion("1.2.3", "unknown"))
+    }
+}

--- a/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryVersionTest.kt
+++ b/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryVersionTest.kt
@@ -7,10 +7,18 @@ import kotlin.test.assertTrue
 /**
  * Update-check version ordering.
  *
- * Every case below is one the previous hand-rolled comparison got wrong. It
- * split on "." and dropped any segment that was not a bare integer, so a
- * dropped segment shifted every later one into the wrong position: "1.0.0+build.7"
- * parsed as [1, 7] and compared 7 against the MINOR of the installed version.
+ * The cases the previous hand-rolled comparison got wrong are the regression
+ * tests here: it split on "." and dropped any segment that was not a bare
+ * integer, and each dropped segment shifted every later one into the wrong
+ * position - "1.0.0+build.7" parsed as [1, 0, 7], the 7 landing in the PATCH
+ * slot, and beat the installed [1, 0, 0]. That is the build-metadata case
+ * below, plus the release-candidate downgrade, the upgrade over a pre-release
+ * install, the release-vs-pre-release ordering, the pre-release ordering among
+ * themselves, and the "v"-prefixed tag.
+ *
+ * The remaining cases ALSO pass against the old comparison. They are pinned as
+ * guards so the delegation to SemanticVersion cannot quietly regress the
+ * ordinary orderings the old code already got right.
  *
  * The two that a user would actually notice are pinned first.
  */
@@ -19,7 +27,8 @@ class PluginRepositoryVersionTest {
 
     @Test
     fun `build metadata does not make a version newer than itself`() {
-        // The loop case. "1.0.0+build.7" read as [1, 7], beating [1, 0, 0], so the
+        // The loop case. "1.0.0+build.7" read as [1, 0, 7] - the "0+build" segment
+        // was dropped, so the 7 landed in the PATCH slot - beating [1, 0, 0], so the
         // store offered an update to the version already installed, on every check,
         // forever. SemVer section 10 says build metadata is ignored for precedence.
         assertFalse(manager.isNewerVersion("1.0.0+build.7", "1.0.0"))
@@ -27,9 +36,9 @@ class PluginRepositoryVersionTest {
 
     @Test
     fun `a release candidate is never offered over its own release`() {
-        // "2.0.0-rc.1" read as [2, 0]; installed "2.0.0" read as [2, 0, 0]. Equal
-        // through both present positions, and the old code then compared 0 with 0
-        // and fell through to true on the earlier segment, offering a downgrade.
+        // "2.0.0-rc.1" read as [2, 0, 1] - "0-rc" was dropped, so the 1 landed in
+        // the PATCH slot - and the old loop returned true the moment 1 > 0 at that
+        // third position, offering the pre-release over its own release.
         assertFalse(manager.isNewerVersion("2.0.0-rc.1", "2.0.0"))
     }
 

--- a/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryVersionTest.kt
+++ b/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryVersionTest.kt
@@ -1,6 +1,9 @@
 package ai.rever.boss.plugin.repository
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -11,10 +14,9 @@ import kotlin.test.assertTrue
  * tests here: it split on "." and dropped any segment that was not a bare
  * integer, and each dropped segment shifted every later one into the wrong
  * position - "1.0.0+build.7" parsed as [1, 0, 7], the 7 landing in the PATCH
- * slot, and beat the installed [1, 0, 0]. That is the build-metadata case
- * below, plus the release-candidate downgrade, the upgrade over a pre-release
- * install, the release-vs-pre-release ordering, the pre-release ordering among
- * themselves, and the "v"-prefixed tag.
+ * slot, and beat the installed [1, 0, 0]. Those are the build-metadata case
+ * below, the release-candidate downgrade, the upgrade over a pre-release
+ * install, the pre-release ordering among themselves, and the "v"-prefixed tag.
  *
  * The remaining cases ALSO pass against the old comparison. They are pinned as
  * guards so the delegation to SemanticVersion cannot quietly regress the
@@ -100,5 +102,77 @@ class PluginRepositoryVersionTest {
         // in a broken state; withholding every future update would strand it there.
         assertTrue(manager.isNewerVersion("1.2.3", ""))
         assertTrue(manager.isNewerVersion("1.2.3", "unknown"))
+    }
+
+    // The two cases below drive checkForUpdates end to end. It has no production
+    // caller today, and without them the offerUpdateIfNewer helper and its debug
+    // log would have no coverage at all; everything else in this file pins
+    // isNewerVersion directly.
+
+    @Test
+    fun `a newer store version is offered through checkForUpdates`() =
+        runTest {
+            val manager = PluginRepositoryManager()
+            manager.addRepository(UpdateCheckRepository(Result.success(plugin("1.0.1"))))
+
+            val result = manager.checkForUpdates(mapOf("com.example.plugin" to "1.0.0"))
+
+            assertTrue(result.isSuccess)
+            val offered = result.getOrThrow()
+            assertEquals(1, offered.size)
+            assertEquals("1.0.1", offered.single().plugin.version)
+        }
+
+    @Test
+    fun `an unparseable store version is never offered through checkForUpdates`() =
+        runTest {
+            val manager = PluginRepositoryManager()
+            manager.addRepository(UpdateCheckRepository(Result.success(plugin("1.0.1.RELEASE"))))
+
+            val updates = manager.checkForUpdates(mapOf("com.example.plugin" to "1.0.0"))
+
+            assertTrue(updates.isSuccess)
+            assertTrue(
+                updates.getOrThrow().isEmpty(),
+                "nothing can be said about a version we cannot parse",
+            )
+        }
+
+    private fun plugin(version: String) =
+        PluginInfo(
+            pluginId = "com.example.plugin",
+            displayName = "Example",
+            version = version,
+            description = "Test plugin",
+        )
+
+    /** Answers every lookup with one canned [Result]; only getPlugin is exercised. */
+    private class UpdateCheckRepository(
+        private val answer: Result<PluginInfo?>,
+    ) : PluginRepository {
+        override val id: String = "store"
+        override val name: String = id
+        override val isLocal: Boolean = false
+        override val isAvailable: Boolean = true
+
+        override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> = answer
+
+        override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(emptyList())
+
+        override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
+            Result.failure(UnsupportedOperationException())
+
+        override suspend fun getPluginVersions(pluginId: String): Result<List<PluginInfo>> = Result.success(emptyList())
+
+        override suspend fun downloadPlugin(
+            pluginId: String,
+            version: String?,
+            targetPath: String,
+            onProgress: ((Float) -> Unit)?,
+        ): Result<String> = Result.failure(UnsupportedOperationException())
+
+        override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
+
+        override suspend fun refresh(): Result<Unit> = Result.success(Unit)
     }
 }

--- a/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
+++ b/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
@@ -614,6 +614,17 @@ class PluginUpdateManager(
 
     /**
      * Check if version1 is newer than version2.
+     *
+     * Fails CLOSED when either side is unparseable: an unreadable version
+     * offers no update. This is the one comparator on the live update path
+     * (Toolbox -> PluginUpdateBridge -> this class).
+     *
+     * The repository-side counterpart, `PluginRepositoryManager.isNewerVersion`
+     * in plugin-repository, fails OPEN on an unparseable *installed* version:
+     * a plugin whose recorded version is already broken should not be stranded
+     * without updates. The two divergences are deliberate on each page; settling
+     * which behaviour is the right one is a change of its own, and until then
+     * this is the answer the user actually gets.
      */
     private fun isNewerVersion(
         version1: String,


### PR DESCRIPTION
## What

`PluginRepositoryManager.isNewerVersion` gates the plugin-store update check. It split a version on
`"."` and dropped any segment that was not a bare integer. Dropping rather than zero-filling shifts
every later segment into the wrong position, so the comparison happens against the wrong field.

This replaces it with `SemanticVersion`, which the codebase already treats as the answer to this
question.

## Two cases a user would notice

**An update offered forever to the version already installed.** `"1.0.0+build.7"` parses as
`[1, 7]`, because `"0+build"` is not an integer and is dropped. Against an installed `"1.0.0"` of
`[1, 0, 0]`, the `7` lands in the minor position and wins. The store offers the update, the user
takes it, the installed version is still `1.0.0`, and it is offered again on the next check. SemVer
section 10 says build metadata is ignored for precedence.

**A genuine update never offered at all.** An installed `"1.0-beta.5"` parses as `[1, 5]`, so the
`5` sits in the minor position and beats the `2` of a real `"1.2.3"` release. The plugin silently
stops receiving updates, and "no update available" is indistinguishable from "up to date" to
someone looking at the Toolbox.

A release candidate also read as newer than its own release, so `"2.0.0-rc.1"` was offered over an
installed `"2.0.0"`.

## Why `SemanticVersion` rather than a local patch

`SemanticVersion` in `plugin-platform/plugin-dependency` opens with the line that it is "the sole
version-comparison primitive for plugin update/floor checks", and `PluginUpdateManager` uses it.
This was the third comparator in the tree and the only one that disagreed with it. The second,
`PluginVersionComparator`, is hand-rolled but position-preserving and pre-release aware, so it
agrees with `SemanticVersion` on everything I tried.

Across a small matrix of realistic version strings the shipped comparison and `SemanticVersion`
disagreed on **32 of 156 ordered pairs**.

`plugin-dependency` has no project dependencies of its own, so depending on it here cannot introduce
a cycle, and `plugin-updater` already does exactly this.

## The behaviour I preserved on purpose

`SemanticVersion.parse` returns null on unparseable input, and the obvious translation would be to
treat null as "not newer" in both directions. That would be a regression: a plugin whose recorded
installed version is unreadable would be refused every future update and stranded there.

So the two directions are deliberately asymmetric, and the test names say so:

- an unparseable **candidate** is never offered, because nothing can be said about it
- an unparseable **installed** version with a parseable candidate **is** offered

A `"v"`-prefixed tag falls in the first group. It is not a SemVer version, and the old code turned
`"v1.2.3"` into `[2, 3]`, making it read as newer than `"1.5.0"`.

## Testing

Ten tests in `PluginRepositoryVersionTest`, each named after the case it pins.

I checked they actually cover the defect rather than assuming it, by reverting the implementation
alone and leaving the tests untouched: **five of the ten fail** against the old comparison. The five
that fail are build metadata, the release candidate case, the stalled pre-release install, the
unreadable candidate, and pre-release ordering. Worth stating plainly that "a release is newer than
its own pre-release" passes against both, so that one is a guard rather than a regression test.

```
./gradlew :plugin-platform:plugin-repository:desktopTest :plugin-platform:plugin-repository:ktlintCheck :plugin-platform:plugin-repository:detekt
```

47 tests in the module, 0 failures. ktlint and detekt both clean.

## Notes for review

- `isNewerVersion` moved from `private` to `internal` for test access, matching how
  `PluginVersionComparator` is already exposed.
- The function body is a single `when` rather than guard clauses because detekt caps this function
  at two returns. Widening `ReturnCount` to keep a prettier shape seemed the wrong trade, so the
  comment records why.
- I have not touched `PluginVersionComparator`. It agrees with `SemanticVersion` on everything I
  tested, and folding it in too would make this PR a refactor rather than a fix. Happy to do it
  separately if you want one comparator rather than two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Review sweep follow-up (config-matching, after Claude review):** commit `20b7e6ff5` (comments plus one log line; no behaviour change). Three comment corrections from the review: the old code parsed `"1.0.0+build.7"` as `[1, 0, 7]` (the `"0+build"` segment was dropped, so the 7 landed in the PATCH slot, not the minor), and `"2.0.0-rc.1"` as `[2, 0, 1]`, returning true on `1 > 0` at the third position rather than "falling through"; the test KDoc now names which cases are regression tests and which are guards. One structural note the review surfaced: `checkForUpdates` has **no production caller today** - the Toolbox path is `PluginUpdateBridge` -> `PluginUpdateManager.checkForUpdates`, which does its own comparison and, unlike this one, fails CLOSED on an unparseable installed version. The two comparators' KDocs now cross-reference each other and state that the fail-open/fail-closed divergence is deliberate on both pages but belongs in its own change to settle, and `checkForUpdates` documents its callerless state and logs (at debug) when a candidate is refused because its store version is not parseable, so "no update offered" and "we could not tell" stay distinguishable in the log.

**Second Claude review (head `20b7e6ff5`):** "the substance of the last review is addressed and the fix itself is unchanged and correct" (5632826950); two comment corrections, both implemented in commit `48973d5f3`: the test KDoc listed six regression cases but `a release is newer than its own pre-release` passes against the old comparison too (it is the guard the "Notes" section above already named), so the list now names the five real regressions; and `checkForUpdates` was called "pinned by tests" while nothing called it - it is now driven end to end by two new tests (a newer store version is offered; an unparseable store version is never offered), which also cover the `offerUpdateIfNewer` helper and its debug log, and the KDoc states the honest reason it is kept. Current head `48973d5f3`; local `:plugin-platform:plugin-repository:desktopTest` 49/49 (12 in PluginRepositoryVersionTest), module ktlintCheck + detekt clean.


Merge review: Original SemanticVersion delegation and comparator regression coverage by @arjun28115; review-agent documentation/logging and end-to-end test additions are recorded separately above. The repository path has no production caller today; this still removes a defective duplicate comparator without changing the live updater policy.
