### PR TITLE
fix(downloads): stop a hostile file name throwing out of the download handler

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
@@ -90,7 +90,8 @@ object FileNameSanitizer {
                 }.joinToString("")
 
         // 4. Handle Windows reserved names. See [defuseDeviceName] for why the check is
-        // against the segment before the FIRST dot.
+        // against the segment before the FIRST dot. The extension is computed from the
+        // LAST dot - "what kind of file is this" - and feeds only the fallback in step 6.
         val extension =
             if (sanitized.contains('.')) {
                 "." + sanitized.substringAfterLast('.')
@@ -149,8 +150,10 @@ object FileNameSanitizer {
     ): String {
         val cut = cutTo(name, MAX_FILENAME_LENGTH, replacement)
         // Defusing prepends one character. Rather than let that push the result over the
-        // limit, the cut is redone one character shorter, which is always enough because
-        // the prefix is exactly one character.
+        // limit, the cut is redone one character shorter. One redo is always enough:
+        // every branch of cutTo returns at most limit + 1 (the defuse is the only thing
+        // that can add a character), so the redo at limit - 1 lands at or under the
+        // limit even when it defuses in turn.
         return if (cut.length <= MAX_FILENAME_LENGTH) {
             cut
         } else {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
@@ -89,8 +89,8 @@ object FileNameSanitizer {
                     }
                 }.joinToString("")
 
-        // 4. Handle Windows reserved names
-        val nameWithoutExtension = sanitized.substringBeforeLast('.', sanitized)
+        // 4. Handle Windows reserved names. See [defuseDeviceName] for why the check is
+        // against the segment before the FIRST dot.
         val extension =
             if (sanitized.contains('.')) {
                 "." + sanitized.substringAfterLast('.')
@@ -98,9 +98,7 @@ object FileNameSanitizer {
                 ""
             }
 
-        if (nameWithoutExtension.uppercase() in WINDOWS_RESERVED_NAMES) {
-            sanitized = "${replacement}${nameWithoutExtension}$extension"
-        }
+        sanitized = defuseDeviceName(sanitized, replacement)
 
         // 5. Remove trailing dots and spaces (invalid on Windows)
         sanitized = sanitized.trimEnd('.', ' ')
@@ -149,25 +147,63 @@ object FileNameSanitizer {
         name: String,
         replacement: Char,
     ): String {
+        val cut = cutTo(name, MAX_FILENAME_LENGTH, replacement)
+        // Defusing prepends one character. Rather than let that push the result over the
+        // limit, the cut is redone one character shorter, which is always enough because
+        // the prefix is exactly one character.
+        return if (cut.length <= MAX_FILENAME_LENGTH) {
+            cut
+        } else {
+            cutTo(name, MAX_FILENAME_LENGTH - 1, replacement)
+        }
+    }
+
+    /** One pass of the cut: shorten to [limit], tidy the tail, then defuse. */
+    private fun cutTo(
+        name: String,
+        limit: Int,
+        replacement: Char,
+    ): String {
         val extension =
             if (name.contains('.')) {
                 "." + name.substringAfterLast('.')
             } else {
                 ""
             }
-        val budget = MAX_FILENAME_LENGTH - extension.length
+        val budget = limit - extension.length
         val truncated =
             if (budget <= 0) {
                 // The extension alone would fill the whole limit, so there is no room
                 // to keep it: preserve the base name only, cut to the limit.
-                name.substringBeforeLast('.').take(MAX_FILENAME_LENGTH)
+                name.substringBeforeLast('.').take(limit)
             } else {
                 name.substringBeforeLast('.').take(budget) + extension
             }
         // Cutting mid-name can expose a dot or space that step 5 had removed, so the
         // Windows rule is re-applied to whatever the cut produced.
-        val cut = truncated.trimEnd('.', ' ').ifBlank { "download" }
-        return if (cut.uppercase() in WINDOWS_RESERVED_NAMES) "$replacement$cut" else cut
+        val tidied = truncated.trimEnd('.', ' ').ifBlank { "download" }
+        return defuseDeviceName(tidied, replacement)
+    }
+
+    /**
+     * Prefix [name] when Windows would resolve it to a character device rather than a file.
+     *
+     * The comparison is against the segment before the **first** dot, not the last. Win32
+     * stops parsing a device name there, so `NUL.txt` and `CON.tar.gz` are both the device,
+     * which Microsoft's own naming rules state in as many words. Comparing the segment
+     * before the *last* dot missed every multi-dot case, and let truncation manufacture a
+     * device out of a name that was not one: cutting `CONSOLE.` followed by 251 characters
+     * to fit the limit leaves `CON.` and the rest, which is the console.
+     *
+     * Trailing spaces are trimmed before the comparison for the same reason: Windows
+     * ignores them, so `CON .txt` is the device too.
+     */
+    private fun defuseDeviceName(
+        name: String,
+        replacement: Char,
+    ): String {
+        val device = name.substringBefore('.').trimEnd(' ')
+        return if (device.uppercase() in WINDOWS_RESERVED_NAMES) "$replacement$name" else name
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
@@ -142,7 +142,9 @@ object FileNameSanitizer {
         val budget = MAX_FILENAME_LENGTH - extension.length
         val truncated =
             if (budget <= 0) {
-                name.take(MAX_FILENAME_LENGTH)
+                // The extension alone would fill the whole limit, so there is no room
+                // to keep it: preserve the base name only, cut to the limit.
+                name.substringBeforeLast('.').take(MAX_FILENAME_LENGTH)
             } else {
                 name.substringBeforeLast('.').take(budget) + extension
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
@@ -105,20 +105,50 @@ object FileNameSanitizer {
         // 5. Remove trailing dots and spaces (invalid on Windows)
         sanitized = sanitized.trimEnd('.', ' ')
 
-        // 6. Ensure at least one character remains
+        // 6. Ensure at least one character remains.
         if (sanitized.isBlank() || sanitized == extension) {
-            sanitized = "download$extension"
+            // The extension is trimmed again on the way in. For a suggested name of
+            // "." or "..." the extension computed in step 4 is a lone ".", and
+            // appending it raw handed back "download.", re-creating exactly the
+            // trailing dot step 5 exists to remove.
+            sanitized = "download" + extension.trimEnd('.', ' ')
         }
 
-        // 7. Truncate to maximum length while preserving extension
+        // 7. Truncate to maximum length, keeping the extension when it fits.
         if (sanitized.length > MAX_FILENAME_LENGTH) {
-            val ext = if (extension.isNotEmpty()) extension else ""
-            val maxNameLength = MAX_FILENAME_LENGTH - ext.length
-            val baseName = sanitized.substringBeforeLast('.').take(maxNameLength)
-            sanitized = baseName + ext
+            sanitized = truncate(sanitized, extension)
         }
 
         return sanitized
+    }
+
+    /**
+     * Cut [name] to [MAX_FILENAME_LENGTH], keeping [extension] only if there is room.
+     *
+     * Nothing bounds how long an extension can be: it is whatever follows the last dot
+     * in a name the download source chose. A suggested name of "a." followed by 300
+     * characters produces an extension of 301, and subtracting that from the limit gave
+     * a negative budget which then reached `take()`, which rejects a negative count and
+     * throws out of the download handler.
+     *
+     * When the extension cannot fit, it is abandoned rather than shortened. A truncated
+     * extension is not the file's type, so inventing one would be worse than having
+     * none, and a name that is nothing but an extension was never worth preserving.
+     */
+    private fun truncate(
+        name: String,
+        extension: String,
+    ): String {
+        val budget = MAX_FILENAME_LENGTH - extension.length
+        val truncated =
+            if (budget <= 0) {
+                name.take(MAX_FILENAME_LENGTH)
+            } else {
+                name.substringBeforeLast('.').take(budget) + extension
+            }
+        // Cutting mid-name can expose a dot or space that step 5 had removed, so the
+        // Windows rule is re-applied to whatever the cut produced.
+        return truncated.trimEnd('.', ' ').ifBlank { "download" }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileNameSanitizer.kt
@@ -116,14 +116,14 @@ object FileNameSanitizer {
 
         // 7. Truncate to maximum length, keeping the extension when it fits.
         if (sanitized.length > MAX_FILENAME_LENGTH) {
-            sanitized = truncate(sanitized, extension)
+            sanitized = truncate(sanitized, replacement)
         }
 
         return sanitized
     }
 
     /**
-     * Cut [name] to [MAX_FILENAME_LENGTH], keeping [extension] only if there is room.
+     * Cut [name] to [MAX_FILENAME_LENGTH], keeping the extension only if there is room.
      *
      * Nothing bounds how long an extension can be: it is whatever follows the last dot
      * in a name the download source chose. A suggested name of "a." followed by 300
@@ -131,14 +131,30 @@ object FileNameSanitizer {
      * a negative budget which then reached `take()`, which rejects a negative count and
      * throws out of the download handler.
      *
+     * The extension is recomputed from [name] rather than taken from the caller. The
+     * caller's copy was computed before the trailing-dot trim, and for exactly the names
+     * this class exists for - ones ending in a dot - it is a stale lone "." that makes a
+     * real extension (".pdf") look as if it did not fit.
+     *
      * When the extension cannot fit, it is abandoned rather than shortened. A truncated
      * extension is not the file's type, so inventing one would be worse than having
      * none, and a name that is nothing but an extension was never worth preserving.
+     *
+     * The cut can also undo a step 4 decision: trimming can shrink the base onto a
+     * reserved device name step 4 missed, because a space before the dot ("CON .") keeps
+     * the checked segment out of the reserved set. Whatever the cut leaves is therefore
+     * defused with [replacement], the way step 4 defuses.
      */
     private fun truncate(
         name: String,
-        extension: String,
+        replacement: Char,
     ): String {
+        val extension =
+            if (name.contains('.')) {
+                "." + name.substringAfterLast('.')
+            } else {
+                ""
+            }
         val budget = MAX_FILENAME_LENGTH - extension.length
         val truncated =
             if (budget <= 0) {
@@ -150,7 +166,8 @@ object FileNameSanitizer {
             }
         // Cutting mid-name can expose a dot or space that step 5 had removed, so the
         // Windows rule is re-applied to whatever the cut produced.
-        return truncated.trimEnd('.', ' ').ifBlank { "download" }
+        val cut = truncated.trimEnd('.', ' ').ifBlank { "download" }
+        return if (cut.uppercase() in WINDOWS_RESERVED_NAMES) "$replacement$cut" else cut
     }
 
     /**

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
@@ -1,0 +1,131 @@
+package ai.rever.boss.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [FileNameSanitizer.sanitize] takes a name chosen by whatever served the download, so
+ * every assertion here is about hostile or degenerate input rather than ordinary names.
+ *
+ * The two cases at the top are the ones that were wrong: a long extension threw out of
+ * the download handler, and a name of only dots came back carrying the trailing dot the
+ * sanitizer exists to remove.
+ *
+ * Stated so nobody assumes more coverage than there is: these assert the returned string
+ * only. Whether Windows would accept it is not exercised anywhere, and cannot be from a
+ * JVM test on another platform.
+ */
+class FileNameSanitizerTest {
+    @Test
+    fun `a name whose extension is longer than the limit does not throw`() {
+        // "a." plus 300 characters gives an extension of 301. The limit is 255, so the
+        // old budget arithmetic reached take(-46), which rejects a negative count.
+        val result = FileNameSanitizer.sanitize("a." + "x".repeat(300))
+
+        assertTrue(result.length <= 255, "result was ${result.length} characters")
+        assertTrue(result.isNotBlank())
+    }
+
+    @Test
+    fun `a name of only dots does not come back ending in a dot`() {
+        // The fallback appended the extension computed in step 4, which for these inputs
+        // is a lone ".", so it handed back "download." and undid the trailing dot
+        // removal. A trailing dot is exactly what is invalid on Windows.
+        for (input in listOf(".", "..", "...", " . ")) {
+            val result = FileNameSanitizer.sanitize(input)
+            assertFalse(result.endsWith("."), "sanitize($input) returned $result")
+            assertTrue(result.isNotBlank(), "sanitize($input) returned blank")
+        }
+    }
+
+    @Test
+    fun `no input produces a name ending in a dot or a space`() {
+        val inputs =
+            listOf(
+                "report.pdf",
+                "CON",
+                "CON.txt",
+                "..",
+                ".",
+                "   ",
+                "",
+                "a." + "x".repeat(300),
+                "x".repeat(300) + ".pdf",
+                "file. ",
+                "file .",
+                "../../etc/passwd",
+                "/etc/shadow",
+            )
+        for (input in inputs) {
+            val result = FileNameSanitizer.sanitize(input)
+            assertFalse(
+                result.endsWith(".") || result.endsWith(" "),
+                "sanitize($input) returned '$result'",
+            )
+        }
+    }
+
+    @Test
+    fun `every result stays within the length limit`() {
+        val inputs = listOf("x".repeat(300), "x".repeat(300) + ".pdf", "a." + "x".repeat(300))
+        for (input in inputs) {
+            assertTrue(FileNameSanitizer.sanitize(input).length <= 255)
+        }
+    }
+
+    @Test
+    fun `a long name keeps its extension when the extension fits`() {
+        val result = FileNameSanitizer.sanitize("x".repeat(300) + ".pdf")
+
+        assertTrue(result.endsWith(".pdf"), "expected the type to survive, got '$result'")
+        assertEquals(255, result.length)
+    }
+
+    @Test
+    fun `ordinary names are returned unchanged`() {
+        assertEquals("report.pdf", FileNameSanitizer.sanitize("report.pdf"))
+        assertEquals("my file (1).tar.gz", FileNameSanitizer.sanitize("my file (1).tar.gz"))
+    }
+
+    @Test
+    fun `path traversal is reduced to the file name`() {
+        assertEquals("passwd", FileNameSanitizer.sanitize("../../etc/passwd"))
+        assertFalse(FileNameSanitizer.sanitize("/etc/shadow").contains("/"))
+        assertFalse(FileNameSanitizer.sanitize("..\\..\\windows\\cmd.exe").contains("\\"))
+    }
+
+    @Test
+    fun `windows device names are defused, whatever their case or extension`() {
+        for (name in listOf("CON", "con", "Con", "PRN", "NUL", "COM1", "LPT9")) {
+            assertFalse(
+                FileNameSanitizer.sanitize(name).uppercase() == name.uppercase(),
+                "sanitize($name) left the device name intact",
+            )
+        }
+        assertEquals("_CON.txt", FileNameSanitizer.sanitize("CON.txt"))
+    }
+
+    @Test
+    fun `a blank name becomes a usable default`() {
+        assertEquals("download", FileNameSanitizer.sanitize(""))
+        assertEquals("download", FileNameSanitizer.sanitize("   "))
+    }
+
+    @Test
+    fun `control characters are dropped rather than replaced`() {
+        // A bell character inside the name must vanish, not become an underscore, or
+        // every name carrying one would gain a stray separator.
+        assertEquals("report.pdf", FileNameSanitizer.sanitize("re\u0007port.pdf"))
+    }
+
+    @Test
+    fun `executable detection is case insensitive and reads the final extension`() {
+        assertTrue(FileNameSanitizer.isExecutableFile("setup.EXE"))
+        assertTrue(FileNameSanitizer.isExecutableFile("invoice.pdf.exe"))
+        assertTrue(FileNameSanitizer.isExecutableFile("script.Sh"))
+        assertFalse(FileNameSanitizer.isExecutableFile("report.pdf"))
+        assertFalse(FileNameSanitizer.isExecutableFile("noextension"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
@@ -68,6 +68,13 @@ class FileNameSanitizerTest {
     }
 
     @Test
+    fun `an extension that cannot fit is abandoned rather than shortened`() {
+        // "a." plus 300 characters gives a 301-character "extension", which cannot
+        // fit in the 255 limit, so the base name survives and the extension goes.
+        assertEquals("a", FileNameSanitizer.sanitize("a." + "x".repeat(300)))
+    }
+
+    @Test
     fun `every result stays within the length limit`() {
         val inputs = listOf("x".repeat(300), "x".repeat(300) + ".pdf", "a." + "x".repeat(300))
         for (input in inputs) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
@@ -104,12 +104,11 @@ class FileNameSanitizerTest {
     }
 
     @Test
-    fun `windows device names are defused in any case, and with a single extension`() {
-        // The check runs on the segment before the last dot, so this pins the bare names in
-        // three cases, the trailing-space padding the top-level trim removes before the check,
-        // and one single-extension name. Multi-dot names like "CON.tar.gz" are untouched by
-        // the sanitizer (pre-existing, out of scope here), so the title says what the check
-        // actually covers instead of promising every extension shape.
+    fun `windows device names are defused whatever their case or padding`() {
+        // The check now runs on the segment before the FIRST dot, so this pins the bare
+        // names in three cases and the trailing-space padding the top-level trim removes
+        // before the check. Extension shapes are covered by the two tests below, which
+        // exist because the last-dot version missed every multi-dot name.
         for (name in listOf("CON", "con", "Con", "PRN", "NUL", "COM1", "LPT9")) {
             assertEquals("_$name", FileNameSanitizer.sanitize(name), "sanitize($name)")
         }
@@ -133,6 +132,59 @@ class FileNameSanitizerTest {
         // fire. The oversized extension then leaves only the base, and the trailing trim
         // removes the padding - leaving bare "CON", a name Windows refuses.
         assertEquals("_CON", FileNameSanitizer.sanitize("CON ." + "x".repeat(255)))
+    }
+
+    @Test
+    fun `a device name with any number of extensions is still defused`() {
+        // Win32 stops the device comparison at the FIRST dot, so NUL.txt and CON.tar.gz
+        // are both the device. Comparing the segment before the LAST dot saw "CON.tar",
+        // which is not reserved, and let the name through untouched.
+        assertEquals("_CON.tar.gz", FileNameSanitizer.sanitize("CON.tar.gz"))
+        assertEquals("_NUL.tar.gz", FileNameSanitizer.sanitize("NUL.tar.gz"))
+        assertEquals("_CON.txt", FileNameSanitizer.sanitize("CON.txt"))
+        assertEquals("CONSOLE.txt", FileNameSanitizer.sanitize("CONSOLE.txt"))
+    }
+
+    @Test
+    fun `truncation cannot manufacture a device name out of one that was not`() {
+        // "CONSOLE." followed by 251 characters is not a device: step 4 sees CONSOLE.
+        // Cutting it to fit the limit left "CON." and the rest, which Windows resolves
+        // to the console, so the download would write nowhere and no file would appear.
+        val result = FileNameSanitizer.sanitize("CONSOLE." + "x".repeat(251))
+
+        assertFalse(
+            result.substringBefore('.').trimEnd(' ').uppercase() == "CON",
+            "truncation produced the console device: '$result'",
+        )
+        assertTrue(result.length <= 255, "result was ${result.length} characters")
+    }
+
+    @Test
+    fun `no input produces a name Windows would resolve to a device`() {
+        val reserved =
+            setOf("CON", "PRN", "AUX", "NUL") +
+                (1..9).map { "COM$it" } + (1..9).map { "LPT$it" }
+        val inputs =
+            listOf(
+                "CON",
+                "con",
+                "CON ",
+                "CON.txt",
+                "CON.tar.gz",
+                "NUL.tar.gz",
+                "CONSOLE." + "x".repeat(251),
+                "CON ." + "x".repeat(255),
+                "COM1.a.b",
+                "lpt9.tar.gz",
+                "aux.x.y.z",
+            )
+        for (input in inputs) {
+            val result = FileNameSanitizer.sanitize(input)
+            assertFalse(
+                result.substringBefore('.').trimEnd(' ').uppercase() in reserved,
+                "sanitize($input) returned '$result', which Windows resolves to a device",
+            )
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
@@ -128,10 +128,20 @@ class FileNameSanitizerTest {
 
     @Test
     fun `truncation cannot shrink a padded name onto a bare device name`() {
-        // "CON " (the space before the dot) is not a reserved segment, so step 4 does not
-        // fire. The oversized extension then leaves only the base, and the trailing trim
-        // removes the padding - leaving bare "CON", a name Windows refuses.
+        // Step 4's own trailing-space trim now defuses this input before truncation
+        // runs, so the cut-level defuse it was written for is exercised by the
+        // tight-limit test below instead. The assertion still pins the end-to-end shape.
         assertEquals("_CON", FileNameSanitizer.sanitize("CON ." + "x".repeat(255)))
+    }
+
+    @Test
+    fun `a redo that itself defuses lands exactly at the limit`() {
+        // The only path where a defused cut survives into the returned value, and the
+        // one where the 255 bound is exactly tight: the budget lands inside the run of
+        // spaces, so both the 255 cut and the 254 redo trim onto "CON" and both defuse.
+        val result = FileNameSanitizer.sanitize("CON  X." + "x".repeat(249))
+        assertEquals("_CON ." + "x".repeat(249), result)
+        assertEquals(255, result.length)
     }
 
     @Test
@@ -148,15 +158,11 @@ class FileNameSanitizerTest {
     @Test
     fun `truncation cannot manufacture a device name out of one that was not`() {
         // "CONSOLE." followed by 251 characters is not a device: step 4 sees CONSOLE.
-        // Cutting it to fit the limit left "CON." and the rest, which Windows resolves
-        // to the console, so the download would write nowhere and no file would appear.
+        // The first cut to the limit leaves "CON." and the rest - the console - so the
+        // redo runs one character shorter and shortens the base to "CO." rather than
+        // defusing it; the pinned shape rules out the defused form as well.
         val result = FileNameSanitizer.sanitize("CONSOLE." + "x".repeat(251))
-
-        assertFalse(
-            result.substringBefore('.').trimEnd(' ').uppercase() == "CON",
-            "truncation produced the console device: '$result'",
-        )
-        assertTrue(result.length <= 255, "result was ${result.length} characters")
+        assertEquals("CO." + "x".repeat(251), result)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/FileNameSanitizerTest.kt
@@ -104,14 +104,35 @@ class FileNameSanitizerTest {
     }
 
     @Test
-    fun `windows device names are defused, whatever their case or extension`() {
+    fun `windows device names are defused in any case, and with a single extension`() {
+        // The check runs on the segment before the last dot, so this pins the bare names in
+        // three cases, the trailing-space padding the top-level trim removes before the check,
+        // and one single-extension name. Multi-dot names like "CON.tar.gz" are untouched by
+        // the sanitizer (pre-existing, out of scope here), so the title says what the check
+        // actually covers instead of promising every extension shape.
         for (name in listOf("CON", "con", "Con", "PRN", "NUL", "COM1", "LPT9")) {
-            assertFalse(
-                FileNameSanitizer.sanitize(name).uppercase() == name.uppercase(),
-                "sanitize($name) left the device name intact",
-            )
+            assertEquals("_$name", FileNameSanitizer.sanitize(name), "sanitize($name)")
         }
+        assertEquals("_CON", FileNameSanitizer.sanitize("CON "))
         assertEquals("_CON.txt", FileNameSanitizer.sanitize("CON.txt"))
+    }
+
+    @Test
+    fun `a trailing dot does not hide a real extension from the truncation`() {
+        // Before the trailing-dot trim, the extension of "a<252 x>.pdf..." is the lone dot
+        // after the last one. Carrying that stale copy into the cut dropped the real ".pdf"
+        // even though it fit, leaving a 253-character extensionless name.
+        val result = FileNameSanitizer.sanitize("a" + "x".repeat(252) + ".pdf...")
+        assertEquals("a" + "x".repeat(250) + ".pdf", result)
+        assertEquals(255, result.length)
+    }
+
+    @Test
+    fun `truncation cannot shrink a padded name onto a bare device name`() {
+        // "CON " (the space before the dot) is not a reserved segment, so step 4 does not
+        // fire. The oversized extension then leaves only the base, and the trailing trim
+        // removes the padding - leaving bare "CON", a name Windows refuses.
+        assertEquals("_CON", FileNameSanitizer.sanitize("CON ." + "x".repeat(255)))
     }
 
     @Test


### PR DESCRIPTION
Hostile download filenames previously could make FileNameSanitizer throw while truncating an oversized extension, aborting the download handler. Truncation could also leave or manufacture a Windows reserved device name. The sanitizer now abandons an extension that cannot fit, defuses the first-dot Windows device segment, and retries one character shorter if defusing the cut would exceed the 255-character limit.

Original contribution: Arjun Singla (@arjun28115), including the sanitizer redesign and author follow-up 40700c137 (Claude co-authored). Review-agent repairs 7d1ee5736 and 9d04f35ba addressed initial edge gaps; final agent commit 8cf9a06d4 strengthens regression assertions and clarifies comments. Agent repair is not original contributor work.

Validation at exact head 8cf9a06d4a2f0331fb805f86b1b1d697f00ed87b: 18 focused local tests, root ktlintCheck/detekt, and all nine hosted Build & Test checks pass (34585318297). Latest Claude review (34585338925) approves this head with no correctness blocker. Its optional comment narrowing is acknowledged: the test uniquely covers a redo that defuses at the tight bound, not every possible surviving defused cut. No production change is warranted for that wording.

Current review reuses the completed unchanged-head validation and checks compatibility with freshly fetched dev under the serialized merge lock. This useful fix is distinct from executable consent #484 and store endpoint/hash changes #571. No live app visual tests were performed: hostile names, dots-only names and Windows multi-dot device names should download without a handler exception; executable classification should still recognize the final extension.
