### PR TITLE
Authenticate and discover BOSS AI without a host-specific broker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,8 +420,10 @@ taking `first().replacementDisplayName` told the user their panel moved somewher
 `supabase/functions/boss-ai` serves multiple configured models through one
 authenticated endpoint. Configuration and accounting tables are service-role-only;
 every inference rechecks live per-model permissions and atomically reserves usage.
-The host's `boss-ai` broker is a fixed trust boundary, not a provider preset.
-Provider discovery is owned by Secret Manager's shared vault definitions.
+Secret Manager owns BOSS AI authentication and discovery. It requests a single-use ticket
+through the existing authenticated RPC API and exchanges it with the edge function.
+The database derives identity from auth.uid(); only the service role can redeem tickets.
+No BOSS AI-specific desktop host registration or shared vault definition is required.
 See `supabase/functions/boss-ai/README.md` for deployment and accounting semantics.
 Do not put upstream credentials in the shared definition or accept caller-selected
 broker URLs. Plugin bundling is intentionally separate.

--- a/supabase/functions/boss-ai/README.md
+++ b/supabase/functions/boss-ai/README.md
@@ -1,31 +1,29 @@
 # Managed BOSS AI
 
-The function owns inference routing, authorization and per-user/model allowances. Secret Manager
-discovers the provider from a shared vault definition. It does not ship a BOSS AI provider entry or
-an upstream API key. The host registers only the trusted `boss-ai` credential broker, whose endpoint
-cannot be changed by a share.
+The function owns inference routing, authorization, provider metadata and per-user/model allowances.
+Secret Manager automatically discovers BOSS AI using the existing generic authenticated Supabase RPC
+API. No host-specific broker registration, shared vault definition, or upstream API key on the
+desktop is needed.
 
 ## Deployment
 
 1. Apply `20260912000000_boss_ai.sql`, `20260912001000_boss_ai_hardening.sql`,
-   `20260912002000_boss_ai_validation.sql`, and `20260912003000_boss_ai_allowance_preflight.sql` in
-   order. Earlier files have already been applied to the preview branch; fixes are forward
-   migrations, not edits to applied history.
+   `20260912002000_boss_ai_validation.sql`, `20260912003000_boss_ai_allowance_preflight.sql`, and
+   `20260912004000_boss_ai_exchange_tickets.sql` in order. Earlier files have already been applied
+   to the preview branch; fixes are forward migrations, not edits to applied history.
 2. Set `BOSS_AI_SIGNING_SECRET` to at least 32 random bytes (encoded as a string). Set upstream API
    keys as secrets named `BOSS_AI_<NAME>`. The signing-secret name is explicitly prohibited as an
    upstream key in both SQL and the handler. Never put these keys in a shared vault entry. Supabase
    supplies its URL and service-role key.
 3. Deploy `boss-ai` using this repository's `supabase/config.toml`. `verify_jwt=false` is required
-   because the handler verifies two distinct credentials: BOSS sessions on `/auth/token`, AI-scoped
-   tokens elsewhere.
+   because `/auth/exchange` redeems a single-use ticket, `/auth/token` supports legacy BOSS
+   sessions, and catalog/inference routes verify AI-scoped tokens.
 4. Configure one or more connections, models, and permission allowances using the SQL editor or
    service-role administration. No client role can read/write these tables or impersonate a user
    through the accounting RPCs.
-5. Create the shared definition below in Secret Manager and share it read-only with the baseline
-   `user` role. Only an administrator with role-sharing permission can do this. The owner retains
-   editing control.
-6. Install a host build with the broker registration and the updated Secret Manager plugin. Existing
-   AI Gateway Chat Completions transport is sufficient.
+5. Install the updated Secret Manager plugin (1.2.25 or later). Existing AI Gateway Chat Completions
+   transport and the existing desktop generic Supabase RPC API are sufficient. BOSS AI is created in
+   memory automatically; new users do not create or receive a secret.
 
 The integration audit checked AI Gateway's `OpenAiChatFormat.buildPayload` in `WireFormat.kt`:
 `model`, `max_tokens`, optional temperature, streaming with usage, tools, and complete message/tool
@@ -40,11 +38,32 @@ usage or adding vendor fields.
 No migration publishes a made-up model, invents an API key, or picks an allowance. Those are
 required deployment inputs. Plugin bundling is outside this change.
 
