### PR TITLE
fix(kernel): require verified caller identity for the Secret Service bridge

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/SecretServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/SecretServiceBridge.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.kernel.services
 
+import ai.rever.boss.ipc.auth.ProcessIdentityInterceptor
 import ai.rever.boss.ipc.proto.services.*
 import ai.rever.boss.plugin.api.CreateSecretRequestData
 import ai.rever.boss.plugin.api.SecretDataProvider
@@ -8,11 +9,28 @@ import ai.rever.boss.plugin.api.SecretShareData
 import ai.rever.boss.plugin.api.ShareSecretRequestData
 import ai.rever.boss.plugin.api.UnshareSecretRequestData
 import ai.rever.boss.plugin.api.UpdateSecretRequestData
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import io.grpc.Status
+import io.grpc.StatusException
 
+/**
+ * Kernel-side proxy over the password vault (BossConsole#53).
+ *
+ * Every RPC here reads or mutates a user's stored credentials - `getUserSecrets` returns
+ * plaintext passwords and TOTP recovery codes, and `shareSecret`/`unshareSecret` grant or revoke
+ * another user's or role's access to them. None of that was gated on who was calling: any process
+ * that could open a connection to the kernel IPC server, not only the plugins the host itself
+ * loaded, could read or reshare every secret the signed-in user owns. [authenticatedCallerOrRefuse]
+ * closes that the same way [PluginUIServiceBridge] and BossConsole#53's other bridges do - refusing
+ * a call with no verified [ProcessIdentityInterceptor] identity rather than letting it through to a
+ * provider that does not itself distinguish callers.
+ */
 class SecretServiceBridge(
     private val provider: SecretDataProvider,
 ) : SecretServiceGrpcKt.SecretServiceCoroutineImplBase() {
     override suspend fun getUserSecrets(request: SecretPaginatedRequest): PaginatedSecretsResponse {
+        authenticatedCallerOrRefuse("GetUserSecrets")
         val result = provider.getUserSecrets(request.limit, request.offset)
         return result.fold(
             onSuccess = { paginated ->
@@ -34,6 +52,7 @@ class SecretServiceBridge(
     }
 
     override suspend fun getUserSecretsWithSharingInfo(request: SecretPaginatedRequest): PaginatedSecretsWithSharingResponse {
+        authenticatedCallerOrRefuse("GetUserSecretsWithSharingInfo")
         val result = provider.getUserSecretsWithSharingInfo(request.limit, request.offset)
         return result.fold(
             onSuccess = { paginated ->
@@ -76,6 +95,7 @@ class SecretServiceBridge(
     }
 
     override suspend fun searchSecrets(request: SearchSecretsRequest): PaginatedSecretsResponse {
+        authenticatedCallerOrRefuse("SearchSecrets")
         val result = provider.searchSecrets(request.query, request.limit, request.offset)
         return result.fold(
             onSuccess = { paginated ->
@@ -97,6 +117,7 @@ class SecretServiceBridge(
     }
 
     override suspend fun createSecret(request: CreateSecretProtoRequest): SecretOperationResult {
+        authenticatedCallerOrRefuse("CreateSecret")
         val result =
             provider.createSecret(
                 CreateSecretRequestData(
@@ -115,6 +136,7 @@ class SecretServiceBridge(
     }
 
     override suspend fun updateSecret(request: UpdateSecretProtoRequest): SecretOperationResult {
+        authenticatedCallerOrRefuse("UpdateSecret")
         val result =
             provider.updateSecret(
                 UpdateSecretRequestData(
@@ -133,10 +155,13 @@ class SecretServiceBridge(
         return result.toOperationResult()
     }
 
-    override suspend fun deleteSecret(request: SecretIdRequest): SecretOperationResult =
-        provider.deleteSecret(request.id).toOperationResult()
+    override suspend fun deleteSecret(request: SecretIdRequest): SecretOperationResult {
+        authenticatedCallerOrRefuse("DeleteSecret")
+        return provider.deleteSecret(request.id).toOperationResult()
+    }
 
     override suspend fun getSecretShares(request: SecretIdRequest): SecretShareListResponse {
+        authenticatedCallerOrRefuse("GetSecretShares")
         val result = provider.getSecretShares(request.id)
         return result.fold(
             onSuccess = { shares ->
@@ -152,6 +177,7 @@ class SecretServiceBridge(
     }
 
     override suspend fun shareSecret(request: ShareSecretProtoRequest): SecretOperationResult {
+        authenticatedCallerOrRefuse("ShareSecret")
         val result =
             provider.shareSecret(
                 ShareSecretRequestData(
@@ -166,6 +192,7 @@ class SecretServiceBridge(
     }
 
     override suspend fun unshareSecret(request: UnshareSecretProtoRequest): SecretOperationResult {
+        authenticatedCallerOrRefuse("UnshareSecret")
         val result =
             provider.unshareSecret(
                 UnshareSecretRequestData(
@@ -219,4 +246,26 @@ class SecretServiceBridge(
                     .build()
             },
         )
+
+    /**
+     * The verified identity behind this call, or a thrown `PERMISSION_DENIED` when there is none.
+     *
+     * Fails closed, same as [PluginUIServiceBridge]'s helper of the same name: a call with no
+     * credential, or one [ProcessIdentityInterceptor] could not resolve to a live process, is
+     * refused here rather than reaching [provider] with a caller nothing has vouched for.
+     */
+    private fun authenticatedCallerOrRefuse(rpc: String): String =
+        ProcessIdentityInterceptor.AUTHENTICATED_PROCESS_ID.get() ?: run {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Refused $rpc: no verified process identity on this call",
+            )
+            throw StatusException(Status.PERMISSION_DENIED.withDescription(NO_IDENTITY))
+        }
+
+    private companion object {
+        val logger = BossLogger.forComponent("SecretServiceBridge")
+
+        const val NO_IDENTITY = "This call presented no verified process identity"
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/SecretServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/SecretServiceBridgeTest.kt
@@ -1,0 +1,236 @@
+package ai.rever.boss.kernel.services
+
+import ai.rever.boss.ipc.auth.ProcessIdentityInterceptor
+import ai.rever.boss.ipc.auth.ProcessTokenClientInterceptor
+import ai.rever.boss.ipc.auth.ProcessTokenRegistry
+import ai.rever.boss.ipc.proto.services.CreateSecretProtoRequest
+import ai.rever.boss.ipc.proto.services.SearchSecretsRequest
+import ai.rever.boss.ipc.proto.services.SecretIdRequest
+import ai.rever.boss.ipc.proto.services.SecretPaginatedRequest
+import ai.rever.boss.ipc.proto.services.SecretServiceGrpcKt
+import ai.rever.boss.ipc.proto.services.ShareSecretProtoRequest
+import ai.rever.boss.ipc.proto.services.UnshareSecretProtoRequest
+import ai.rever.boss.ipc.proto.services.UpdateSecretProtoRequest
+import ai.rever.boss.plugin.api.CreateSecretRequestData
+import ai.rever.boss.plugin.api.PaginatedSecretsData
+import ai.rever.boss.plugin.api.PaginatedSecretsWithSharingData
+import ai.rever.boss.plugin.api.SecretDataProvider
+import ai.rever.boss.plugin.api.SecretEntryData
+import ai.rever.boss.plugin.api.SecretShareData
+import ai.rever.boss.plugin.api.ShareSecretRequestData
+import ai.rever.boss.plugin.api.UnshareSecretRequestData
+import ai.rever.boss.plugin.api.UpdateSecretRequestData
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.Status
+import io.grpc.StatusException
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The password vault's kernel bridge, exercised over a real gRPC server (BossConsole#53).
+ *
+ * Before this bridge checked identity, any process that could open a connection to the kernel IPC
+ * server - not only the plugins the host itself loaded - could read every stored password and TOTP
+ * recovery code, or reshare a secret with a user or role of its choosing. The assertion that matters
+ * throughout is not just "the RPC is refused" but "the provider is never reached" - a refusal that
+ * still queried the vault would leak timing and existence information even without returning data.
+ */
+class SecretServiceBridgeTest {
+    private lateinit var tokenRegistry: ProcessTokenRegistry
+    private lateinit var provider: FakeSecretDataProvider
+    private lateinit var server: Server
+    private lateinit var authenticatedChannel: ManagedChannel
+    private lateinit var anonymousChannel: ManagedChannel
+    private lateinit var authenticated: SecretServiceGrpcKt.SecretServiceCoroutineStub
+    private lateinit var anonymous: SecretServiceGrpcKt.SecretServiceCoroutineStub
+
+    @BeforeTest
+    fun setUp() {
+        tokenRegistry = ProcessTokenRegistry()
+        provider = FakeSecretDataProvider()
+        server =
+            ServerBuilder
+                .forPort(0)
+                .intercept(ProcessIdentityInterceptor(tokenRegistry))
+                .addService(SecretServiceBridge(provider))
+                .build()
+                .start()
+        authenticatedChannel =
+            ManagedChannelBuilder
+                .forAddress("localhost", server.port)
+                .usePlaintext()
+                .intercept(ProcessTokenClientInterceptor(tokenRegistry.issue(CALLER)))
+                .build()
+        anonymousChannel = ManagedChannelBuilder.forAddress("localhost", server.port).usePlaintext().build()
+        authenticated = SecretServiceGrpcKt.SecretServiceCoroutineStub(authenticatedChannel)
+        anonymous = SecretServiceGrpcKt.SecretServiceCoroutineStub(anonymousChannel)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        authenticatedChannel.shutdownNow()
+        authenticatedChannel.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        anonymousChannel.shutdownNow()
+        anonymousChannel.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        server.shutdownNow()
+        server.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    }
+
+    @Test
+    fun `every RPC is refused with no credential, and never reaches the vault`() =
+        runBlocking {
+            assertRefused { anonymous.getUserSecrets(SecretPaginatedRequest.getDefaultInstance()) }
+            assertRefused { anonymous.getUserSecretsWithSharingInfo(SecretPaginatedRequest.getDefaultInstance()) }
+            assertRefused { anonymous.searchSecrets(SearchSecretsRequest.getDefaultInstance()) }
+            assertRefused { anonymous.createSecret(CreateSecretProtoRequest.getDefaultInstance()) }
+            assertRefused { anonymous.updateSecret(UpdateSecretProtoRequest.getDefaultInstance()) }
+            assertRefused { anonymous.deleteSecret(SecretIdRequest.getDefaultInstance()) }
+            assertRefused { anonymous.getSecretShares(SecretIdRequest.getDefaultInstance()) }
+            assertRefused { anonymous.shareSecret(ShareSecretProtoRequest.getDefaultInstance()) }
+            assertRefused { anonymous.unshareSecret(UnshareSecretProtoRequest.getDefaultInstance()) }
+
+            assertTrue(provider.calls.isEmpty(), "a refused call must never reach the vault provider")
+        }
+
+    @Test
+    fun `an authenticated caller can read the vault`() =
+        runBlocking {
+            provider.secrets += fakeSecret()
+
+            val response = authenticated.getUserSecrets(SecretPaginatedRequest.newBuilder().setLimit(10).build())
+
+            assertEquals(1, response.secretsCount)
+            assertEquals("acme.com", response.secretsList.single().website)
+            assertEquals(listOf("getUserSecrets"), provider.calls)
+        }
+
+    @Test
+    fun `an authenticated caller can create, share and delete a secret`() =
+        runBlocking {
+            val created =
+                authenticated.createSecret(
+                    CreateSecretProtoRequest
+                        .newBuilder()
+                        .setWebsite("new.example")
+                        .setUsername("me")
+                        .build(),
+                )
+            val shared =
+                authenticated.shareSecret(
+                    ShareSecretProtoRequest
+                        .newBuilder()
+                        .setSecretId("secret-1")
+                        .setTargetUserId("user-2")
+                        .build(),
+                )
+            val unshared =
+                authenticated.unshareSecret(
+                    UnshareSecretProtoRequest
+                        .newBuilder()
+                        .setSecretId("secret-1")
+                        .setTargetUserId("user-2")
+                        .build(),
+                )
+            val deleted = authenticated.deleteSecret(SecretIdRequest.newBuilder().setId("secret-1").build())
+
+            assertTrue(created.success)
+            assertTrue(shared.success)
+            assertTrue(unshared.success)
+            assertTrue(deleted.success)
+            assertEquals(listOf("createSecret", "shareSecret", "unshareSecret", "deleteSecret"), provider.calls)
+        }
+
+    private suspend fun assertRefused(call: suspend () -> Unit) {
+        val failure = assertFailsWith<StatusException> { call() }
+        assertEquals(Status.Code.PERMISSION_DENIED, failure.status.code)
+    }
+
+    private fun fakeSecret(): SecretEntryData =
+        SecretEntryData(
+            id = "secret-1",
+            website = "acme.com",
+            username = "user",
+            password = "hunter2",
+            notes = null,
+            expirationDate = null,
+            tags = emptyList(),
+            metadata = null,
+            createdAt = "2026-01-01T00:00:00Z",
+            updatedAt = "2026-01-01T00:00:00Z",
+        )
+
+    /** Records every method it was actually asked to perform, so a refusal can be proven silent. */
+    private class FakeSecretDataProvider : SecretDataProvider {
+        val calls = mutableListOf<String>()
+        val secrets = mutableListOf<SecretEntryData>()
+
+        override suspend fun getUserSecrets(
+            limit: Int,
+            offset: Int,
+        ): Result<PaginatedSecretsData> {
+            calls += "getUserSecrets"
+            return Result.success(PaginatedSecretsData(data = secrets.toList(), hasMore = false))
+        }
+
+        override suspend fun getUserSecretsWithSharingInfo(
+            limit: Int,
+            offset: Int,
+        ): Result<PaginatedSecretsWithSharingData> {
+            calls += "getUserSecretsWithSharingInfo"
+            return Result.success(PaginatedSecretsWithSharingData(data = emptyList(), hasMore = false))
+        }
+
+        override suspend fun searchSecrets(
+            query: String,
+            limit: Int,
+            offset: Int,
+        ): Result<PaginatedSecretsData> {
+            calls += "searchSecrets"
+            return Result.success(PaginatedSecretsData(data = emptyList(), hasMore = false))
+        }
+
+        override suspend fun createSecret(request: CreateSecretRequestData): Result<Unit> {
+            calls += "createSecret"
+            return Result.success(Unit)
+        }
+
+        override suspend fun updateSecret(request: UpdateSecretRequestData): Result<Unit> {
+            calls += "updateSecret"
+            return Result.success(Unit)
+        }
+
+        override suspend fun deleteSecret(id: String): Result<Unit> {
+            calls += "deleteSecret"
+            return Result.success(Unit)
+        }
+
+        override suspend fun getSecretShares(secretId: String): Result<List<SecretShareData>> {
+            calls += "getSecretShares"
+            return Result.success(emptyList())
+        }
+
+        override suspend fun shareSecret(request: ShareSecretRequestData): Result<Unit> {
+            calls += "shareSecret"
+            return Result.success(Unit)
+        }
+
+        override suspend fun unshareSecret(request: UnshareSecretRequestData): Result<Unit> {
+            calls += "unshareSecret"
+            return Result.success(Unit)
+        }
+    }
+
+    private companion object {
+        const val CALLER = "secret-manager-plugin"
+        const val SHUTDOWN_TIMEOUT_MS = 5_000L
+    }
+}


### PR DESCRIPTION
## Summary

`SecretServiceBridge` proxies the password vault to out-of-process plugins over the kernel's gRPC IPC server - `getUserSecrets`/`getUserSecretsWithSharingInfo` return plaintext passwords and TOTP recovery codes, and `shareSecret`/`unshareSecret` grant or revoke another user's or role's access to a secret. Continuing the BossConsole#53 caller-identity work, none of this bridge's nine RPCs checked who was calling before this: any process able to open a connection to the kernel IPC server - not only the plugins the host itself loaded - could read or reshare every secret the signed-in user owns.

- Gate every RPC (`GetUserSecrets`, `GetUserSecretsWithSharingInfo`, `SearchSecrets`, `CreateSecret`, `UpdateSecret`, `DeleteSecret`, `GetSecretShares`, `ShareSecret`, `UnshareSecret`) behind `authenticatedCallerOrRefuse()`, the same `PERMISSION_DENIED`-on-no-verified-identity pattern `PluginUIServiceBridge` established for #53.
- A call with no `ProcessIdentityInterceptor`-verified identity is refused before it ever reaches `SecretDataProvider`, so a refusal can't leak timing/existence information either.

## Test plan

- [x] New `SecretServiceBridgeTest` runs a real gRPC server behind `ProcessIdentityInterceptor` with a real client stub (no mocking of the transport): asserts every RPC is refused with `PERMISSION_DENIED` for an anonymous caller **and** that the fake vault provider is never invoked, and that an authenticated caller can still read, create, share, unshare and delete secrets normally.
- [x] `./gradlew :composeApp:compileKotlinDesktop :composeApp:compileTestKotlinDesktop`
- [x] `./gradlew :composeApp:desktopTest --tests "ai.rever.boss.kernel.services.SecretServiceBridgeTest"`
- [x] `./gradlew :composeApp:ktlintDesktopTestSourceSetCheck`
- [x] `./gradlew :composeApp:detektDesktopMain :composeApp:detektDesktopTest`