### PR TITLE
fix(logging): mask a URL whose fragment comes before its query

### DIFF
--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
@@ -143,7 +143,18 @@ object LogSanitizer {
         endChar: Char,
         sensitiveParams: Set<String>,
     ): String {
-        val endIndex = if (endChar == '\u0000') uri.length else uri.indexOf(endChar).let { if (it < 0) uri.length else it }
+        // Searched from startIndex, not from 0. A URL whose fragment precedes its query
+        // (`https://app/#/reset?token=...`, the ordinary shape of a hash-routed callback)
+        // otherwise found the '#' BEFORE the segment being masked, producing an endIndex
+        // below startIndex and a StringIndexOutOfBoundsException out of substring. The
+        // caller's catch turned that into "[uri-mask-error]", so the whole URL was lost
+        // from the log rather than masked.
+        val endIndex =
+            if (endChar == '\u0000') {
+                uri.length
+            } else {
+                uri.indexOf(endChar, startIndex).let { if (it < 0) uri.length else it }
+            }
         val segment = uri.substring(startIndex, endIndex)
 
         val maskedSegment =

--- a/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/UriFragmentOrderTest.kt
+++ b/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/UriFragmentOrderTest.kt
@@ -1,0 +1,82 @@
+package ai.rever.boss.plugin.logging
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * [LogSanitizer.maskUriParams] when the fragment comes before the query.
+ *
+ * Every existing test puts the fragment last or omits it, which is the shape a deep
+ * link has. A hash-routed web callback is the other way round, and that ordering hit an
+ * end index computed by searching from 0 rather than from the start of the segment being
+ * masked. The index landed before the segment, substring threw, and the caller's catch
+ * replaced the whole URL with "[uri-mask-error]".
+ *
+ * Nothing leaked, so this is a diagnostic fault rather than a disclosure one: the URL was
+ * lost from the log, not printed. The assertions are written against the masked output
+ * rather than against the absence of a secret, so a version that went back to refusing to
+ * mask would fail them. Three of the four fail against the previous implementation; the
+ * fourth pins the orderings that already worked and passes against both, deliberately.
+ */
+class UriFragmentOrderTest {
+    @Test
+    fun `a hash-routed callback is masked rather than discarded`() {
+        assertEquals(
+            "https://app.example.com/#/reset?token=[REDACTED]",
+            LogSanitizer.maskUriParams("https://app.example.com/#/reset?token=abc123"),
+        )
+    }
+
+    @Test
+    fun `every sensitive parameter after a fragment is still redacted`() {
+        val masked =
+            LogSanitizer.maskUriParams(
+                "https://app.example.com/#/callback?access_token=secret123&code=xyz789&type=implicit",
+            )
+
+        assertTrue(masked.contains("access_token=[REDACTED]"), masked)
+        assertTrue(masked.contains("code=[REDACTED]"), masked)
+        assertTrue(masked.contains("type=implicit"), "a harmless parameter should survive: $masked")
+        assertTrue(!masked.contains("secret123"), "the token must not reach the log: $masked")
+        assertTrue(!masked.contains("xyz789"), "the code must not reach the log: $masked")
+    }
+
+    @Test
+    fun `the failure placeholder is no longer produced for these URLs`() {
+        val inputs =
+            listOf(
+                "https://app.example.com/#/reset?token=abc123",
+                "https://x/#frag?code=secret",
+                "boss://auth#/route?refresh_token=secret",
+            )
+        for (input in inputs) {
+            assertTrue(
+                LogSanitizer.maskUriParams(input) != "[uri-mask-error]",
+                "sanitising $input still fails outright",
+            )
+        }
+    }
+
+    @Test
+    fun `the ordinary orderings are unchanged`() {
+        // Pinned here as well as in the existing suite, because the fix edits the index
+        // both orderings share and a regression would be silent in the common case.
+        assertEquals(
+            "boss://auth?token=[REDACTED]&type=signup",
+            LogSanitizer.maskUriParams("boss://auth?token=abc123&type=signup"),
+        )
+        assertEquals(
+            "boss://auth#access_token=[REDACTED]",
+            LogSanitizer.maskUriParams("boss://auth#access_token=secret123"),
+        )
+        assertEquals(
+            "boss://auth?type=signup#access_token=[REDACTED]",
+            LogSanitizer.maskUriParams("boss://auth?type=signup#access_token=secret123"),
+        )
+        assertEquals(
+            "boss://auth/verify",
+            LogSanitizer.maskUriParams("boss://auth/verify"),
+        )
+    }
+}


### PR DESCRIPTION
## What

`LogSanitizer.maskParamsInSegment` computed the end of the segment it was masking with
`uri.indexOf(endChar)`, which searches from index 0 rather than from the start of that segment.

One word changes: `uri.indexOf(endChar, startIndex)`.

## The defect

For the query pass the terminator is `'#'`. A URL whose fragment precedes its query therefore found
the `'#'` **before** the segment, producing an end index below the start index, and `substring`
threw `StringIndexOutOfBoundsException`. `maskUriParams` caught it and returned `"[uri-mask-error]"`,
so the entire URL was lost from the log and a warning was written in its place.

That ordering is not exotic. It is the ordinary shape of a hash-routed web callback, which is
exactly the auth flow this function exists to mask:

| Input | Before | After |
|---|---|---|
| `boss://auth?token=X&type=signup` | `boss://auth?token=[REDACTED]&type=signup` | unchanged |
| `boss://auth#access_token=X` | `boss://auth#access_token=[REDACTED]` | unchanged |
| `boss://auth?type=signup#access_token=X` | `boss://auth?type=signup#access_token=[REDACTED]` | unchanged |
| `https://app/#/reset?token=X` | `[uri-mask-error]` | `https://app/#/reset?token=[REDACTED]` |
| `https://app/#/callback?access_token=X&code=Y` | `[uri-mask-error]` | both redacted |

## Severity, stated plainly

**Nothing leaked.** The failure was safe: the URL was discarded rather than printed, so this is a
diagnostic fault, not a disclosure one. What it cost is the ability to see the URL at all in exactly
the flow where a masked URL is most wanted, plus a warning line per occurrence.

I am flagging that explicitly because the file is a security boundary and a reviewer scanning the
diff might reasonably assume otherwise.

## Why it survived

There are eleven existing tests for `maskUriParams`. Every one of them puts the fragment last or
omits it, which is the shape a `boss://` deep link has. None covers a fragment before a query.

## Testing

Four tests, placed next to the implementation in `plugin-logging` rather than beside the host facade
in `composeApp`, since that is where the code being changed lives and where
`QueryParameterSanitizerTest` already sits.

I checked they cover the defect by reverting the implementation alone: **three of the four fail**.
The fourth pins the three orderings that already worked and passes against both, deliberately, since
the fix edits an index all four orderings share and a regression in the common case would otherwise
be silent.

The assertions are written against the masked output rather than against the absence of a secret, so
a future change that went back to refusing to mask would fail them rather than pass.

```
./gradlew :plugin-platform:plugin-logging:desktopTest :plugin-platform:plugin-logging:ktlintCheck :plugin-platform:plugin-logging:detekt
./gradlew :composeApp:desktopTest --tests "ai.rever.boss.utils.logging.LogSanitizerTest"
```

22 tests in `plugin-logging` and the 80 existing host-facade tests all pass. ktlint and detekt clean.

## Notes for review

- The host's `ai.rever.boss.utils.logging.LogSanitizer` is a thin delegate to this one, so there is
  no second copy to keep in step. I checked that before editing, since this repo has three other
  deliberately duplicated `ai.rever.boss.plugin.*` packages.
- The fix is inside `plugin-logging`, which AGENTS.md notes ships a package the api jar also
  carries. This change adds no public member and no new class, so it cannot affect the `$stable`
  surface that `LoggingStableFieldTest` guards. That test still passes.
- No open PR touches either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