-## Shared vault definition
+## Plugin-owned authentication and discovery
 
-Create a normal secret with website/name `BOSS AI`, username `BOSS sign-in`, password
-`Managed by BOSS` (an inert placeholder, never used as a credential), tag `ai-provider-definition`,
-and these notes:
+1. Secret Manager calls `boss_ai_create_exchange_ticket()` through the existing authenticated RPC
+   API. The database derives the user from `auth.uid()` and checks `ai.use`, bans and anonymous
+   status. No caller-supplied user id is accepted.
+2. The plugin POSTs the returned ticket to `/auth/exchange`. The edge function redeems it through
+   the service-only `boss_ai_consume_exchange_ticket` RPC, then mints a five-minute AI token.
+3. The plugin GETs `/v1/provider` with that AI token. The versioned metadata supplies the provider
+   name, API base and new-user default recommendation. The plugin confines all endpoints to its
+   trusted BOSS AI scope and refuses redirects.
+4. `/v1/models` supplies permission-filtered models, capabilities, limits, defaults and allowances.
+   Inference independently enforces live authorization and usage policy.
+
+Tickets expire after 60 seconds, are stored only as SHA-256 hashes, and are consumed atomically.
+Each user may hold at most eight pending tickets; issuance removes their expired tickets. The edge
+function alone can redeem them. Ban and permission checks run again at redemption. No BOSS login
+token reaches the plugin, and no extra signing secret is required by the database. Credentials and
+account-specific catalogs stay in memory. Explicit provider/model preferences remain local and are
+never overwritten by a provider default. The stable provider id is `managed:boss-ai`; optional
+legacy shared definitions for this same provider are deduplicated.
+
+`/auth/token` remains for compatibility with already shipped host brokers. The plugin does not use
+it or require a host broker registration. The function source lives in this repository for backend
+deployment; it is not desktop runtime code.
+
+The `/v1/provider` response is:
 
 ```json
 {
@@ -55,17 +74,6 @@ and these notes:
   "defaultForNewUsers": true
 }
 ```
-
-The provider identity is derived from the secret's UUID, so renaming the shared entry does not lose
-selections. Users' model choices are local preferences and never modify the shared definition. A
-shared note can reference only a broker known to the host and endpoints within that broker's
-declared scope. A forged share cannot send a login token or a broker credential to an arbitrary URL.
-
-Share with `user` to distribute to everyone, or use existing user/role/organisation sharing for
-narrower distribution. Availability of a definition and permission to spend on a model are separate:
-inference always rechecks the model's live policy. The `ai.use` permission is granted to the
-baseline user role by the migration. Additional allowance permissions use the existing RBAC
-administration.
 
 ## Server configuration example
 

--- a/supabase/functions/boss-ai/app.ts
+++ b/supabase/functions/boss-ai/app.ts
@@ -51,14 +51,38 @@ export function createHandler(deps: Dependencies): (request: Request) => Promise
         /^\/boss-ai(?=\/|$)/,
         "",
       )
-      const token = bearer(request)
       const key = signingKey(deps.secret("BOSS_AI_SIGNING_SECRET"))
+      if (request.method === "POST" && path === "/auth/exchange") {
+        const input = await readJson(request.body, 1024)
+        if (typeof input.ticket !== "string" || !/^[a-f0-9]{64}$/.test(input.ticket)) {
+          throw new HttpError(401, "unauthorized", "Request a new BOSS AI sign-in ticket.")
+        }
+        const user = await deps.rpc("boss_ai_consume_exchange_ticket", { p_ticket: input.ticket })
+        if (typeof user !== "string" || !user) {
+          throw new HttpError(401, "unauthorized", "Request a new BOSS AI sign-in ticket.")
+        }
+        return json(await mintToken(user, key), 200, requestId)
+      }
+      const token = bearer(request)
       if (request.method === "POST" && path === "/auth/token") {
         const user = await deps.sessionUser(token)
         if (!user) throw new HttpError(401, "unauthorized", "Sign in to BOSS to use AI.")
         return json(await mintToken(user, key), 200, requestId)
       }
       const user = await verifyToken(token, key)
