### PR TITLE
fix: attach plugin file picker to active window

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/FilePickerProviderFactory.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/FilePickerProviderFactory.kt
@@ -3,8 +3,10 @@ package ai.rever.boss.components.plugin.providers
 import ai.rever.boss.plugin.api.FilePickerProvider
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import java.awt.Dialog
 import java.awt.FileDialog
 import java.awt.Frame
+import java.awt.KeyboardFocusManager
 import java.io.File
 import javax.swing.JFileChooser
 import javax.swing.SwingUtilities
@@ -31,7 +33,7 @@ private class DesktopFilePickerProvider : FilePickerProvider {
         SwingUtilities.invokeLater {
             try {
                 if (isMacOS) {
-                    val dialog = FileDialog(null as Frame?, title ?: "Open File", FileDialog.LOAD)
+                    val dialog = createFileDialog(title ?: "Open File", FileDialog.LOAD)
                     if (!filters.isNullOrEmpty()) {
                         dialog.setFilenameFilter { _, name ->
                             filters.any { ext -> name.endsWith(".$ext", ignoreCase = true) }
@@ -45,6 +47,7 @@ private class DesktopFilePickerProvider : FilePickerProvider {
                     } else {
                         onResult(null)
                     }
+                    dialog.dispose()
                 } else {
                     val chooser =
                         JFileChooser().apply {
@@ -61,7 +64,7 @@ private class DesktopFilePickerProvider : FilePickerProvider {
                                 )
                             }
                         }
-                    val result = chooser.showOpenDialog(null)
+                    val result = chooser.showOpenDialog(activeWindow())
                     if (result == JFileChooser.APPROVE_OPTION) {
                         onResult(chooser.selectedFile?.absolutePath)
                     } else {
@@ -83,9 +86,14 @@ private class DesktopFilePickerProvider : FilePickerProvider {
         SwingUtilities.invokeLater {
             try {
                 if (isMacOS) {
-                    val dialog = FileDialog(null as Frame?, "Save File", FileDialog.SAVE)
+                    val dialog = createFileDialog("Save File", FileDialog.SAVE)
                     if (suggestedFileName != null) {
                         dialog.file = suggestedFileName
+                    }
+                    if (!filters.isNullOrEmpty()) {
+                        dialog.setFilenameFilter { _, name ->
+                            filters.any { ext -> name.endsWith(".$ext", ignoreCase = true) }
+                        }
                     }
                     dialog.isVisible = true
                     val dir = dialog.directory
@@ -95,6 +103,7 @@ private class DesktopFilePickerProvider : FilePickerProvider {
                     } else {
                         onResult(null)
                     }
+                    dialog.dispose()
                 } else {
                     val chooser =
                         JFileChooser().apply {
@@ -114,7 +123,7 @@ private class DesktopFilePickerProvider : FilePickerProvider {
                                 )
                             }
                         }
-                    val result = chooser.showSaveDialog(null)
+                    val result = chooser.showSaveDialog(activeWindow())
                     if (result == JFileChooser.APPROVE_OPTION) {
                         onResult(chooser.selectedFile?.absolutePath)
                     } else {
@@ -128,3 +137,25 @@ private class DesktopFilePickerProvider : FilePickerProvider {
         }
     }
 }
+
+/**
+ * Returns the AWT window currently receiving keyboard focus.
+ *
+ * Using the active window as the owner keeps native file dialogs attached to the
+ * BOSS window that initiated the request instead of allowing them to appear behind it.
+ */
+private fun activeWindow(): java.awt.Window? =
+    KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
+
+/**
+ * FileDialog has separate constructors for Frame and Dialog owners.
+ */
+private fun createFileDialog(
+    title: String,
+    mode: Int,
+): FileDialog =
+    when (val window = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow) {
+        is Frame -> FileDialog(window, title, mode)
+        is Dialog -> FileDialog(window, title, mode)
+        else -> FileDialog(null as Frame?, title, mode)
+    }


### PR DESCRIPTION
# 📋 Pull Request

## Description

Fixes #551.

The plugin file picker used an ownerless AWT `FileDialog` on macOS. This could cause the native file dialog to appear behind the BOSS window, making the file picker appear unresponsive.

This change attaches file dialogs to the currently active AWT window and disposes native dialogs after use. Swing file choosers also use the active window as their owner.

## 🔄 Type of Change

- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [ ] 🔧 **Configuration change**
- [ ] 📚 **Documentation**
- [ ] 🧹 **Refactoring**
- [ ] ⚡ **Performance improvement**
- [ ] 🧪 **Tests**

## 📦 Version Impact

- [x] **No version change needed**
- [ ] **Patch version**
- [ ] **Minor version**
- [ ] **Major version**

## ✅ Testing Checklist

### 🧪 **Local Testing**

- [ ] I have tested this change locally on my development machine
- [ ] All existing tests pass with my changes
- [ ] I have added new tests for new functionality (if applicable)
- [ ] I have verified the fix/feature works as intended

### 🖥️ **Platform Testing**

- [ ] 🍎 **macOS** - Tested and working
- [ ] 🪟 **Windows** - Tested and working
- [ ] 🐧 **Linux** - Tested and working
- [ ] 📱 **Mobile** (iOS/Android) - Tested if applicable
- [ ] 🌐 **Web** (WASM) - Tested if applicable

### 🏗️ **Build Verification**

- [ ] Project builds successfully with my changes
- [ ] No new build warnings introduced
- [ ] Distribution packages can be created successfully
- [ ] Version system integration tested

## 🔍 Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where appropriate
- [ ] I have made corresponding changes to documentation (if needed)
- [ ] My changes generate no new warnings or errors

## 🚀 CI/CD Integration

- [x] This PR will trigger appropriate CI/CD workflows
- [x] I understand that all status checks must pass before merging

## 📸 Screenshots/Media

Not applicable. This is a native file-dialog behavior fix.

## 🔗 Related Issues

Fixes #551

## 📝 Additional Context

### 🎯 **Motivation and Context**

Issue #551 reports that the plugin file picker can appear to do nothing because the macOS native file dialog is created without an owner. An ownerless native dialog can appear behind the BOSS window instead of being associated with the window that initiated the request.

### 🧠 **Implementation Details**

- Added active AWT window detection using `KeyboardFocusManager`.
- `FileDialog` now uses the active `Frame` or `Dialog` as its owner.
- Swing `JFileChooser` dialogs also use the active window.
- Native `FileDialog` instances are disposed after the dialog operation completes.
- Existing file filtering and callback behavior are preserved.

### ⚠️ **Breaking Changes**

None.

### 🔮 **Future Considerations**

The native dialog ownership approach could be reused by other desktop file-picker implementations if similar ownership issues are found.

## 👀 Review Focus Areas

- [x] **Logic and Algorithm**
- [ ] **Performance**
- [ ] **Security**
- [x] **Platform Compatibility**
- [x] **User Experience**
- [ ] **Documentation**

## 🚨 Pre-merge Checklist

- [ ] All conversations have been resolved
- [ ] Code has been rebased on latest main branch
- [x] Commit messages are clear and descriptive
- [x] PR title accurately describes the change
- [ ] Ready for production deployment

## Testing Note

`git diff --check` passes. Local Gradle compilation could not be run because Java/JAVA_HOME is not configured on the development machine. CI checks are expected to provide build and test verification.