### PR TITLE
fix(storage): make plugin persistence transactional

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/PluginStorageFactoryProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/PluginStorageFactoryProvider.kt
@@ -3,15 +3,22 @@ package ai.rever.boss.components.plugin.providers
 import ai.rever.boss.plugin.api.PluginStorageFactory
 import ai.rever.boss.plugin.api.PluginStorageProvider
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.nio.file.Files
 import java.util.Properties
 import java.util.concurrent.ConcurrentHashMap
 
@@ -49,28 +56,28 @@ class PluginStorageFactoryImpl private constructor() : PluginStorageFactory {
 /**
  * Desktop implementation of PluginStorageProvider.
  * Stores data in ~/.boss/plugin-data/{pluginId}/storage.properties
+ *
+ * The factory shares one provider per plugin across windows. Mutations serialize the entire
+ * read-modify-persist-publish transaction; readers see only committed, immutable snapshots.
+ * Persistence errors propagate to the caller without publishing a value or change event.
  */
-class PluginStorageProviderImpl(
+class PluginStorageProviderImpl internal constructor(
     private val pluginId: String,
+    private val storageFile: File,
+    private val writeProperties: (File, Properties) -> Unit = ::writePluginProperties,
 ) : PluginStorageProvider {
     companion object {
         private val logger = BossLogger.forComponent("PluginStorage")
     }
 
-    private val storageDir: File by lazy {
-        val dir = BossDirectories.resolve("plugin-data/$pluginId")
-        if (!dir.exists()) {
-            dir.mkdirs()
-        }
-        dir
-    }
+    constructor(pluginId: String) : this(
+        pluginId,
+        File(BossDirectories.resolve("plugin-data/$pluginId"), "storage.properties"),
+    )
 
-    private val storageFile: File by lazy {
-        File(storageDir, "storage.properties")
-    }
-
-    // In-memory cache
-    private val cache = ConcurrentHashMap<String, String>()
+    @Volatile
+    private var cache: Map<String, String> = emptyMap()
+    private val mutationMutex = Mutex()
 
     // Change notification
     private val _changes = MutableSharedFlow<String>(extraBufferCapacity = 64)
@@ -88,9 +95,7 @@ class PluginStorageProviderImpl(
         key: String,
         value: String,
     ) {
-        cache[key] = value
-        saveToDisk()
-        _changes.tryEmit(key)
+        mutate(key) { it + (key to value) }
     }
 
     override suspend fun getString(
@@ -170,17 +175,13 @@ class PluginStorageProviderImpl(
     override suspend fun contains(key: String): Boolean = cache.containsKey(key)
 
     override suspend fun remove(key: String) {
-        cache.remove(key)
-        saveToDisk()
-        _changes.tryEmit(key)
+        mutate(key) { it - key }
     }
 
     override suspend fun getAllKeys(): Set<String> = cache.keys.toSet()
 
     override suspend fun clear() {
-        cache.clear()
-        saveToDisk()
-        _changes.tryEmit("*")
+        mutate("*") { emptyMap() }
     }
 
     override fun observeString(key: String): Flow<String?> =
@@ -203,9 +204,7 @@ class PluginStorageProviderImpl(
             if (storageFile.exists()) {
                 val properties = Properties()
                 storageFile.inputStream().use { properties.load(it) }
-                properties.forEach { key, value ->
-                    cache[key.toString()] = value.toString()
-                }
+                cache = properties.entries.associate { (key, value) -> key.toString() to value.toString() }
                 logger.debug(
                     LogCategory.SYSTEM,
                     "Loaded plugin storage",
@@ -227,26 +226,40 @@ class PluginStorageProviderImpl(
         }
     }
 
-    private suspend fun saveToDisk() {
+    private suspend fun mutate(
+        changedKey: String,
+        transform: (Map<String, String>) -> Map<String, String>,
+    ) {
         withContext(Dispatchers.IO) {
-            try {
-                val properties = Properties()
-                cache.forEach { (key, value) ->
-                    properties[key] = value
+            mutationMutex.withLock {
+                currentCoroutineContext().ensureActive()
+                // Waiting callers remain cancellable. Once admitted, a blocking file commit and
+                // cache publication must finish together even if the caller cancels during I/O.
+                withContext(NonCancellable) {
+                    val updated = transform(cache)
+                    val properties = Properties().apply { putAll(updated) }
+                    writeProperties(storageFile, properties)
+                    cache = updated
+                    _changes.tryEmit(changedKey)
                 }
-                storageFile.outputStream().use {
-                    properties.store(it, "Plugin storage for $pluginId")
-                }
-            } catch (e: Exception) {
-                logger.error(
-                    LogCategory.SYSTEM,
-                    "Failed to save plugin storage",
-                    mapOf(
-                        "pluginId" to pluginId,
-                    ),
-                    e,
-                )
             }
         }
+    }
+}
+
+internal fun writePluginProperties(
+    file: File,
+    properties: Properties,
+) {
+    val target = file.absoluteFile
+    target.parentFile.mkdirs()
+    val temporary = Files.createTempFile(target.parentFile.toPath(), "${target.name}.", ".tmp").toFile()
+    try {
+        // Keep OutputStream encoding: Properties.load(InputStream) expects Latin-1 with escaped
+        // Unicode, not the unescaped Unicode emitted by Properties.store(Writer).
+        temporary.outputStream().use { properties.store(it, "Plugin storage") }
+        target.atomicMoveFrom(temporary)
+    } finally {
+        temporary.delete()
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/PluginStorageCancellationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/PluginStorageCancellationTest.kt
@@ -1,0 +1,76 @@
+package ai.rever.boss.components.plugin.providers
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PluginStorageCancellationTest {
+    private val directory = createTempDirectory("plugin-storage-cancellation").toFile()
+    private val file = File(directory, "storage.properties")
+    private val entered = CountDownLatch(1)
+    private val release = CountDownLatch(1)
+
+    private fun blockedStorage() =
+        PluginStorageProviderImpl("test", file) { target, properties ->
+            writePluginProperties(target, properties)
+            entered.countDown()
+            check(release.await(10, TimeUnit.SECONDS))
+        }
+
+    @AfterTest
+    fun cleanUp() {
+        directory.deleteRecursively()
+    }
+
+    @Test
+    fun `cancellation during an admitted write still publishes the committed value`() =
+        runBlocking {
+            val storage = blockedStorage()
+            val write = launch(Dispatchers.Default) { storage.putString("key", "committed") }
+            try {
+                assertTrue(entered.await(10, TimeUnit.SECONDS))
+                assertEquals("committed", PluginStorageProviderImpl("test", file).getString("key"))
+                assertFalse(storage.contains("key"))
+                write.cancel()
+            } finally {
+                release.countDown()
+                write.join()
+            }
+
+            assertTrue(write.isCancelled)
+            assertEquals("committed", storage.getString("key"))
+            assertEquals("committed", PluginStorageProviderImpl("test", file).getString("key"))
+        }
+
+    @Test
+    fun `cancellation before admission cannot modify cache or disk`() =
+        runBlocking {
+            val storage = blockedStorage()
+            val first = launch(Dispatchers.Default) { storage.putString("first", "committed") }
+            try {
+                assertTrue(entered.await(10, TimeUnit.SECONDS))
+                val waiting =
+                    launch(Dispatchers.IO, start = CoroutineStart.UNDISPATCHED) {
+                        storage.putString("cancelled", "must not persist")
+                    }
+                waiting.cancelAndJoin()
+            } finally {
+                release.countDown()
+                first.join()
+            }
+
+            assertFalse(storage.contains("cancelled"))
+            assertEquals(setOf("first"), PluginStorageProviderImpl("test", file).getAllKeys())
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/PluginStorageConcurrencyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/PluginStorageConcurrencyTest.kt
@@ -1,0 +1,87 @@
+package ai.rever.boss.components.plugin.providers
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PluginStorageConcurrencyTest {
+    private val directory = createTempDirectory("plugin-storage-concurrency").toFile()
+    private val file = File(directory, "storage.properties")
+
+    @AfterTest
+    fun cleanUp() {
+        directory.deleteRecursively()
+    }
+
+    @Test
+    fun `an older save cannot overwrite a successful later put`() =
+        checkOverlappingMutation(mapOf("seed" to "value", "first" to "value", "second" to "value")) {
+            it.putString("second", "value")
+        }
+
+    @Test
+    fun `an older save cannot resurrect a removed key`() =
+        checkOverlappingMutation(mapOf("first" to "value")) {
+            it.remove("seed")
+        }
+
+    @Test
+    fun `an older save cannot resurrect cleared storage`() =
+        checkOverlappingMutation(emptyMap()) {
+            it.clear()
+        }
+
+    private fun checkOverlappingMutation(
+        expected: Map<String, String>,
+        mutate: suspend (PluginStorageProviderImpl) -> Unit,
+    ) = runBlocking {
+        PluginStorageProviderImpl("test", file).putString("seed", "value")
+        val firstEntered = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val writes = AtomicInteger()
+        val storage =
+            PluginStorageProviderImpl("test", file) { target, properties ->
+                if (writes.incrementAndGet() == 1) {
+                    firstEntered.countDown()
+                    check(releaseFirst.await(10, TimeUnit.SECONDS))
+                }
+                writePluginProperties(target, properties)
+            }
+        val first = async(Dispatchers.Default) { storage.putString("first", "value") }
+        try {
+            assertTrue(firstEntered.await(10, TimeUnit.SECONDS))
+            // Matching the provider's IO context and starting undispatched enters the mutation
+            // immediately, up to its first suspension: the mutex on the fixed implementation.
+            val second = async(Dispatchers.IO, start = CoroutineStart.UNDISPATCHED) { mutate(storage) }
+            try {
+                assertFalse(second.isCompleted, "the later mutation must wait for the first commit")
+                assertEquals(1, writes.get(), "the second writer must not enter concurrently")
+            } finally {
+                releaseFirst.countDown()
+                second.await()
+            }
+        } finally {
+            releaseFirst.countDown()
+            first.await()
+        }
+
+        val reloaded = PluginStorageProviderImpl("test", file)
+        assertEquals(expected.keys, reloaded.getAllKeys())
+        expected.forEach { (key, value) ->
+            assertEquals(value, reloaded.getString(key))
+            assertEquals(value, storage.getString(key))
+        }
+        assertEquals(expected.keys, storage.getAllKeys())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/PluginStoragePersistenceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/PluginStoragePersistenceTest.kt
@@ -1,0 +1,176 @@
+package ai.rever.boss.components.plugin.providers
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import java.io.File
+import java.io.IOException
+import java.io.OutputStream
+import java.util.Properties
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class PluginStoragePersistenceTest {
+    private val directory = createTempDirectory("plugin-storage-test").toFile()
+    private val file = File(directory, "storage.properties")
+
+    @AfterTest
+    fun cleanUp() {
+        directory.deleteRecursively()
+    }
+
+    @Test
+    fun `failed writes leave the committed value unchanged and report failure`() =
+        runBlocking {
+            PluginStorageProviderImpl("test", file).putString("key", "committed")
+            val before = file.readBytes()
+            val storage = PluginStorageProviderImpl("test", file) { _, _ -> throw IOException("disk unavailable") }
+
+            assertFailsWith<IOException> { storage.putString("key", "uncommitted") }
+
+            assertEquals("committed", storage.getString("key"))
+            assertTrue(before.contentEquals(file.readBytes()))
+        }
+
+    @Test
+    fun `readers do not see a mutation before its disk commit`() =
+        runBlocking {
+            PluginStorageProviderImpl("test", file).putString("key", "committed")
+            val entered = CountDownLatch(1)
+            val release = CountDownLatch(1)
+            val storage =
+                PluginStorageProviderImpl("test", file) { target, properties ->
+                    entered.countDown()
+                    check(release.await(10, TimeUnit.SECONDS))
+                    writePluginProperties(target, properties)
+                }
+            val write = async(Dispatchers.Default) { storage.putString("key", "next") }
+            try {
+                assertTrue(entered.await(10, TimeUnit.SECONDS))
+                assertEquals("committed", storage.getString("key"))
+                assertEquals("committed", PluginStorageProviderImpl("test", file).getString("key"))
+            } finally {
+                release.countDown()
+                write.await()
+            }
+            assertEquals("next", storage.getString("key"))
+            assertEquals("next", PluginStorageProviderImpl("test", file).getString("key"))
+        }
+
+    @Test
+    fun `serialization failure preserves the existing file and removes temporary files`() {
+        val original = "existing=value\n".toByteArray()
+        file.writeBytes(original)
+        val invalid = Properties().apply { put("not-a-string", 42) }
+
+        assertFailsWith<ClassCastException> { writePluginProperties(file, invalid) }
+
+        assertTrue(original.contentEquals(file.readBytes()))
+        assertEquals(listOf(file.name), directory.listFiles()!!.map { it.name })
+    }
+
+    @Test
+    fun `overlapping file writes use distinct temporary files and clean up both outcomes`() =
+        runBlocking {
+            val entered = CountDownLatch(2)
+            val release = CountDownLatch(1)
+
+            fun properties(fail: Boolean) =
+                object : Properties() {
+                    override fun store(
+                        out: OutputStream,
+                        comments: String?,
+                    ) {
+                        entered.countDown()
+                        check(release.await(10, TimeUnit.SECONDS))
+                        super.store(out, comments)
+                        if (fail) throw IOException("interrupted serialization")
+                    }
+                }.apply { setProperty("key", "committed") }
+
+            val failing =
+                async(Dispatchers.IO) {
+                    assertFailsWith<IOException> { writePluginProperties(file, properties(true)) }
+                }
+            val successful = async(Dispatchers.IO) { writePluginProperties(file, properties(false)) }
+            try {
+                assertTrue(entered.await(10, TimeUnit.SECONDS))
+                val temporaryFiles = directory.listFiles()!!.toList()
+                assertEquals(2, temporaryFiles.size)
+                assertEquals(2, temporaryFiles.map { it.name }.toSet().size)
+                assertTrue(temporaryFiles.all { it.name.endsWith(".tmp") })
+            } finally {
+                release.countDown()
+                failing.await()
+                successful.await()
+            }
+            assertEquals(listOf(file.name), directory.listFiles()!!.map { it.name })
+            assertEquals("committed", PluginStorageProviderImpl("test", file).getString("key"))
+        }
+
+    @Test
+    fun `typed and escaped values survive reload in the existing properties format`() =
+        runBlocking {
+            val storage = PluginStorageProviderImpl("test", file)
+            val text = "line one\nUnicode: \u00e9\u6f22\ud83d\ude00\\=:\t"
+            storage.putString("key with = and :", text)
+            storage.putInt("int", 42)
+            storage.putLong("long", Long.MAX_VALUE)
+            storage.putBoolean("boolean", true)
+            storage.putFloat("float", 1.25f)
+            storage.putJson("json", "{\"value\":\"\u6f22\"}")
+
+            val reloaded = PluginStorageProviderImpl("test", file)
+            assertEquals(text, reloaded.getString("key with = and :"))
+            assertEquals(42, reloaded.getInt("int"))
+            assertEquals(Long.MAX_VALUE, reloaded.getLong("long"))
+            assertTrue(reloaded.getBoolean("boolean"))
+            assertEquals(1.25f, reloaded.getFloat("float"))
+            assertEquals("{\"value\":\"\u6f22\"}", reloaded.getJson("json"))
+        }
+
+    @Test
+    fun `failed mutations publish no changes and can be retried`() =
+        runBlocking {
+            PluginStorageProviderImpl("test", file).putString("key", "committed")
+            val fail = AtomicBoolean(true)
+            val storage =
+                PluginStorageProviderImpl("test", file) { target, properties ->
+                    if (fail.get()) throw IOException("disk unavailable")
+                    writePluginProperties(target, properties)
+                }
+            val changes = mutableListOf<String>()
+            val observer =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    storage.observeChanges().collect { changes.add(it) }
+                }
+            try {
+                assertFailsWith<IOException> { storage.putString("key", "next") }
+                assertFailsWith<IOException> { storage.remove("key") }
+                assertFailsWith<IOException> { storage.clear() }
+                yield()
+                assertTrue(changes.isEmpty())
+                assertEquals("committed", storage.getString("key"))
+                assertEquals("committed", PluginStorageProviderImpl("test", file).getString("key"))
+
+                fail.set(false)
+                storage.putString("key", "next")
+                yield()
+                assertEquals(listOf("key"), changes)
+                assertEquals("next", PluginStorageProviderImpl("test", file).getString("key"))
+            } finally {
+                observer.cancelAndJoin()
+            }
+        }
+}


### PR DESCRIPTION
Fixes #506.

## Summary

* Serialize the complete plugin-storage read, persist, and publish transaction with a provider-scoped mutex.
* Persist an immutable `Properties` snapshot through a unique sibling temporary file and the repository’s shared atomic-move utility.
* Publish the new immutable cache snapshot and change notification only after persistence succeeds.
* Propagate write failures while preserving the previously committed cache and file.
* Keep callers cancellable while waiting for admission; once admitted, complete the file commit and cache publication consistently.

## Regression coverage

Adds 11 focused tests covering:

* deterministic overlapping puts;
* remove and clear ordering;
* prevention of older writes resurrecting removed or cleared state;
* cancellation before admission and during an admitted commit;
* failed-write propagation and retry;
* preservation of committed cache and file contents;
* reader visibility while a commit is pending;
* serialization failure cleanup;
* distinct temporary files during overlapping physical writes;
* change-event behavior after failed mutations;
* typed, JSON, escaped, and Unicode value reload compatibility.

## Parallel implementation

PR #529 is a parallel implementation of the same issue.

I opened and claimed #506 before #529 appeared, and this implementation was developed independently. This PR is offered as an independently validated alternative and consolidation source.

Its distinct approach centralizes every mutation through one transaction function, publishes immutable committed cache snapshots to readers, reuses the repository’s existing atomic-move abstraction, and uses an injected writer seam for deterministic ordering and failure tests.

## Validation

* `git diff --check`
* 11 focused plugin-storage regression tests
* `:composeApp:ktlintCheck`
* `detekt`
* Full `:composeApp:desktopTest`

All passed on Temurin JDK 17 against the refreshed `dev` base.