+      if (request.method === "GET" && path === "/v1/provider") {
+        return json(
+          {
+            schema: "boss-managed-provider-v1",
+            name: "BOSS AI",
+            brokerId: "boss-ai",
+            baseUrl: "https://api.risaboss.com/functions/v1/boss-ai/v1",
+            defaultForNewUsers: true,
+          },
+          200,
+          requestId,
+        )
+      }
       if (request.method === "GET" && (path === "/v1/models" || path === "/v1/usage")) {
         phase = "catalog"
         const data = await deps.rpc("boss_ai_catalog", { p_user_id: user })

--- a/supabase/functions/boss-ai/tests/app.test.ts
+++ b/supabase/functions/boss-ai/tests/app.test.ts
@@ -114,7 +114,7 @@ const body = { model: "boss-test", messages: [{ role: "user", content: "private 
 
 Deno.test("all inference and catalog access requires AI-scoped authentication", async () => {
   const f = await fixture()
-  for (const path of ["v1/models", "v1/usage", "v1/chat/completions"]) {
+  for (const path of ["v1/provider", "v1/models", "v1/usage", "v1/chat/completions"]) {
     assertEquals((await f.handler(new Request(`https://api.example/boss-ai/${path}`))).status, 401)
   }
   for (const token of ["boss-session", f.token.slice(0, -5) + "wrong"]) {
@@ -392,4 +392,67 @@ Deno.test("stream cancellation retains usage and does not attempt to write to a 
   await reader.cancel()
   assertEquals(f.calls.filter((call) => call.name === "boss_ai_settle").length, 1)
   assertEquals(f.calls.at(-1)?.params.p_tokens, null)
+})
+
+Deno.test("provider publishes discovery metadata without vault or upstream access", async () => {
+  const f = await fixture()
+  const response = await f.handler(
+    new Request("https://api.example/boss-ai/v1/provider", {
+      headers: { Authorization: `Bearer ${f.token}` },
+    }),
+  )
+  assertEquals(response.status, 200)
+  assertEquals(response.headers.get("cache-control"), "no-store")
+  assertEquals(await response.json(), {
+    schema: "boss-managed-provider-v1",
+    name: "BOSS AI",
+    brokerId: "boss-ai",
+    baseUrl: "https://api.risaboss.com/functions/v1/boss-ai/v1",
+    defaultForNewUsers: true,
+  })
+  assertEquals(f.calls.length, 0)
+  assertEquals(f.requests.length, 0)
+})
+
+Deno.test("RPC tickets exchange for AI tokens without a BOSS session", async () => {
+  const ticket = "a".repeat(64)
+  let consumed = false
+  let calls = 0
+  const handler = createHandler({
+    sessionUser: () => {
+      throw new Error("Must not access BOSS session")
+    },
+    secret: () => secret,
+    fetch: () => {
+      throw new Error("Must not call upstream")
+    },
+    rpc: async (name, params) => {
+      calls++
+      assertEquals(name, "boss_ai_consume_exchange_ticket")
+      assertEquals(params, { p_ticket: ticket })
+      if (consumed) return null
+      consumed = true
+      return "00000000-0000-0000-0000-000000000001"
+    },
+  })
+  const exchange = (value: string) =>
+    handler(
+      new Request("https://api.example/boss-ai/auth/exchange", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ticket: value }),
+      }),
+    )
+  assertEquals((await exchange("invalid")).status, 401)
+  assertEquals(calls, 0)
+  const response = await exchange(ticket)
+  assertEquals(response.status, 200)
+  const token = (await response.json()).access_token
+  const metadata = await handler(
+    new Request("https://api.example/boss-ai/v1/provider", {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+  )
+  assertEquals(metadata.status, 200)
+  assertEquals((await exchange(ticket)).status, 401)
 })

--- a/supabase/functions/boss-ai/tests/tickets.test.ts
+++ b/supabase/functions/boss-ai/tests/tickets.test.ts
@@ -1,0 +1,74 @@
+import { PGlite } from "npm:@electric-sql/pglite@0.3.14"
+import { assertEquals, assertRejects } from "@std/assert"
+
+Deno.test("exchange tickets bind identity, expire, are single-use and service-only", async () => {
+  const db = new PGlite()
+  const user = "00000000-0000-0000-0000-000000000001"
+  const other = "00000000-0000-0000-0000-000000000002"
+  try {
+    await db.exec(`
+      CREATE ROLE anon; CREATE ROLE authenticated; CREATE ROLE service_role;
+      CREATE SCHEMA auth;
+      CREATE TABLE auth.users(id uuid PRIMARY KEY, banned_until timestamptz, is_anonymous boolean DEFAULT false);
+      CREATE TABLE public.test_permissions(user_id uuid);
+      CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql AS
+        'SELECT nullif(current_setting(''request.jwt.claim.sub'',true),'''')::uuid';
+      CREATE FUNCTION public.user_has_permission(p_user_id uuid,p_permission text) RETURNS boolean LANGUAGE sql AS
+        'SELECT EXISTS(SELECT 1 FROM public.test_permissions WHERE user_id=p_user_id)';
+      INSERT INTO auth.users(id) VALUES('${user}'),('${other}');
+      INSERT INTO public.test_permissions VALUES('${user}'),('${other}');
+    `)
+    await db.exec(
+      await Deno.readTextFile(
+        new URL("../../../migrations/20260912004000_boss_ai_exchange_tickets.sql", import.meta.url),
+      ),
+    )
+    const scalar = async (sql: string, params: unknown[] = []) =>
+      (await db.query<{ value: any }>(sql, params)).rows[0].value
+    const issue = () => scalar("SELECT public.boss_ai_create_exchange_ticket()->>'ticket' AS value")
+    const consume = (ticket: string) =>
+      scalar("SELECT public.boss_ai_consume_exchange_ticket($1) AS value", [ticket])
+    await db.exec("SET ROLE authenticated")
+    await assertRejects(issue)
+    await db.query("SELECT set_config('request.jwt.claim.sub',$1,false)", [user])
+    const ticket = await issue()
+    assertEquals(ticket.length, 64)
+    await assertRejects(() => db.query("SELECT * FROM public.boss_ai_exchange_tickets"))
+    await assertRejects(() => consume(ticket))
+    await db.exec("RESET ROLE")
+    assertEquals(
+      await scalar("SELECT count(*)::int AS value FROM public.boss_ai_exchange_tickets"),
+      1,
+    )
+    await db.exec("SET ROLE service_role")
+    assertEquals(await consume(ticket), user)
+    assertEquals(await consume(ticket), null)
+    assertEquals(await consume("0".repeat(64)), null)
+    await db.exec("RESET ROLE")
+
+    const expired = await issue()
+    await db.exec("UPDATE public.boss_ai_exchange_tickets SET expires_at=now()-interval '1 second'")
+    assertEquals(await consume(expired), null)
+    const revoked = await issue()
+    await db.exec(`DELETE FROM public.test_permissions WHERE user_id='${user}'`)
+    assertEquals(await consume(revoked), null)
+    await assertRejects(issue)
+    await db.exec(`INSERT INTO public.test_permissions VALUES('${user}')`)
+    const banned = await issue()
+    await db.exec(`UPDATE auth.users SET banned_until=now()+interval '1 hour' WHERE id='${user}'`)
+    assertEquals(await consume(banned), null)
+    await assertRejects(issue)
+    await db.exec(`UPDATE auth.users SET banned_until=NULL, is_anonymous=true WHERE id='${user}'`)
+    await assertRejects(issue)
+    await db.exec(`UPDATE auth.users SET is_anonymous=false WHERE id='${user}'`)
+    for (let i = 0; i < 8; i++) await issue()
+    await assertRejects(issue)
+    await db.query("SELECT set_config('request.jwt.claim.sub',$1,false)", [other])
+    assertEquals(await consume(await issue()), other)
+    await db.exec("SET ROLE anon")
+    await assertRejects(issue)
+    await assertRejects(() => consume(ticket))
+  } finally {
+    await db.close()
+  }
+})

--- a/supabase/migrations/20260912004000_boss_ai_exchange_tickets.sql
+++ b/supabase/migrations/20260912004000_boss_ai_exchange_tickets.sql
@@ -1,0 +1,60 @@
+-- Plugin-owned BOSS AI authentication through the existing generic authenticated RPC API.
+-- Tickets are single-use and AI-only; plugins never receive the BOSS login session.
+BEGIN;
+CREATE TABLE public.boss_ai_exchange_tickets (
+  ticket_hash bytea PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  expires_at timestamptz NOT NULL DEFAULT now() + interval '60 seconds'
+);
+CREATE INDEX boss_ai_exchange_ticket_user ON public.boss_ai_exchange_tickets(user_id);
+ALTER TABLE public.boss_ai_exchange_tickets ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.boss_ai_exchange_tickets FROM PUBLIC, anon, authenticated;
+GRANT ALL ON public.boss_ai_exchange_tickets TO service_role;
+
+CREATE FUNCTION public.boss_ai_create_exchange_ticket()
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  caller uuid := auth.uid();
+  ticket text;
+BEGIN
+  IF caller IS NULL OR NOT EXISTS (
+    SELECT 1 FROM auth.users u WHERE u.id = caller AND NOT COALESCE(u.is_anonymous, false)
+      AND (u.banned_until IS NULL OR u.banned_until < now())
+  ) OR public.user_has_permission(caller, 'ai.use') IS NOT TRUE THEN
+    RAISE EXCEPTION 'BOSS AI access is required' USING ERRCODE = '42501';
+  END IF;
+  -- Bound pending tickets without invalidating another window's in-flight exchange.
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('boss-ai-ticket:' || caller::text, 0));
+  DELETE FROM public.boss_ai_exchange_tickets WHERE user_id = caller AND expires_at <= now();
+  IF (SELECT count(*) FROM public.boss_ai_exchange_tickets WHERE user_id = caller) >= 8 THEN
+    RAISE EXCEPTION 'Too many pending BOSS AI exchanges; retry shortly' USING ERRCODE = '54000';
+  END IF;
+  ticket := replace(gen_random_uuid()::text || gen_random_uuid()::text, '-', '');
+  INSERT INTO public.boss_ai_exchange_tickets(ticket_hash, user_id)
+    VALUES (sha256(convert_to(ticket, 'UTF8')), caller);
+  RETURN jsonb_build_object('ticket', ticket);
+END;
+$$;
+
+CREATE FUNCTION public.boss_ai_consume_exchange_ticket(p_ticket text)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  caller uuid;
+BEGIN
+  IF p_ticket IS NULL OR p_ticket !~ '^[a-f0-9]{64}$' THEN RETURN NULL; END IF;
+  -- DELETE RETURNING makes simultaneous redemption single-use as well.
+  DELETE FROM public.boss_ai_exchange_tickets
+    WHERE ticket_hash = sha256(convert_to(p_ticket, 'UTF8')) AND expires_at > now()
+    RETURNING user_id INTO caller;
+  IF caller IS NULL OR NOT EXISTS (
+    SELECT 1 FROM auth.users u WHERE u.id = caller AND NOT COALESCE(u.is_anonymous, false)
+      AND (u.banned_until IS NULL OR u.banned_until < now())
+  ) OR public.user_has_permission(caller, 'ai.use') IS NOT TRUE THEN RETURN NULL; END IF;
+  RETURN caller;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.boss_ai_create_exchange_ticket() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.boss_ai_create_exchange_ticket() TO authenticated;
+REVOKE ALL ON FUNCTION public.boss_ai_consume_exchange_ticket(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.boss_ai_consume_exchange_ticket(text) TO service_role;
+COMMIT;


### PR DESCRIPTION
BOSS AI currently requires a desktop release containing its host broker and an admin-published vault definition. This adds plugin-owned authentication and provider discovery so the existing desktop RPC API is sufficient.

Secret Manager requests an AI-only ticket through `boss_ai_create_exchange_ticket()`, exchanges it at `/auth/exchange`, and reads `/v1/provider` followed by the existing model catalog. The database derives identity from `auth.uid()`. Tickets expire after 60 seconds, are stored as hashes, are single-use, and can only be redeemed by the edge function's service role. Issuance and redemption check live access. The existing `/auth/token` route remains compatible.

Companion plugin: https://github.com/risa-labs-inc/boss-plugin-secret-manager/pull/28. No host or AI Gateway update is required. Apply `20260912004000_boss_ai_exchange_tickets.sql` and redeploy `boss-ai`; existing signing and upstream secrets are reused. The user will deploy; no live changes were made.

Validation: Deno format/type checks passed; all 45 backend tests passed, including the real ticket migration in PGlite with identity, grants, expiry, replay, ban, revocation and pending-ticket-limit checks. Live deployment verification remains outstanding.
