### PR TITLE
fix(chrome): focusWindow leaves a minimized target window iconified

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -546,6 +546,10 @@ actual object WindowFocusManager {
                     window.isVisible = true
                 }
 
+                if (window is java.awt.Frame && window.state == java.awt.Frame.ICONIFIED) {
+                    window.state = java.awt.Frame.NORMAL
+                }
+
                 // Bring to front
                 window.toFront()
 
@@ -567,6 +571,10 @@ actual object WindowFocusManager {
                 // Make window visible if minimized
                 if (!window.isVisible) {
                     window.isVisible = true
+                }
+
+                if (window is java.awt.Frame && window.state == java.awt.Frame.ICONIFIED) {
+                    window.state = java.awt.Frame.NORMAL
                 }
 
                 // Bring to front

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
@@ -221,4 +221,51 @@ class WindowFocusManagerTest {
         tracker.onUnregistered("window-b")
         assertFalse(tracker.isFocused("window-b"))
     }
+
+    @Test
+    fun `focusWindow restores an ICONIFIED frame to NORMAL`() {
+        if (java.awt.GraphicsEnvironment.isHeadless()) return
+        val frame = java.awt.Frame("Test")
+        javax.swing.SwingUtilities.invokeAndWait { WindowFocusManager.registerWindow("test-id-iconified", frame) }
+        try {
+            frame.state = java.awt.Frame.ICONIFIED
+            val result = WindowFocusManager.focusWindow("test-id-iconified")
+            assertTrue(result)
+
+            // Wait for EDT to process the SwingUtilities.invokeLater block
+            javax.swing.SwingUtilities.invokeAndWait {}
+
+            assertEquals(java.awt.Frame.NORMAL, frame.state)
+            assertTrue(frame.isVisible)
+        } finally {
+            javax.swing.SwingUtilities.invokeAndWait { WindowFocusManager.unregisterWindow("test-id-iconified") }
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun `focusWindow keeps a NORMAL frame in NORMAL state`() {
+        if (java.awt.GraphicsEnvironment.isHeadless()) return
+        val frame = java.awt.Frame("Test")
+        javax.swing.SwingUtilities.invokeAndWait { WindowFocusManager.registerWindow("test-id-normal", frame) }
+        try {
+            frame.state = java.awt.Frame.NORMAL
+            val result = WindowFocusManager.focusWindow("test-id-normal")
+            assertTrue(result)
+
+            javax.swing.SwingUtilities.invokeAndWait {}
+
+            assertEquals(java.awt.Frame.NORMAL, frame.state)
+            assertTrue(frame.isVisible)
+        } finally {
+            javax.swing.SwingUtilities.invokeAndWait { WindowFocusManager.unregisterWindow("test-id-normal") }
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun `focusWindow preserves failure behavior for invalid or unregistered target`() {
+        val result = WindowFocusManager.focusWindow("invalid-unregistered-id")
+        assertFalse(result)
+    }
 }


### PR DESCRIPTION
Fixes #560

### Description
This PR resolves the issue where `WindowFocusManager.focusWindow` left a minimized window iconified after bringing it to the foreground.

Previously, `focusWindow` and `bringToFront` checked if `!window.isVisible` to set it visible, and called `toFront()` and `requestFocus()`. However, for a minimized window, `isVisible` can be true while `state` is `ICONIFIED`, causing the window to remain hidden. 

This PR addresses this by:
1. Detecting if the target is an instance of `java.awt.Frame` and explicitly checking if its state is `ICONIFIED`.
2. Restoring the state to `NORMAL` before requesting focus.
3. Adding focused regression tests for normal, iconified, and unregistered frame resolution.

### Testing
- [x] Ran `./gradlew :composeApp:desktopTest --tests "ai.rever.boss.utils.WindowFocusManagerTest"` and verified lifecycle tests passed successfully.
- [x] Passed `ktlintCheck` and `detekt` checks (ignoring pre-existing `LargeClass` warning in unrelated files).
